### PR TITLE
Fix manifest.json for Obsidian community validation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,9 @@
 {
   "id": "obsidian-getnote-importer",
   "name": "GetNote Importer",
-  "version": "0.5.11",
+  "version": "0.5.20",
   "description": "将 Get笔记 App 的笔记同步到 Obsidian vault",
   "author": "Zheng Yan",
-  "authorUrl": "",
-  "fundingUrl": "",
-  "license": "MIT",
   "isDesktopOnly": false,
-  "minAppVersion": "1.5.0",
-  "js": "main.js",
-  "styles": ["styles.css"]
+  "minAppVersion": "1.5.0"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
-  "id": "obsidian-getnote-importer",
+  "id": "getnote-importer",
   "name": "GetNote Importer",
-  "version": "0.5.20",
-  "description": "将 Get笔记 App 的笔记同步到 Obsidian vault",
+  "version": "0.5.21",
+  "description": "将 Get笔记 App 的笔记同步到 Obsidian vault。",
   "author": "Zheng Yan",
   "isDesktopOnly": false,
   "minAppVersion": "1.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "0.5.11",
+  "version": "0.5.20",
   "description": "GetNote Importer for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "GetNote Importer for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Fix manifest.json to pass Obsidian community plugin validation:
- Remove invalid manifest fields (license, js, styles, authorUrl, fundingUrl)
- Change plugin ID to `getnote-importer` (no "obsidian" in ID per validation rules)
- Add Chinese period to description ending (validation requirement)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] Manifest validated against obsidian-releases workflow spec