### PR TITLE
Require PR workflow for repository changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,52 @@
-<claude-mem-context>
-# Memory Context
+# Repository Instructions
 
-# [obsidian-getnote-importer] recent context, 2026-05-08 8:51pm GMT+8
+This repository contains `obsidian-getnote-importer`, a TypeScript Obsidian plugin that syncs GetNote notes into a local Obsidian vault.
 
-Legend: 🎯session 🔴bugfix 🟣feature 🔄refactor ✅change 🔵discovery ⚖️decision 🚨security_alert 🔐security_note
-Format: ID TIME TYPE TITLE
-Fetch details: get_observations([IDs]) | Search: mem-search skill
+## Mandatory GitHub Workflow
 
-Stats: 50 obs (10,098t read) | 2,489,012t work | 100% savings
+- Never push directly to `main`.
+- All code, workflow, documentation, release, and automation changes must go through a pull request targeting `main`.
+- Work on branches prefixed with `codex/` unless the user explicitly asks for a different branch name.
+- After pushing a branch, create a pull request and share the PR URL.
+- Merge only after required checks pass and the user explicitly approves the merge.
+- If the user says "提交", interpret it as commit and push the current feature branch, not direct push to `main`.
+- If the user says "merge", confirm whether they mean merging an existing PR unless they explicitly say to bypass PR.
 
-### May 8, 2026
-20 12:49p ✅ Completed sync button label translation updates
-S15 i18n Translation Fixes and Main.tsx Sync Method Refactoring (May 8 at 12:50 PM)
-21 12:50p ✅ Version bumped to 0.5.6
-S16 调试同步日志为空问题，添加查看日志按钮 (May 8 at 12:51 PM)
-22 12:59p 🔵 Sync logging still returning empty results
-S17 同步日志显示优化 - 询问用户具体需求 (May 8 at 1:00 PM)
-S18 重构设置界面布局 - 新增同步日志一级栏目 (May 8 at 1:01 PM)
-S19 重构设置界面布局 - 新增同步日志一级栏目 (May 8 at 1:01 PM)
-23 1:02p 🔄 精简定时同步栏目，移除重复的日志状态信息
-S20 排查同步日志为空问题 (May 8 at 1:02 PM)
-S21 Deploy obsidian-getnote-importer plugin v0.5.7 to local vault (May 8 at 1:03 PM)
-24 1:31p 🔴 修复同步弹窗文案不一致问题
-25 " 🔴 查看日志弹窗内容为空
-26 " 🔴 发现同步弹窗文案不一致的代码根源
-27 " 🔴 发现查看日志弹窗为空的代码逻辑
-28 1:32p 🔴 修复同步弹窗文案不一致问题
-29 " 🔴 修复查看日志弹窗为空的问题
-30 " 🔵 发现 TypeScript 类型检查错误
-31 " 🔴 修复 TypeScript 类型错误
-32 " 🔵 发现 ESLint 错误
-33 " 🔴 完成两个 UI Bug 修复
-34 1:33p ✅ 构建成功
-35 1:36p 🔴 Fixed dialog text inconsistencies in sync feature
-36 " 🔴 Log viewing dialog displays no content
-37 " 🔄 Extended SyncResult with per-note item tracking
-38 " 🔵 SyncEngine sync() and syncNoteIds() maintain separate uidIndex per call
-39 1:37p ✅ Added i18n strings for enhanced history modal
-40 " 🔄 main.tsx integrated scope tracking and mode into history records
-41 " 🔴 syncNoteIds now increments result.total
-42 " 🟣 Redesigned sync history modal with collapsible per-note details
-43 " ✅ CSS redesigned for rich history modal card layout
-44 1:38p 🔴 Fixed 2 failing tests after writeNote return type changed
-45 " ✅ Full build pipeline verified passing: typecheck, 172 tests, build all green
-46 " ⚖️ New file: manual-sync-modal.tsx created during refactoring session
-47 1:39p 🟣 Obsidian GetNote Importer plugin deployed to vault
-S22 Redeploy Obsidian plugin after refactoring work (May 8 at 1:40 PM)
-48 1:44p 🟣 openviking-server auto-start via LaunchAgent
-50 1:46p 🔵 Claude Code to Codex migration surfaces
-51 " 🔵 Plugin migration limitations documented
-52 1:47p 🔵 Plugin infrastructure differs between Claude Code and Codex
-53 1:48p 🔵 Plugin parity gap: chrome-devtools-mcp missing from Codex
-54 " 🔵 Codex marketplace sync uses separate .tmp directory
-55 1:49p 🔵 validate-target command hanging on MCP server validation
-56 1:50p 🔵 Process termination blocked by macOS sandbox restrictions
-57 1:51p ✅ Claude Code to Codex migration completed
-58 2:23p 🟣 Adding detail view for sync/update operations in popup dialogs
-59 " 🟣 Sync history modal implements detailed note-level view with collapsible groups
-60 2:24p 🔄 Sync history item groups changed from collapsible to always-visible
-61 " 🟣 Obsidian plugin redeployed to local vault
-S23 Deploy Obsidian plugin v0.5.10 to vault (May 8 at 2:25 PM)
-62 2:26p 🟣 Consolidated sync/update details with status pill indicators
-63 2:27p 🟣 Added pagination to sync history modal with 5 entries per page
-64 2:28p ✅ Centralized note list page size limit with GETNOTE_LIST_LIMIT constant
-65 2:29p 🔵 GetNote list API has hard limit of 20 items per request
-66 2:38p 🟣 Redeployment of Obsidian Plugin
-67 2:39p 🔵 Obsidian Vault File Creation Methods
-68 " 🔴 Large Integer Precision Loss in JSON Parsing
-69 " 🔵 Error Logging in sync.ts
-70 2:41p ✅ Added Debug Logging for Audio Sync Processing
-S24 Debug audio attachment download issue in Obsidian GetNote Importer plugin (May 8 at 2:41 PM)
-**Investigated**: Examined sync.ts code flow for audio note processing; traced through downloadAudioAsset method; verified API response parsing for large integers (note_id precision); explored safeJsonParse implementation for handling audio/attachments fields
+## Project Shape
 
