### PR TITLE
docs: add Install for Local Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,35 @@ GetNote Importer treats GetNote as the source of truth for imported note content
 - Audio download works only when the detail API returns a valid HTTPS audio attachment.
 - Imported Markdown content may be updated by future syncs. Keep personal edits in separate notes or backlinks if you need full manual control.
 
+## Install for Local Testing
+
+Two options:
+
+**Option 1 — Download from releases (no build needed)**
+1. Download `main.js`, `manifest.json`, and `styles.css` from the [latest release](https://github.com/AndyZhengyan/obsidian-getnote-importer/releases/latest).
+2. Create the plugin directory if it doesn't exist:
+   ```bash
+   mkdir -p <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+   ```
+3. Copy the files in:
+   ```bash
+   cp main.js manifest.json styles.css <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+   ```
+
+**Option 2 — Build from source**
+```bash
+# Build the plugin
+npm run build
+
+# Create plugin directory (if it doesn't exist)
+mkdir -p <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+
+# Copy plugin files to vault
+cp main.js manifest.json styles.css <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+```
+
+**Reload Obsidian** after installing: press `Cmd+P` (macOS) or `Ctrl+P` (Windows/Linux), search `Reload`, and choose `Reload app without saving` (or restart Obsidian).
+
 ## Development
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -215,6 +215,35 @@ tags: ["work"]
 | 同步间隔 | 定时同步间隔（分钟） | `30` |
 | 启动时同步 | Obsidian 启动时自动同步一次 | 开启 |
 
+## 本地测试安装
+
+两种方式：
+
+**方式一 — 直接下载 release（无需构建）**
+1. 从 [最新版本](https://github.com/AndyZhengyan/obsidian-getnote-importer/releases/latest) 下载 `main.js`、`manifest.json`、`styles.css`。
+2. 创建插件目录（如不存在）：
+   ```bash
+   mkdir -p <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+   ```
+3. 复制文件进去：
+   ```bash
+   cp main.js manifest.json styles.css <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+   ```
+
+**方式二 — 从源码构建**
+```bash
+# 构建插件
+npm run build
+
+# 创建插件目录（如不存在）
+mkdir -p <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+
+# 复制插件文件到 vault
+cp main.js manifest.json styles.css <your-vault>/.obsidian/plugins/obsidian-getnote-importer/
+```
+
+**安装完成后重载 Obsidian**：按 `Cmd+P`（macOS）或 `Ctrl+P`（Windows/Linux），搜索 `Reload`，选择 `Reload app without saving`（或直接重启 Obsidian）。
+
 ## 同步模型
 
 对已导入内容来说，插件默认把 Get笔记视为同步来源。


### PR DESCRIPTION
## Summary
- Add "Install for Local Testing" section with two options:
  - Option 1: Download pre-built files from GitHub releases
  - Option 2: Build from source
- Both options include mkdir step (handles missing plugin directory)
- Reload instructions cover macOS + Windows/Linux
- Update both README.md and README_zh.md

## Test plan
- [x] Readme renders correctly
- [x] Both EN and ZH versions consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)