### PR TITLE
Revert accidental version bump

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "getnote-importer",
   "name": "GetNote Importer",
-  "version": "1.0.9",
+  "version": "1.0.2",
   "description": "Sync notes, links, recordings, and AI summaries from GetNote into your local vault.",
   "author": "Zheng Yan",
   "isDesktopOnly": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "1.0.9",
+  "version": "0.5.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-getnote-importer",
-      "version": "1.0.9",
+      "version": "0.5.19",
       "license": "MIT",
       "dependencies": {
         "preact": "^10.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-getnote-importer",
-  "version": "1.0.9",
+  "version": "0.5.21",
   "description": "GetNote Importer for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Revert the accidental non-release version bump from PR #23.
- Restore package metadata versions to the pre-sync-hardening values.

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build