-**Learned**: Obsidian plugin uses createBinary for audio files and standard create for text files; large integer IDs (beyond JavaScript MAX_SAFE_INTEGER) lose precision in JSON.parse unless preserved as strings; safeJsonParse successfully maintains attachments and audio fields in nested API responses; downloadAudioAsset returns file path on success, null on failure
+- `src/main.tsx` wires the plugin lifecycle, commands, settings, and sync history.
+- `src/sync.ts` owns GetNote-to-vault sync behavior and must be treated as high risk.
+- `src/api.ts`, `src/note-parser.ts`, and `src/types.ts` contain API parsing and shared contracts.
+- `src/ui/` and `src/settings/` contain Obsidian modal and settings UI implemented with Preact-compatible React APIs.
+- Tests live in `tests/` and adjacent `src/*.test.ts` files.
 
-**Completed**: Added debug logging to both sync() and syncNoteIds() methods - logs attachments JSON, audio field presence, and download result; built and deployed to vault at version 0.5.11
+## Required Checks
 
-**Next Steps**: User needs to reload Obsidian plugin and trigger a sync to capture console logs showing [GetNote] debug output; will analyze logs to determine if issue is: (1) API not returning audio attachments, (2) attachments returning but no audio type found, or (3) download failing silently
+Run these before proposing a pull request or claiming a fix is complete:
 
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm run build
+```
 
-Access 2489k tokens of past work via get_observations([IDs]) or mem-search skill.
-</claude-mem-context>
+Run this after editing GitHub Actions workflows:
+
+```bash
+actionlint
+```
+
+## Engineering Rules
+
+- Keep changes small and scoped to the issue or review comment.
+- Preserve existing Obsidian vault data. Do not overwrite user notes unless the existing sync contract explicitly allows it.
+- Be careful with GetNote IDs and timestamps. Large numeric IDs may exceed JavaScript safe integer precision, so prefer string-preserving parsing and comparisons.
+- Add or update focused tests for sync, parser, settings, modal, or i18n behavior changes.
+- Do not bump `package.json` or `manifest.json` versions unless the task is explicitly about releasing.
+- Release artifacts are `main.js`, `manifest.json`, and `styles.css`.
+
+## Local Memory
+
+- Keep claude-mem or other dynamic session memory out of tracked repository files.
+- Local claude-mem context for this workspace should be written to `.claude-mem-context.md`, which is ignored by Git.


### PR DESCRIPTION
## Summary

- Replace the dynamic claude-mem snapshot in `AGENTS.md` with stable repository instructions.
- Add a mandatory GitHub workflow rule requiring agents to work on `codex/` branches, open PRs targeting `main`, and merge only after checks pass and user approval.
- Document that dynamic claude-mem context belongs in `.claude-mem-context.md`, not tracked repository files.

## Verification

- Documentation-only change; no test run required.

## Follow-up

To make this a hard GitHub-side rule, enable a branch ruleset for `main` requiring pull requests before merge and disallowing bypass.