### PR TITLE
[codex] Harden scheduled sync early stop

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "getnote-importer",
   "name": "GetNote Importer",
-  "version": "1.0.2",
+  "version": "1.0.8",
   "description": "Sync notes, links, recordings, and AI summaries from GetNote into your local vault.",
   "author": "Zheng Yan",
   "isDesktopOnly": false,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "getnote-importer",
   "name": "GetNote Importer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Sync notes, links, recordings, and AI summaries from GetNote into your local vault.",
   "author": "Zheng Yan",
   "isDesktopOnly": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-getnote-importer",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "preact": "^10.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "0.5.19",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-getnote-importer",
-      "version": "0.5.19",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "preact": "^10.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "0.5.21",
+  "version": "1.0.8",
   "description": "GetNote Importer for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "GetNote Importer for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -146,6 +146,7 @@ export default class GetNoteSyncPlugin extends Plugin {
         void this.doAutoSync();
       }
     }, interval);
+    this.registerInterval(this.autoSyncIntervalId);
   }
 
   stopAutoSync(): void {
@@ -186,7 +187,7 @@ export default class GetNoteSyncPlugin extends Plugin {
     this.settings.syncHistory = this.syncHistory;
 
     // lastSyncEndTimestamp only belongs to auto sync
-    if (type === 'auto' && result.lastNoteTimestamp) {
+    if (type === 'auto' && result.failed === 0 && result.lastNoteTimestamp) {
       this.settings.lastSyncEndTimestamp = result.lastNoteTimestamp;
     }
 
@@ -236,19 +237,11 @@ export default class GetNoteSyncPlugin extends Plugin {
           showNotice(t('notice.autoSynced', { created: result.created, updated: result.updated }));
         }
       } else {
-        this.syncProgress = {
-          message: t('modal.done'),
-          count: `${t('modal.created', { created: result.created })} · ${t('modal.updated', { updated: result.updated })} · ${t('modal.skipped', { skipped: result.skipped })}${result.failed > 0 ? ` · ${t('modal.failed', { failed: result.failed })}` : ''}`,
-          percent: 100,
-        };
-        this.refreshSettingsTab();
         showNotice(t('notice.syncComplete', { created: result.created, updated: result.updated, skipped: result.skipped, failed: result.failed > 0 ? ` · ${t('modal.failed', { failed: result.failed })}` : '' }), 8000);
-        activeWindow.setTimeout(() => {
-          this.syncProgress = { message: '', count: '', percent: 0 };
-          this.isSyncing = false;
-          this.currentSyncEngine = null;
-          this.refreshSettingsTab();
-        }, 8000);
+        this.syncProgress = { message: '', count: '', percent: 0 };
+        this.isSyncing = false;
+        this.currentSyncEngine = null;
+        this.refreshSettingsTab();
         return;
       }
     } catch (err) {
@@ -297,8 +290,9 @@ export default class GetNoteSyncPlugin extends Plugin {
   private doAutoSync(): void {
     // Auto sync uses lastSyncEndTimestamp as cutoff: skip notes already synced last time.
     // This IS the early-exit mechanism — no separate lastSyncEndTimestamp logic needed in engine.
-    const scopeOptions: Partial<SyncScopeOptions> = this.settings.lastSyncEndTimestamp
-      ? { syncStartDate: this.settings.lastSyncEndTimestamp, maxDays: 0 }
+    const syncStartDate = this.settings.lastSyncEndTimestamp || this.settings.syncStartDate;
+    const scopeOptions: Partial<SyncScopeOptions> = syncStartDate
+      ? { syncStartDate, maxDays: 0 }
       : {};
     void this.runSync('auto', scopeOptions);
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -207,9 +207,10 @@ export default class GetNoteSyncPlugin extends Plugin {
     }
 
     const startedAt = Date.now();
+    const resolvedSyncStartDate = scopeOptions?.syncStartDate ?? this.settings.syncStartDate;
     const resolvedScope: SyncHistoryScope = {
-      maxDays: scopeOptions?.maxDays ?? this.settings.maxDays,
-      syncStartDate: scopeOptions?.syncStartDate ?? this.settings.syncStartDate,
+      maxDays: resolvedSyncStartDate ? 0 : scopeOptions?.maxDays ?? this.settings.maxDays,
+      syncStartDate: resolvedSyncStartDate,
       selectedCount: selectedIds?.length,
       selectedIds,
     };

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -82,9 +82,10 @@ export class SyncEngine {
   constructor(app: App, settings: Settings, onProgress?: SyncProgressCallback, scopeOptions?: Partial<SyncScopeOptions>) {
     this.app = app;
     this.settings = settings;
+    const syncStartDate = scopeOptions?.syncStartDate ?? settings.syncStartDate;
     this.scopeOptions = {
-      maxDays: scopeOptions?.maxDays ?? settings.maxDays,
-      syncStartDate: scopeOptions?.syncStartDate ?? settings.syncStartDate,
+      maxDays: syncStartDate ? 0 : scopeOptions?.maxDays ?? settings.maxDays,
+      syncStartDate,
     };
     this.onProgress = onProgress;
   }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -14,6 +14,36 @@ const AUDIO_NOTE_TYPES = new Set([
   'local_audio',
 ]);
 
+function parseSyncBoundaryTime(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+  }
+
+  const parsed = Date.parse(trimmed);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function parseNoteUpdatedTime(note: GetNoteNote): number | null {
+  const parsed = Date.parse(note.updated_at);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function isSortedByUpdatedDesc(notes: GetNoteNote[]): boolean {
+  let previous: number | null = null;
+  for (const note of notes) {
+    const current = parseNoteUpdatedTime(note);
+    if (current === null) return false;
+    if (previous !== null && current > previous) return false;
+    previous = current;
+  }
+  return true;
+}
+
 function isSafeAttachmentUrl(url: string): boolean {
   try {
     return new URL(url).protocol === 'https:';
@@ -327,10 +357,12 @@ export class SyncEngine {
     const { syncStartDate } = this.scopeOptions;
     if (!syncStartDate) return notes;
 
-    const startTime = new Date(syncStartDate).getTime();
+    const startTime = parseSyncBoundaryTime(syncStartDate);
+    if (startTime === null) return notes;
+
     return notes.filter(note => {
-      const updated = new Date(note.updated_at).getTime();
-      return updated >= startTime;
+      const updated = parseNoteUpdatedTime(note);
+      return updated !== null && updated >= startTime;
     });
   }
 
@@ -340,8 +372,8 @@ export class SyncEngine {
 
     const cutoff = Date.now() - maxDays * 24 * 60 * 60 * 1000;
     return notes.filter(note => {
-      const updated = new Date(note.updated_at).getTime();
-      return !Number.isNaN(updated) && updated >= cutoff;
+      const updated = parseNoteUpdatedTime(note);
+      return updated !== null && updated >= cutoff;
     });
   }
 
@@ -357,7 +389,7 @@ export class SyncEngine {
     // - maxDays cutoff (relative): only keep notes within last N days
     // Taking the max means early exit fires when EITHER boundary is reached.
     const syncStartCutoff = this.scopeOptions.syncStartDate
-      ? new Date(this.scopeOptions.syncStartDate).getTime()
+      ? parseSyncBoundaryTime(this.scopeOptions.syncStartDate)
       : null;
     const maxDaysCutoff = this.scopeOptions.maxDays && this.scopeOptions.maxDays > 0
       ? Date.now() - this.scopeOptions.maxDays * 24 * 60 * 60 * 1000
@@ -365,6 +397,7 @@ export class SyncEngine {
     const cutoffTime = [syncStartCutoff, maxDaysCutoff]
       .filter((t): t is number => t !== null)
       .reduce((max, t) => Math.max(max, t), 0) || null;
+    let lastNoteTimestampTime: number | null = null;
 
     const cleanup = () => {
       this.cancelled = true;
@@ -380,17 +413,6 @@ export class SyncEngine {
         this.onProgress?.({ page: pageCount, percent: 0 });
 
         const recentNotes = this.filterRecentNotes(notes);
-
-        // Notes are sorted by updated_at DESC. Check the oldest note in this page;
-        // if it's already older than cutoff, no more pages need processing.
-        if (cutoffTime !== null && notes.length > 0) {
-          const oldestNote = notes[notes.length - 1];
-          const oldestTime = new Date(oldestNote.updated_at).getTime();
-          if (oldestTime < cutoffTime) {
-            break;
-          }
-        }
-
         const filtered = this.filterNotesByDateRange(recentNotes);
 
         for (const note of filtered) {
@@ -405,8 +427,21 @@ export class SyncEngine {
             case 'failed': result.failed++; break;
           }
           this.recordItem(result, noteToWrite, writeResult);
-          if (!result.lastNoteTimestamp || note.updated_at > result.lastNoteTimestamp) {
+          const updatedTime = parseNoteUpdatedTime(note);
+          if (updatedTime !== null && (lastNoteTimestampTime === null || updatedTime > lastNoteTimestampTime)) {
+            lastNoteTimestampTime = updatedTime;
             result.lastNoteTimestamp = note.updated_at;
+          }
+        }
+
+        // Notes are sorted by updated_at DESC. Once the oldest note in this page
+        // is older than the cutoff, later pages can be skipped after this page's
+        // still-valid notes have been processed.
+        if (cutoffTime !== null && notes.length > 0 && isSortedByUpdatedDesc(notes)) {
+          const oldestNote = notes[notes.length - 1];
+          const oldestTime = parseNoteUpdatedTime(oldestNote);
+          if (oldestTime !== null && oldestTime < cutoffTime) {
+            break;
           }
         }
 

--- a/src/ui/sync-history-modal.tsx
+++ b/src/ui/sync-history-modal.tsx
@@ -8,6 +8,21 @@ export function formatHistoryNoteType(noteType: string): string {
   return label === key ? t('picker.type.unknown') : label;
 }
 
+export function formatHistoryScope(entry: SyncHistoryEntry): string {
+  if (entry.scope?.selectedCount !== undefined) {
+    return t('syncHistory.params.selected', { count: entry.scope.selectedCount });
+  }
+
+  const parts: string[] = [];
+  if (entry.scope?.syncStartDate) {
+    parts.push(t('syncHistory.params.startDate', { date: entry.scope.syncStartDate }));
+  }
+  if (!entry.scope?.syncStartDate && entry.scope?.maxDays && entry.scope.maxDays > 0) {
+    parts.push(t('syncHistory.params.maxDays', { days: entry.scope.maxDays }));
+  }
+  return parts.length > 0 ? parts.join(' · ') : t('syncHistory.params.noLimit');
+}
+
 export function openSyncHistoryModal(app: App, history: SyncHistoryEntry[]) {
   const modal = new SyncHistoryModal(app, history);
   modal.open();
@@ -61,21 +76,6 @@ class SyncHistoryModal extends Modal {
         if (entry.mode === 'auto' || entry.type === 'auto') return t('syncHistory.mode.auto');
         if (entry.mode === 'selected' || entry.type === 'selective') return t('syncHistory.mode.selected');
         return t('syncHistory.mode.time');
-      };
-
-      const formatScope = (entry: SyncHistoryEntry): string => {
-        if (entry.scope?.selectedCount !== undefined) {
-          return t('syncHistory.params.selected', { count: entry.scope.selectedCount });
-        }
-
-        const parts: string[] = [];
-        if (entry.scope?.syncStartDate) {
-          parts.push(t('syncHistory.params.startDate', { date: entry.scope.syncStartDate }));
-        }
-        if (entry.scope?.maxDays && entry.scope.maxDays > 0) {
-          parts.push(t('syncHistory.params.maxDays', { days: entry.scope.maxDays }));
-        }
-        return parts.length > 0 ? parts.join(' · ') : t('syncHistory.params.noLimit');
       };
 
       const renderMeta = (parent: HTMLElement, label: string, value: string): void => {
@@ -157,7 +157,7 @@ class SyncHistoryModal extends Modal {
         const detailEl = entryEl.createDiv('getnote-history-entry-body');
         const metaEl = detailEl.createDiv('getnote-history-meta-grid');
         renderMeta(metaEl, t('syncHistory.meta.method'), formatMode(entry));
-        renderMeta(metaEl, t('syncHistory.meta.params'), formatScope(entry));
+        renderMeta(metaEl, t('syncHistory.meta.params'), formatHistoryScope(entry));
         renderMeta(metaEl, t('syncHistory.meta.filter'), t('syncHistory.filter.default'));
         renderMeta(metaEl, t('syncHistory.meta.result'), `${formatStatus(entry.status)} · ${formatDuration(entry.durationMs)}`);
 

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -129,6 +129,108 @@ describe('SyncEngine — filterRecentNotes', () => {
   });
 });
 
+describe('SyncEngine — page cutoff', () => {
+  it('treats date-only syncStartDate as the local start of day', () => {
+    const app = makeMockApp();
+    const engine = new SyncEngine(
+      app as any,
+      makeSettings({ maxDays: 0 }),
+      undefined,
+      { syncStartDate: '2026-05-09', maxDays: 0 }
+    );
+    const justAfterLocalMidnight = makeNote({
+      note_id: 'local_midnight',
+      updated_at: '2026-05-09T00:30:00+08:00',
+    });
+
+    // @ts-ignore accessing private method for boundary regression coverage
+    expect(engine['filterNotesByDateRange']([justAfterLocalMidnight])).toHaveLength(1);
+  });
+
+  it('uses chronological time instead of string order for last synced timestamp', async () => {
+    const requestSpy = vi.spyOn(obsidian, 'requestUrl').mockResolvedValue({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      text: JSON.stringify({
+        data: {
+          notes: [
+            makeNote({
+              note_id: 'lexically_later',
+              updated_at: '2026-05-09T09:30:00+08:00',
+            }),
+            makeNote({
+              note_id: 'chronologically_later',
+              updated_at: '2026-05-09T02:00:00Z',
+            }),
+          ],
+          has_more: false,
+          next_cursor: '',
+        },
+      }),
+      json: null,
+      arrayBuffer: new ArrayBuffer(0),
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }));
+
+      const result = await engine.sync();
+
+      expect(result.lastNoteTimestamp).toBe('2026-05-09T02:00:00Z');
+    } finally {
+      requestSpy.mockRestore();
+    }
+  });
+
+  it('processes recent notes on a page before stopping at an old tail note', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00+08:00'));
+    const requestSpy = vi.spyOn(obsidian, 'requestUrl').mockResolvedValue({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      text: JSON.stringify({
+        data: {
+          notes: [
+            makeNote({
+              note_id: 'today',
+              title: '今天最新',
+              updated_at: '2026-05-11T11:30:00+08:00',
+            }),
+            makeNote({
+              note_id: 'old_tail',
+              title: '旧尾巴',
+              updated_at: '2026-05-09T11:30:00+08:00',
+            }),
+          ],
+          has_more: false,
+          next_cursor: '',
+        },
+      }),
+      json: null,
+      arrayBuffer: new ArrayBuffer(0),
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 1 }));
+
+      const result = await engine.sync();
+
+      expect(result.created).toBe(1);
+      expect(result.items).toEqual([
+        expect.objectContaining({
+          noteId: 'today',
+          status: 'created',
+        }),
+      ]);
+    } finally {
+      requestSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('SyncEngine — buildUidIndex', () => {
   it('返回空 Map 当 vault 没有 md 文件', () => {
     const app = makeMockApp();

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -92,6 +92,16 @@ function mockFetchAllNotes(notes: GetNoteNote[] = []) {
 }
 
 describe('SyncEngine — filterRecentNotes', () => {
+  it('disables maxDays when syncStartDate is set', () => {
+    const app = makeMockApp();
+    const engine = new SyncEngine(app as any, makeSettings({ maxDays: 30, syncStartDate: '2026-05-09' }));
+
+    expect(engine['scopeOptions']).toEqual({
+      maxDays: 0,
+      syncStartDate: '2026-05-09',
+    });
+  });
+
   it('返回所有笔记当 maxDays <= 0', () => {
     const app = makeMockApp();
     const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }));

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -148,9 +148,10 @@ describe('SyncEngine — page cutoff', () => {
       undefined,
       { syncStartDate: '2026-05-09', maxDays: 0 }
     );
+    const localMidnight = new Date(2026, 4, 9, 0, 30, 0);
     const justAfterLocalMidnight = makeNote({
       note_id: 'local_midnight',
-      updated_at: '2026-05-09T00:30:00+08:00',
+      updated_at: localMidnight.toISOString(),
     });
 
     // @ts-ignore accessing private method for boundary regression coverage

--- a/tests/sync-history.spec.ts
+++ b/tests/sync-history.spec.ts
@@ -163,12 +163,10 @@ describe('sync history note type display', () => {
 });
 
 describe('sync history scope display', () => {
-  it('hides maxDays for auto sync when a start date is present', () => {
+  it('hides maxDays when a start date is present', () => {
     initI18n('zh-CN');
 
     expect(formatHistoryScope(makeEntry({
-      type: 'auto',
-      mode: 'auto',
       scope: {
         syncStartDate: '2026-05-09',
         maxDays: 30,

--- a/tests/sync-history.spec.ts
+++ b/tests/sync-history.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { SyncHistoryEntry, SyncResult } from '../src/types';
 import { initI18n } from '../src/i18n';
-import { formatHistoryNoteType } from '../src/ui/sync-history-modal';
+import { formatHistoryNoteType, formatHistoryScope } from '../src/ui/sync-history-modal';
 
 function makeResult(overrides: Partial<SyncResult> = {}): SyncResult {
   return { created: 0, updated: 0, skipped: 0, failed: 0, total: 0, ...overrides };
@@ -159,5 +159,20 @@ describe('sync history note type display', () => {
 
     expect(formatHistoryNoteType('recorder_audio')).toBe('录音长录');
     expect(formatHistoryNoteType('unknown_remote_type')).toBe('其他');
+  });
+});
+
+describe('sync history scope display', () => {
+  it('hides maxDays for auto sync when a start date is present', () => {
+    initI18n('zh-CN');
+
+    expect(formatHistoryScope(makeEntry({
+      type: 'auto',
+      mode: 'auto',
+      scope: {
+        syncStartDate: '2026-05-09',
+        maxDays: 30,
+      },
+    }))).toBe('起始日期 2026-05-09');
   });
 });

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -83,6 +83,27 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     expect(plugin.syncProgress).toEqual({ message: '', count: '', percent: 0 });
   });
 
+  it('records only start date when scope contains both date and maxDays', async () => {
+    vi.spyOn(SyncEngine.prototype, 'sync').mockResolvedValue({
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      total: 0,
+      items: [],
+    });
+    const plugin = makePlugin();
+
+    await plugin['runSync']('full', { maxDays: 30, syncStartDate: '2026-05-09' });
+
+    expect(plugin.syncHistory.at(-1)?.scope).toEqual({
+      maxDays: 0,
+      syncStartDate: '2026-05-09',
+      selectedCount: undefined,
+      selectedIds: undefined,
+    });
+  });
+
   it('registers scheduled sync interval with Obsidian lifecycle', () => {
     vi.useFakeTimers();
     const plugin = makePlugin();

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -28,6 +28,7 @@ describe('SyncCancelledError', () => {
 
 describe('GetNoteSyncPlugin runSync cleanup', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -62,5 +63,112 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
 
     expect(plugin.isSyncing).toBe(false);
     expect(plugin.syncProgress.message).toContain('已取消');
+  });
+
+  it('manual sync success clears syncing state immediately', async () => {
+    vi.spyOn(SyncEngine.prototype, 'sync').mockResolvedValue({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      total: 1,
+      items: [],
+    });
+    const plugin = makePlugin();
+
+    await plugin['runSync']('full', { maxDays: 0, syncStartDate: '' });
+
+    expect(plugin.isSyncing).toBe(false);
+    expect(plugin.currentSyncEngine).toBe(null);
+    expect(plugin.syncProgress).toEqual({ message: '', count: '', percent: 0 });
+  });
+
+  it('registers scheduled sync interval with Obsidian lifecycle', () => {
+    vi.useFakeTimers();
+    const plugin = makePlugin();
+    plugin.settings.scheduledSync = {
+      enabled: true,
+      intervalMinutes: 5,
+      syncOnStart: true,
+    };
+    const registerInterval = vi.fn();
+    Object.assign(plugin, { registerInterval });
+
+    plugin.startAutoSync();
+
+    expect(registerInterval).toHaveBeenCalledTimes(1);
+    expect(registerInterval).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('disables maxDays when scheduled sync resumes from last synced timestamp', async () => {
+    const syncScopeOptions: unknown[] = [];
+    vi.spyOn(SyncEngine.prototype, 'sync').mockImplementation(function (this: SyncEngine) {
+      syncScopeOptions.push(this['scopeOptions']);
+      return Promise.resolve({ created: 0, updated: 0, skipped: 0, failed: 0, total: 0 });
+    });
+    const plugin = makePlugin();
+    plugin.settings.maxDays = 30;
+    plugin.settings.lastSyncEndTimestamp = '2026-05-09T10:00:00+08:00';
+
+    plugin['doAutoSync']();
+
+    await vi.waitFor(() => {
+      expect(syncScopeOptions).toEqual([
+        {
+          maxDays: 0,
+          syncStartDate: '2026-05-09T10:00:00+08:00',
+        },
+      ]);
+    });
+  });
+
+  it('disables maxDays when scheduled sync uses configured start date', async () => {
+    const syncScopeOptions: unknown[] = [];
+    vi.spyOn(SyncEngine.prototype, 'sync').mockImplementation(function (this: SyncEngine) {
+      syncScopeOptions.push(this['scopeOptions']);
+      return Promise.resolve({ created: 0, updated: 0, skipped: 0, failed: 0, total: 0 });
+    });
+    const plugin = makePlugin();
+    plugin.settings.maxDays = 30;
+    plugin.settings.syncStartDate = '2026-05-09';
+    plugin.settings.lastSyncEndTimestamp = '';
+
+    plugin['doAutoSync']();
+
+    await vi.waitFor(() => {
+      expect(syncScopeOptions).toEqual([
+        {
+          maxDays: 0,
+          syncStartDate: '2026-05-09',
+        },
+      ]);
+      expect(plugin.syncHistory.at(-1)?.scope).toEqual({
+        maxDays: 0,
+        syncStartDate: '2026-05-09',
+        selectedCount: undefined,
+        selectedIds: undefined,
+      });
+    });
+  });
+
+  it('does not advance scheduled sync checkpoint when any note fails', async () => {
+    vi.spyOn(SyncEngine.prototype, 'sync').mockResolvedValue({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 1,
+      total: 2,
+      items: [],
+      lastNoteTimestamp: '2026-05-10T12:00:00+08:00',
+    });
+    const plugin = makePlugin();
+    plugin.settings.lastSyncEndTimestamp = '2026-05-09T10:00:00+08:00';
+
+    await plugin['runSync']('auto', {
+      maxDays: 0,
+      syncStartDate: plugin.settings.lastSyncEndTimestamp,
+    });
+
+    expect(plugin.settings.lastSyncEndTimestamp).toBe('2026-05-09T10:00:00+08:00');
   });
 });


### PR DESCRIPTION
## Summary
- Harden scheduled sync early-stop behavior so checkpoint advancement cannot skip failed notes.
- Parse sync date boundaries consistently and compare note timestamps chronologically instead of lexicographically.
- Clarify auto sync history scope display and include focused regression coverage.

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build