### PR TITLE
fix: i18n cleanup, settings layout, community link

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,8 +1,8 @@
 export const translations: Record<string, Record<string, string>> = {
   zh: {
     // === Settings ===
-    'settings.title': 'Get笔记导入',
-    'settings.desc': '🔄 Get笔记 → Obsidian，一键迁移无负担',
+    'settings.title': '⏪ Get笔记导入',
+    'settings.desc': 'Get笔记 → Obsidian，一键迁移无负担，',
     'settings.community': '欢迎交流',
     'settings.apiToken.label': 'API Token',
     'settings.apiToken.desc': 'Get笔记开放平台的 Authorization Token（gk_live_xxx）',
@@ -201,18 +201,18 @@ export const translations: Record<string, Record<string, string>> = {
 
   en: {
     // === Settings ===
-    'settings.title': 'Get笔记导入',
-    'settings.desc': '🔄 Get笔记 → Obsidian，one-click migration',
+    'settings.title': '⏪ GetNote Importer',
+    'settings.desc': 'GetNote → Obsidian, one-click migration',
     'settings.community': 'Welcome to discuss',
     'settings.apiToken.label': 'API Token',
-    'settings.apiToken.desc': 'Get笔记 Open Platform Authorization Token (gk_live_xxx)',
+    'settings.apiToken.desc': 'GetNote Open Platform Authorization Token (gk_live_xxx)',
     'settings.apiToken.placeholder': 'App Key: gk_xxx',
     'settings.clientId.label': 'Client ID',
-    'settings.clientId.desc': 'Get笔记 Open Platform Client ID (cli_xxx)',
+    'settings.clientId.desc': 'GetNote Open Platform Client ID (cli_xxx)',
     'settings.clientId.placeholder': 'Client ID: cli_xxx',
     'settings.folder.label': 'Target Folder',
-    'settings.folder.desc': 'Subfolder in vault to sync notes to (default: Get笔记)',
-    'settings.folder.placeholder': 'Get笔记',
+    'settings.folder.desc': 'Subfolder in vault to sync notes to (default: GetNote)',
+    'settings.folder.placeholder': 'GetNote',
     'settings.maxDays.label': 'Auto Sync Range',
     'settings.maxDays.desc': 'Scheduled sync only pulls notes updated within N days (0 = no limit)',
     'settings.maxDays.placeholder': '30',
@@ -347,7 +347,7 @@ export const translations: Record<string, Record<string, string>> = {
     'picker.type.unknown': 'Other',
 
     // === Sync Modal ===
-    'modal.title': 'Get笔记 Syncing',
+    'modal.title': 'GetNote Syncing',
     'modal.connecting': 'Connecting to API...',
     'modal.done': 'Sync Complete',
     'modal.created': 'Created {created}',

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -8,7 +8,7 @@ import { App, AbstractInputSuggest } from 'obsidian';
 import { fetchNotes } from '../api';
 import { t } from '../i18n';
 
-const GITHUB_URL = 'https://github.com/AndyZhengyan/obsidian-getnote-importer';
+const GITHUB_URL = 'https://github.com/AndyZhengyan/obsidian-getnote-importer#about-the-author';
 
 class FolderSuggest extends AbstractInputSuggest<string> {
   private el: HTMLInputElement;

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,8 @@
 
 .getnote-settings-header h2 {
   margin: 0 0 4px;
+  padding-left: 0;
+  border-left: none;
 }
 
 .getnote-settings-author {
@@ -55,6 +57,7 @@
 .getnote-settings-desc {
   color: var(--text-muted);
   margin: 0 0 16px;
+  padding-left: 0;
   font-size: 13px;
 }
 


### PR DESCRIPTION
## Summary

- **i18n**: 清理英文翻译中的中文残留（`Get笔记` → `GetNote`）
- **UI**: 修复设置页标题与副标题的水平对齐
- **Layout**: 将 🔄 emoji 从描述移至标题，改为 ⏪
- **Link**: 社区链接指向 `#about-the-author`

## Changes

| File | Change |
|------|--------|
| `src/i18n.ts` | 英文 5 处 `Get笔记`→`GetNote`；中文 desc 加逗号；标题 emoji 改为 ⏪ |
| `src/settings/index.tsx` | GITHUB_URL 加 `#about-the-author` |
| `styles.css` | h2 重置 border-left/padding-left，desc 加 padding-left:0 |

Fixes #41