### PR TITLE
Initialize manual sync modal from settings, resolve initial mode, and add tests

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -350,7 +350,10 @@ class ManualSyncModalWrapper extends Modal {
   onOpen() {
     ReactDOM.render(
       <ManualSyncModal
-        initialOptions={{ syncStartDate: '', maxDays: 0 }}
+        initialOptions={{
+          syncStartDate: this.plugin.settings.syncStartDate,
+          maxDays: this.plugin.settings.maxDays,
+        }}
         onConfirm={(options) => {
           this.close();
           this.plugin.startSync(options);

--- a/src/ui/manual-sync-modal.tsx
+++ b/src/ui/manual-sync-modal.tsx
@@ -10,8 +10,22 @@ interface ManualSyncModalProps {
   onCancel: () => void;
 }
 
+function resolveInitialSyncMode(initialOptions: SyncScopeOptions): SyncMode {
+  const hasDate = Boolean(initialOptions.syncStartDate);
+  const hasDays = initialOptions.maxDays > 0;
+  if (!hasDate && !hasDays) return 'days';
+  if (hasDate && !hasDays) return 'date';
+  if (!hasDate && hasDays) return 'days';
+
+  const startTime = Date.parse(initialOptions.syncStartDate);
+  if (Number.isNaN(startTime)) return 'days';
+
+  const daysCutoff = Date.now() - initialOptions.maxDays * 24 * 60 * 60 * 1000;
+  return daysCutoff >= startTime ? 'days' : 'date';
+}
+
 export function ManualSyncModal({ initialOptions, onConfirm, onCancel }: ManualSyncModalProps) {
-  const [syncMode, setSyncMode] = useState<SyncMode>('date');
+  const [syncMode, setSyncMode] = useState<SyncMode>(resolveInitialSyncMode(initialOptions));
   const [syncStartDate, setSyncStartDate] = useState(initialOptions.syncStartDate);
   const [maxDays, setMaxDays] = useState(String(initialOptions.maxDays));
 
@@ -22,7 +36,7 @@ export function ManualSyncModal({ initialOptions, onConfirm, onCancel }: ManualS
       const parsedMaxDays = parseInt(maxDays, 10);
       onConfirm({
         syncStartDate: '',
-        maxDays: Number.isNaN(parsedMaxDays) || parsedMaxDays < 0 ? 0 : parsedMaxDays,
+        maxDays: Number.isNaN(parsedMaxDays) || parsedMaxDays < 1 ? 1 : parsedMaxDays,
       });
     }
   };

--- a/tests/manual-sync-modal.spec.ts
+++ b/tests/manual-sync-modal.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { ManualSyncModal } from '../src/ui/manual-sync-modal';
+
+function renderModal(initialOptions: { syncStartDate: string; maxDays: number }, onConfirm = vi.fn()) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  render(
+    h(ManualSyncModal, {
+      initialOptions,
+      onConfirm,
+      onCancel: vi.fn(),
+    }),
+    container
+  );
+  return { container, onConfirm };
+}
+
+afterEach(() => {
+  render(null, document.body);
+  document.body.innerHTML = '';
+});
+
+describe('ManualSyncModal filters', () => {
+  it('defaults to days mode and submits maxDays >= 1', async () => {
+    const { container, onConfirm } = renderModal({ syncStartDate: '', maxDays: 0 });
+
+    const daysInput = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(daysInput).toBeTruthy();
+    expect(daysInput.value).toBe('0');
+
+    await act(() => {
+      container.querySelector('.mod-cta')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({ syncStartDate: '', maxDays: 1 });
+  });
+
+  it('submits configured maxDays in days mode', async () => {
+    const { container, onConfirm } = renderModal({ syncStartDate: '', maxDays: 30 });
+
+    await act(() => {
+      container.querySelector('.mod-cta')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({ syncStartDate: '', maxDays: 30 });
+  });
+
+  it('uses date mode when syncStartDate exists and disables maxDays', async () => {
+    const { container, onConfirm } = renderModal({ syncStartDate: '2026-05-09', maxDays: 0 });
+
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    expect(dateInput).toBeTruthy();
+    expect(dateInput.value).toBe('2026-05-09');
+
+    await act(() => {
+      container.querySelector('.mod-cta')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({ syncStartDate: '2026-05-09', maxDays: 0 });
+  });
+
+  it('prefers the stricter filter when both date and days are present: days', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-19T00:00:00Z').getTime());
+    const { container, onConfirm } = renderModal({ syncStartDate: '2026-05-09', maxDays: 7 });
+
+    const daysInput = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(daysInput).toBeTruthy();
+    expect(daysInput.value).toBe('7');
+
+    await act(() => {
+      container.querySelector('.mod-cta')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({ syncStartDate: '', maxDays: 7 });
+  });
+
+  it('prefers the stricter filter when both date and days are present: date', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-19T00:00:00Z').getTime());
+    const { container, onConfirm } = renderModal({ syncStartDate: '2026-05-18', maxDays: 7 });
+
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    expect(dateInput).toBeTruthy();
+    expect(dateInput.value).toBe('2026-05-18');
+
+    await act(() => {
+      container.querySelector('.mod-cta')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({ syncStartDate: '2026-05-18', maxDays: 0 });
+  });
+});

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -104,6 +104,42 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     });
   });
 
+  it('manual sync days scope passes maxDays through engine', async () => {
+    const syncScopeOptions: unknown[] = [];
+    vi.spyOn(SyncEngine.prototype, 'sync').mockImplementation(function (this: SyncEngine) {
+      syncScopeOptions.push(this['scopeOptions']);
+      return Promise.resolve({ created: 0, updated: 0, skipped: 0, failed: 0, total: 0, items: [] });
+    });
+    const plugin = makePlugin();
+
+    await plugin['runSync']('full', { maxDays: 7, syncStartDate: '' });
+
+    expect(syncScopeOptions).toEqual([
+      {
+        maxDays: 7,
+        syncStartDate: '',
+      },
+    ]);
+  });
+
+  it('manual sync date scope disables maxDays in engine', async () => {
+    const syncScopeOptions: unknown[] = [];
+    vi.spyOn(SyncEngine.prototype, 'sync').mockImplementation(function (this: SyncEngine) {
+      syncScopeOptions.push(this['scopeOptions']);
+      return Promise.resolve({ created: 0, updated: 0, skipped: 0, failed: 0, total: 0, items: [] });
+    });
+    const plugin = makePlugin();
+
+    await plugin['runSync']('full', { maxDays: 7, syncStartDate: '2026-05-09' });
+
+    expect(syncScopeOptions).toEqual([
+      {
+        maxDays: 0,
+        syncStartDate: '2026-05-09',
+      },
+    ]);
+  });
+
   it('registers scheduled sync interval with Obsidian lifecycle', () => {
     vi.useFakeTimers();
     const plugin = makePlugin();


### PR DESCRIPTION
### Motivation
- Ensure the manual sync modal opens with the plugin's saved `syncStartDate` and `maxDays` so the UI reflects persisted settings. 
- Choose the most appropriate initial sync mode when both a date and a days cutoff are present, and enforce a sensible minimum for `maxDays` in days mode.

### Description
- Use the plugin settings as the initial options for `ManualSyncModal` in `src/main.tsx` by passing `this.plugin.settings.syncStartDate` and `this.plugin.settings.maxDays` instead of hardcoded defaults.  
- Add `resolveInitialSyncMode` to `src/ui/manual-sync-modal.tsx` and initialize the modal's `syncMode` with it to pick either `date` or `days` based on the provided `initialOptions` and the current time.  
- Enforce a minimum `maxDays` of `1` when confirming in days mode and ensure date mode confirms with `maxDays: 0`.  
- Add unit tests to cover the modal behavior and `runSync` scope handling in `tests/manual-sync-modal.spec.ts` and extend `tests/sync.spec.ts` to assert the `SyncEngine` receives the expected scope.

### Testing
- Added `tests/manual-sync-modal.spec.ts` which exercises defaulting, days/date modes, and strictness selection when both filters are present, and these tests passed.  
- Extended `tests/sync.spec.ts` with checks that `runSync` passes the adjusted scope to `SyncEngine`, and these tests passed.  
- Ran the full unit test suite with `vitest` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5783e298832f93b46add3a1a39cc)