### PR TITLE
feat: sync GetNote append notes

### DIFF
--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -4,10 +4,20 @@ import { t } from '../i18n';
 export const GETNOTE_LIST_LIMIT = 20;
 
 function safeJsonParse(text: string): unknown {
-  const safe = text.replace(
+  let safe = text.replace(
     /"(id|note_id|parent_id|follow_id|live_id)"\s*:\s*(\d+)/g,
     '"$1":"$2"'
   );
+  safe = safe.replace(/"children_ids"\s*:\s*\[([^\]]*)\]/g, (_match, body: string) => {
+    const normalized = body
+      .split(',')
+      .map(item => {
+        const trimmed = item.trim();
+        return /^\d{15,}$/.test(trimmed) ? `"${trimmed}"` : item;
+      })
+      .join(',');
+    return `"children_ids":[${normalized}]`;
+  });
   return JSON.parse(safe);
 }
 
@@ -55,7 +65,51 @@ function normalizeNoteDetailData(value: unknown): Partial<GetNoteNote> | null {
   const detail = { ...source } as Partial<GetNoteNote>;
   const attachments = (value.attachments ?? source.attachments) as Attachment[] | undefined;
   const audio = normalizeAudio(value.audio ?? source.audio);
-  return { ...detail, attachments, audio };
+  const childrenIds = Array.isArray(source.children_ids)
+    ? source.children_ids.map(id => String(id))
+    : undefined;
+  return { ...detail, attachments, audio, children_ids: childrenIds };
+}
+
+async function waitForRetry(signal?: AbortSignal): Promise<void> {
+  await new Promise<void>(resolve => {
+    const timer = window.setTimeout(() => resolve(), 3000);
+    signal?.addEventListener('abort', () => {
+      window.clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+
+function parseErrorBody(text: string): Record<string, unknown> {
+  try {
+    const value = safeJsonParse(text) as unknown;
+    return isRecord(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+async function handleRateLimit<T>(
+  url: string,
+  options: RequestInit,
+  res: Response,
+  retries: number,
+  signal?: AbortSignal
+): Promise<T> {
+  const text = await res.text().catch(() => '');
+  const json = parseErrorBody(text);
+  const errObj = (json.error ?? json) as Record<string, unknown>;
+  const reason = errObj.reason as string | undefined;
+  if (reason === 'quota_day' || reason === 'quota_month') {
+    throw new Error(t('error.quotaExceeded'));
+  }
+  if (retries > 0) {
+    await waitForRetry(signal);
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    return apiRequest(url, options, retries - 1, signal);
+  }
+  throw new Error(t('error.rateLimited'));
 }
 
 async function apiRequest<T>(url: string, options: RequestInit, retries = 1, signal?: AbortSignal): Promise<T> {
@@ -63,7 +117,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
   const res = await fetch(url, { ...options, signal });
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   if (res.status === 401) throw new Error(t('error.invalidCredentials'));
-  if (res.status === 429) throw new Error(t('error.quotaExceeded'));
+  if (res.status === 429) return handleRateLimit<T>(url, options, res, retries, signal);
   if (res.status < 200 || res.status >= 300) {
     const text = await res.text();
     const json = safeJsonParse(text) as Record<string, unknown>;
@@ -82,7 +136,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
     const code = errObj?.code as number | undefined;
     if (code === 10201) throw new Error(t('error.openApiNotMember'));
     if (code === 10202 && retries > 0) {
-      await new Promise(r => window.setTimeout(r, 3000));
+      await waitForRetry(signal);
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       return apiRequest(url, options, retries - 1, signal);
     }

--- a/src/api-clients/webapi-client.ts
+++ b/src/api-clients/webapi-client.ts
@@ -28,6 +28,10 @@ function parseWebApiListResponse(value: unknown): { notes: GetNoteNote[]; hasMor
   const notes: GetNoteNote[] = list.map((n): GetNoteNote => ({
     id: n.id as string,
     note_id: n.note_id as string,
+    parent_id: (n.parent_id as string) ?? undefined,
+    children_count: typeof n.children_count === 'number' ? n.children_count : undefined,
+    children_ids: Array.isArray(n.children_ids) ? n.children_ids.map((id: unknown) => String(id)) : undefined,
+    is_child_note: typeof n.is_child_note === 'boolean' ? n.is_child_note : undefined,
     title: (n.title as string) ?? '',
     content: (n.content as string) ?? '',
     note_type: (n.note_type as string) ?? 'plain_text',
@@ -49,7 +53,10 @@ function normalizeNoteDetailData(value: unknown): Partial<GetNoteNote> | null {
   const detail = { ...source } as Partial<GetNoteNote>;
   const attachments = (value.attachments ?? source.attachments) as Attachment[] | undefined;
   const audio = typeof (value.audio ?? source.audio) === 'string' ? (value.audio ?? source.audio) as string : undefined;
-  return { ...detail, attachments, audio };
+  const childrenIds = Array.isArray(source.children_ids)
+    ? source.children_ids.map(id => String(id))
+    : undefined;
+  return { ...detail, attachments, audio, children_ids: childrenIds };
 }
 
 function tryParseJsonObject(text: string): Record<string, unknown> {
@@ -59,6 +66,38 @@ function tryParseJsonObject(text: string): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+async function waitForRetry(signal?: AbortSignal): Promise<void> {
+  await new Promise<void>(resolve => {
+    const timer = window.setTimeout(() => resolve(), 3000);
+    signal?.addEventListener('abort', () => {
+      window.clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+
+async function handleRateLimit<T>(
+  url: string,
+  options: RequestInit,
+  res: Response,
+  retries: number,
+  signal?: AbortSignal
+): Promise<T> {
+  const text = await res.text().catch(() => '');
+  const json = tryParseJsonObject(text);
+  const err = (json.error ?? json) as Record<string, unknown>;
+  const reason = err.reason as string | undefined;
+  if (reason === 'quota_day' || reason === 'quota_month') {
+    throw new Error(t('error.quotaExceeded'));
+  }
+  if (retries > 0) {
+    await waitForRetry(signal);
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    return apiRequest(url, options, retries - 1, signal);
+  }
+  throw new Error(t('error.rateLimited'));
 }
 
 async function apiRequest<T>(url: string, options: RequestInit, retries = 1, signal?: AbortSignal): Promise<T> {
@@ -72,10 +111,10 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
     if (msg === 'LoginRequired') throw new Error(t('error.webApiLoginRequired'));
     throw new Error(t('error.webApiForbidden'));
   }
-  if (res.status === 429) throw new Error(t('error.quotaExceeded'));
+  if (res.status === 429) return handleRateLimit<T>(url, options, res, retries, signal);
   if (res.status < 200 || res.status >= 300) {
     if (res.status >= 500 && retries > 0) {
-      await new Promise(r => window.setTimeout(r, 3000));
+      await waitForRetry(signal);
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       return apiRequest(url, options, retries - 1, signal);
     }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -206,6 +206,7 @@ export const translations: Record<string, Record<string, string>> = {
     'error.oauthUnknown': 'OAuth 授权未知错误 {status}',
     'error.oauthCancelled': 'OAuth 授权已取消',
     'error.quotaExceeded': 'API 配额已用完，请明天再试',
+    'error.rateLimited': 'API 调用频率过高，请稍后再试',
     'error.webApiLoginRequired': 'Web Token 已过期，请刷新登录后重新复制 Token',
     'error.webApiForbidden': 'Web Token 无效，请检查设置',
 
@@ -425,6 +426,7 @@ export const translations: Record<string, Record<string, string>> = {
     'error.oauthUnknown': 'OAuth unknown error {status}',
     'error.oauthCancelled': 'OAuth authorization cancelled',
     'error.quotaExceeded': 'API quota exhausted, please try again tomorrow',
+    'error.rateLimited': 'API rate limit exceeded, please try again later',
     'error.webApiLoginRequired': 'Web Token expired, please refresh login and copy a new Token',
     'error.webApiForbidden': 'Web Token invalid, please check settings',
 

--- a/src/note-parser.ts
+++ b/src/note-parser.ts
@@ -74,6 +74,7 @@ export function formatTimestampPrefix(format: string, isoDate: string): string {
 function buildFrontmatter(note: GetNoteNote): string {
   const tags = note.tags.map(t => `"${t.name}"`).join(', ');
   const tagBlock = tags ? `[${tags}]` : '[]';
+  const childrenIds = note.children_ids?.map(id => `"${escapeYamlDoubleQuoted(id)}"`).join(', ');
 
   const title = sanitizeTitle(note.title) ||
     escapeYamlDoubleQuoted((note.content || '').slice(0, 10));
@@ -87,10 +88,22 @@ function buildFrontmatter(note: GetNoteNote): string {
     `source: Get笔记`,
     `note_type: ${note.note_type}`,
     `tags: ${tagBlock}`,
-    '---',
-    '',
   ];
 
+  if (note.parent_id) {
+    lines.push(`parent_id: "${escapeYamlDoubleQuoted(note.parent_id)}"`);
+  }
+  if (typeof note.is_child_note === 'boolean') {
+    lines.push(`is_child_note: ${note.is_child_note}`);
+  }
+  if (typeof note.children_count === 'number') {
+    lines.push(`children_count: ${note.children_count}`);
+  }
+  if (note.children_ids) {
+    lines.push(`children_ids: [${childrenIds ?? ''}]`);
+  }
+
+  lines.push('---', '');
   return lines.join('\n');
 }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -105,22 +105,27 @@ export class SyncEngine {
     const rawTitle = generateDisplayTitle(note);
     const displayTitle = rawTitle || t('picker.noTitle');
     const prefix = this.settings.filenamePrefix?.trim();
-    if (!prefix) {
-      return displayTitle;
-    }
+    const baseName = (() => {
+      if (!prefix) return displayTitle;
 
-    const hasTimestampTokens = /YYYY|MM|DD|HH|mm|ss/.test(prefix);
-    if (hasTimestampTokens) {
-      const formattedPrefix = formatTimestampPrefix(prefix, note.created_at);
-      if (!formattedPrefix) {
-        return displayTitle;
+      const hasTimestampTokens = /YYYY|MM|DD|HH|mm|ss/.test(prefix);
+      if (hasTimestampTokens) {
+        const formattedPrefix = formatTimestampPrefix(prefix, note.created_at);
+        if (!formattedPrefix) {
+          return displayTitle;
+        }
+        const separator = formattedPrefix.endsWith('_') ? '' : '_';
+        return `${formattedPrefix}${separator}${displayTitle}`;
       }
-      const separator = formattedPrefix.endsWith('_') ? '' : '_';
-      return `${formattedPrefix}${separator}${displayTitle}`;
-    }
 
-    const separator = prefix.endsWith('_') ? '' : '_';
-    return `${prefix}${separator}${displayTitle}`;
+      const separator = prefix.endsWith('_') ? '' : '_';
+      return `${prefix}${separator}${displayTitle}`;
+    })();
+
+    if (note.is_child_note || note.parent_id) {
+      return `${baseName}__${note.note_id}`;
+    }
+    return baseName;
   }
 
   private getFilePath(categoryDir: string, note: GetNoteNote): string {
@@ -349,8 +354,42 @@ export class SyncEngine {
     });
   }
 
+  private applyWriteResult(result: SyncResult, writeResult: WriteNoteResult): void {
+    switch (writeResult.status) {
+      case 'created': result.created++; break;
+      case 'updated': result.updated++; break;
+      case 'skipped': result.skipped++; break;
+      case 'failed': result.failed++; break;
+    }
+  }
+
+  private mergeNoteDetail(note: GetNoteNote, detail: Partial<GetNoteNote>): GetNoteNote {
+    return {
+      ...note,
+      ...detail,
+      id: detail.id ?? note.id,
+      note_id: detail.note_id ?? note.note_id,
+      title: detail.title ?? note.title,
+      content: detail.content ?? note.content,
+      note_type: detail.note_type ?? note.note_type,
+      source: detail.source ?? note.source,
+      tags: detail.tags ?? note.tags,
+      created_at: detail.created_at ?? note.created_at,
+      updated_at: detail.updated_at ?? note.updated_at,
+      parent_id: detail.parent_id ?? note.parent_id,
+      children_count: detail.children_count ?? note.children_count,
+      children_ids: detail.children_ids ?? note.children_ids,
+      is_child_note: detail.is_child_note ?? note.is_child_note,
+    };
+  }
+
+  private needsRelationDetail(note: GetNoteNote): boolean {
+    return Boolean((note.children_count ?? 0) > 0 && !note.children_ids?.length);
+  }
+
   private async enrichAudioNote(note: GetNoteNote, signal: AbortSignal): Promise<GetNoteNote> {
-    if (!AUDIO_NOTE_TYPES.has(note.note_type)) {
+    const needsAudioDetail = AUDIO_NOTE_TYPES.has(note.note_type);
+    if (!needsAudioDetail && !this.needsRelationDetail(note)) {
       return note;
     }
 
@@ -365,19 +404,10 @@ export class SyncEngine {
         signal,
         credentials.authMode
       );
-      const enrichedNote: GetNoteNote = {
-        ...note,
-        ...noteDetail,
-        id: noteDetail.id ?? note.id,
-        note_id: noteDetail.note_id ?? note.note_id,
-        title: noteDetail.title ?? note.title,
-        content: noteDetail.content ?? note.content,
-        note_type: noteDetail.note_type ?? note.note_type,
-        source: noteDetail.source ?? note.source,
-        tags: noteDetail.tags ?? note.tags,
-        created_at: noteDetail.created_at ?? note.created_at,
-        updated_at: noteDetail.updated_at ?? note.updated_at,
-      };
+      const enrichedNote = this.mergeNoteDetail(note, noteDetail);
+      if (!needsAudioDetail) {
+        return enrichedNote;
+      }
       const attachment = enrichedNote.attachments?.find(a => a.type === 'audio');
       if (attachment) {
         await this.downloadAudioAsset(enrichedNote, attachment);
@@ -388,9 +418,48 @@ export class SyncEngine {
       enrichedNote.assetFileName = this.getFileName(enrichedNote);
       return enrichedNote;
     } catch (err) {
-      console.warn(`[GetNote] Failed to enrich audio note ${note.note_id}:`, err);
+      console.warn(`[GetNote] Failed to enrich note ${note.note_id}:`, err);
       return note;
     }
+  }
+
+  private async fetchAppendNotes(parent: GetNoteNote, signal: AbortSignal): Promise<GetNoteNote[]> {
+    const childIds = parent.children_ids ?? [];
+    if (!childIds.length) return [];
+
+    const credentials = getAuthCredentials(this.settings);
+    const appendNotes: GetNoteNote[] = [];
+    for (const childId of childIds) {
+      try {
+        const childDetail = await fetchNoteDetail(
+          childId,
+          credentials.token,
+          credentials.clientId,
+          signal,
+          credentials.authMode
+        );
+        const baseChild: GetNoteNote = {
+          id: childDetail.id ?? childId,
+          note_id: childDetail.note_id ?? childId,
+          title: childDetail.title ?? '',
+          content: childDetail.content ?? '',
+          note_type: childDetail.note_type ?? 'plain_text',
+          source: childDetail.source ?? parent.source,
+          tags: childDetail.tags ?? [],
+          created_at: childDetail.created_at ?? parent.created_at,
+          updated_at: childDetail.updated_at ?? parent.updated_at,
+          parent_id: childDetail.parent_id ?? parent.note_id,
+          children_count: childDetail.children_count,
+          children_ids: childDetail.children_ids,
+          is_child_note: childDetail.is_child_note ?? true,
+        };
+        const child = await this.enrichAudioNote(this.mergeNoteDetail(baseChild, childDetail), signal);
+        appendNotes.push(child);
+      } catch (err) {
+        console.warn(`[GetNote] Failed to fetch append note ${childId}:`, err);
+      }
+    }
+    return appendNotes;
   }
 
   private filterNotesByDateRange(notes: GetNoteNote[]): GetNoteNote[] {
@@ -464,13 +533,19 @@ export class SyncEngine {
           result.total++;
           const noteToWrite = await this.enrichAudioNote(note, controller.signal);
           const writeResult = await this.writeNote(noteToWrite, uidIndex);
-          switch (writeResult.status) {
-            case 'created': result.created++; break;
-            case 'updated': result.updated++; break;
-            case 'skipped': result.skipped++; break;
-            case 'failed': result.failed++; break;
-          }
+          this.applyWriteResult(result, writeResult);
           this.recordItem(result, noteToWrite, writeResult);
+
+          const appendNotes = await this.fetchAppendNotes(noteToWrite, controller.signal);
+          for (const appendNote of appendNotes) {
+            if (seenNoteIds.has(appendNote.note_id)) continue;
+            seenNoteIds.add(appendNote.note_id);
+            result.total++;
+            const appendWriteResult = await this.writeNote(appendNote, uidIndex);
+            this.applyWriteResult(result, appendWriteResult);
+            this.recordItem(result, appendNote, appendWriteResult);
+          }
+
           const updatedTime = parseNoteUpdatedTime(note);
           if (updatedTime !== null && (lastNoteTimestampTime === null || updatedTime > lastNoteTimestampTime)) {
             lastNoteTimestampTime = updatedTime;
@@ -559,17 +634,26 @@ export class SyncEngine {
           if (preCheck.exists) {
             result.skipped++;
             this.recordItem(result, note, { status: 'skipped' });
-            continue;
+            if (!this.needsRelationDetail(note)) {
+              continue;
+            }
           }
           const noteToWrite = await this.enrichAudioNote(note, controller.signal);
-          const writeResult = await this.writeNote(noteToWrite, uidIndex);
-          switch (writeResult.status) {
-            case 'created': result.created++; break;
-            case 'updated': result.updated++; break;
-            case 'skipped': result.skipped++; break;
-            case 'failed': result.failed++; break;
+          if (!preCheck.exists) {
+            const writeResult = await this.writeNote(noteToWrite, uidIndex);
+            this.applyWriteResult(result, writeResult);
+            this.recordItem(result, noteToWrite, writeResult);
           }
-          this.recordItem(result, noteToWrite, writeResult);
+
+          const appendNotes = await this.fetchAppendNotes(noteToWrite, controller.signal);
+          for (const appendNote of appendNotes) {
+            if (seenNoteIds.has(appendNote.note_id)) continue;
+            seenNoteIds.add(appendNote.note_id);
+            result.total++;
+            const appendWriteResult = await this.writeNote(appendNote, uidIndex);
+            this.applyWriteResult(result, appendWriteResult);
+            this.recordItem(result, appendNote, appendWriteResult);
+          }
         }
 
         if (fetchedCount >= noteIds.length) break;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -423,7 +423,11 @@ export class SyncEngine {
     }
   }
 
-  private async fetchAppendNotes(parent: GetNoteNote, signal: AbortSignal): Promise<GetNoteNote[]> {
+  private async fetchAppendNotes(
+    parent: GetNoteNote,
+    signal: AbortSignal,
+    result: SyncResult
+  ): Promise<GetNoteNote[]> {
     const childIds = parent.children_ids ?? [];
     if (!childIds.length) return [];
 
@@ -431,8 +435,11 @@ export class SyncEngine {
     const appendNotes: GetNoteNote[] = [];
     for (const childId of childIds) {
       try {
+        // Web API may require prime_id (not note_id) to locate child note details.
+        // Use prime_id when available, mirroring enrichAudioNote's detailId pattern.
+        const detailId = (parent as { prime_id?: string }).prime_id ?? childId;
         const childDetail = await fetchNoteDetail(
-          childId,
+          detailId,
           credentials.token,
           credentials.clientId,
           signal,
@@ -456,6 +463,24 @@ export class SyncEngine {
         const child = await this.enrichAudioNote(this.mergeNoteDetail(baseChild, childDetail), signal);
         appendNotes.push(child);
       } catch (err) {
+        result.failed++;
+        const failedNote: GetNoteNote = {
+          id: childId,
+          note_id: childId,
+          title: '',
+          content: '',
+          note_type: 'plain_text',
+          source: parent.source,
+          tags: [],
+          created_at: parent.created_at,
+          updated_at: parent.updated_at,
+          parent_id: parent.note_id,
+          is_child_note: true,
+        };
+        this.recordItem(result, failedNote, {
+          status: 'failed',
+          error: err instanceof Error ? err.message : String(err),
+        });
         console.warn(`[GetNote] Failed to fetch append note ${childId}:`, err);
       }
     }
@@ -536,7 +561,7 @@ export class SyncEngine {
           this.applyWriteResult(result, writeResult);
           this.recordItem(result, noteToWrite, writeResult);
 
-          const appendNotes = await this.fetchAppendNotes(noteToWrite, controller.signal);
+          const appendNotes = await this.fetchAppendNotes(noteToWrite, controller.signal, result);
           for (const appendNote of appendNotes) {
             if (seenNoteIds.has(appendNote.note_id)) continue;
             seenNoteIds.add(appendNote.note_id);
@@ -645,7 +670,7 @@ export class SyncEngine {
             this.recordItem(result, noteToWrite, writeResult);
           }
 
-          const appendNotes = await this.fetchAppendNotes(noteToWrite, controller.signal);
+          const appendNotes = await this.fetchAppendNotes(noteToWrite, controller.signal, result);
           for (const appendNote of appendNotes) {
             if (seenNoteIds.has(appendNote.note_id)) continue;
             seenNoteIds.add(appendNote.note_id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,10 @@
 export interface GetNoteNote {
   id: string | number;  // OpenAPI: number → string via safeJsonParse; Web API: string
   note_id: string;
+  parent_id?: string;
+  children_count?: number;
+  children_ids?: string[];
+  is_child_note?: boolean;
   title: string;
   content: string;       // 正文（markdown），录音笔记为 AI 摘要
   note_type: NoteType;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -4,10 +4,20 @@ import type { ListResponse } from '../src/types';
 
 // Extract the internal safeJsonParse for direct testing
 function safeJsonParse(text: string): unknown {
-  const safe = text.replace(
+  let safe = text.replace(
     /"(id|note_id|parent_id|follow_id|live_id)"\s*:\s*(\d+)/g,
     '"$1":"$2"'
   );
+  safe = safe.replace(/"children_ids"\s*:\s*\[([^\]]*)\]/g, (_match, body: string) => {
+    const normalized = body
+      .split(',')
+      .map(item => {
+        const trimmed = item.trim();
+        return /^\d{15,}$/.test(trimmed) ? `"${trimmed}"` : item;
+      })
+      .join(',');
+    return `"children_ids":[${normalized}]`;
+  });
   return JSON.parse(safe);
 }
 
@@ -75,6 +85,12 @@ describe('safeJsonParse', () => {
     const data = result.data as { notes: Array<{ id: string; title: string }> };
     expect(data.notes[0].id).toBe('9999999999999999');
     expect(data.notes[1].id).toBe('8888888888888888');
+  });
+
+  it('children_ids 数组中的大整数也转为字符串', () => {
+    const input = '{"children_ids":[1909246675068292528,1908043831896764336]}';
+    const result = safeJsonParse(input) as { children_ids: string[] };
+    expect(result.children_ids).toEqual(['1909246675068292528', '1908043831896764336']);
   });
 
   it('处理空对象', () => {
@@ -160,6 +176,43 @@ describe('fetchNoteDetail', () => {
     }
   });
 
+  it('解析官方详情接口里的主子笔记关系字段', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockTextFetchResponse(JSON.stringify({
+        success: true,
+        data: {
+          note: {
+            id: 0,
+            note_id: 0,
+            title: '主笔记',
+            content: '正文',
+            note_type: 'plain_text',
+            source: 'app',
+            tags: [],
+            created_at: '2026-05-06 22:07:04',
+            updated_at: '2026-05-06 22:07:04',
+            children_count: 1,
+            children_ids: [0],
+            is_child_note: false,
+          },
+        },
+      })
+        .replace('"id":0', '"id":1909193892067130512')
+        .replace('"note_id":0', '"note_id":1909193892067130512')
+        .replace('[0]', '[1909246675068292528]')) as Response
+    );
+
+    try {
+      const result = await fetchNoteDetail('1909193892067130512', 'test-token', 'test-client');
+      expect(result.note_id).toBe('1909193892067130512');
+      expect(result.children_count).toBe(1);
+      expect(result.children_ids).toEqual(['1909246675068292528']);
+      expect(result.is_child_note).toBe(false);
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
   it('笔记不存在时抛出错误', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       mockFetchResponse({ success: false, error: { message: '笔记不存在' } }) as Response
@@ -208,6 +261,54 @@ describe('fetchNotes limit', () => {
         expect.any(Object)
       );
     } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
+  it('429 频率限制时等待 3 秒后重试', async () => {
+    const timeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((fn: TimerHandler) => {
+      if (typeof fn === 'function') fn();
+      return 1;
+    });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockFetchResponse({
+        success: false,
+        error: { code: 10203, message: 'too many requests', reason: 'qps' },
+      }, 429) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { notes: [], has_more: false, next_cursor: '' },
+      }) as Response);
+
+    try {
+      const result = await fetchNotes({ token: 'test-token', clientId: 'test-client' });
+
+      expect(result.notes).toEqual([]);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 3000);
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
+  it('429 日配额耗尽时不重试', async () => {
+    const timeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((fn: TimerHandler) => {
+      if (typeof fn === 'function') fn();
+      return 1;
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({
+        success: false,
+        error: { code: 10203, message: 'quota exhausted', reason: 'quota_day' },
+      }, 429) as Response
+    );
+
+    try {
+      await expect(fetchNotes({ token: 'test-token', clientId: 'test-client' })).rejects.toThrow('API 配额已用完');
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(timeoutSpy).not.toHaveBeenCalled();
+    } finally {
+      timeoutSpy.mockRestore();
       vi.mocked(globalThis.fetch).mockRestore();
     }
   });

--- a/tests/note-parser.spec.ts
+++ b/tests/note-parser.spec.ts
@@ -59,6 +59,27 @@ describe('renderNote', () => {
     expect(result).toContain('tags: []');
   });
 
+  it('附加笔记输出 parent_id 与 child 标识', () => {
+    const result = renderNote(makeNote({
+      note_id: '1909246675068292528',
+      parent_id: '1909193892067130512',
+      is_child_note: true,
+    }));
+
+    expect(result).toContain('parent_id: "1909193892067130512"');
+    expect(result).toContain('is_child_note: true');
+  });
+
+  it('主笔记输出 children_ids', () => {
+    const result = renderNote(makeNote({
+      children_count: 1,
+      children_ids: ['1909246675068292528'],
+    }));
+
+    expect(result).toContain('children_count: 1');
+    expect(result).toContain('children_ids: ["1909246675068292528"]');
+  });
+
   it('正文为空时只输出 frontmatter', () => {
     const result = renderNote(makeNote({ content: '' }));
     expect(result.endsWith('---\n')).toBe(true);

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -639,6 +639,91 @@ describe('SyncEngine — getFileName', () => {
     // @ts-ignore
     expect(engine['getFileName'](note)).toBe('我的笔记');
   });
+
+  it('附加笔记在文件名末尾追加 __note_id', () => {
+    const app = makeMockApp();
+    const engine = new SyncEngine(app as any, makeSettings({ filenamePrefix: 'getnote' }));
+    const note = makeNote({
+      title: '原笔记标题',
+      note_id: '1909246675068292528',
+      parent_id: '1909193892067130512',
+      is_child_note: true,
+    });
+
+    // @ts-ignore
+    expect(engine['getFileName'](note)).toBe('getnote_原笔记标题__1909246675068292528');
+  });
+});
+
+describe('SyncEngine — append note sync', () => {
+  it('同步主笔记时通过官方详情接口拉取并写入附加笔记', async () => {
+    const parentNote = makeNote({
+      note_id: '1909193892067130512',
+      title: '主笔记',
+      content: '主笔记正文',
+      children_count: 1,
+      updated_at: '2026-05-06 22:07:04',
+    });
+    const childNote = makeNote({
+      note_id: '1909246675068292528',
+      title: '',
+      content: '附加笔记正文',
+      parent_id: parentNote.note_id,
+      is_child_note: true,
+      updated_at: '2026-05-07 19:19:30',
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url: unknown) => {
+      const urlStr = typeof url === 'string' ? url : (url as Request).url;
+      if (urlStr.includes('/resource/note/list')) {
+        return Promise.resolve(mockFetchResponse({
+          data: { notes: [parentNote], has_more: false, cursor: '' },
+        }) as Response);
+      }
+      if (urlStr.includes(`/resource/note/detail?id=${parentNote.note_id}`)) {
+        return Promise.resolve(mockFetchResponse({
+          success: true,
+          data: {
+            note: {
+              ...parentNote,
+              children_ids: [childNote.note_id],
+              is_child_note: false,
+            },
+          },
+        }) as Response);
+      }
+      if (urlStr.includes(`/resource/note/detail?id=${childNote.note_id}`)) {
+        return Promise.resolve(mockFetchResponse({
+          success: true,
+          data: { note: childNote },
+        }) as Response);
+      }
+      throw new Error(`Unexpected request: ${urlStr}`);
+    });
+
+    const app = makeMockApp();
+
+    try {
+      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }));
+      const result = await engine.sync();
+
+      expect(result.created).toBe(2);
+      expect(result.items).toEqual([
+        expect.objectContaining({ noteId: parentNote.note_id, status: 'created' }),
+        expect.objectContaining({ noteId: childNote.note_id, status: 'created' }),
+      ]);
+      const createdPaths = vi.mocked(app.vault.create).mock.calls.map(([path]) => path);
+      expect(createdPaths).toContain('Get笔记/纯文本/主笔记.md');
+      expect(createdPaths).toContain('Get笔记/纯文本/附加笔记正文__1909246675068292528.md');
+      const childContent = vi.mocked(app.vault.create).mock.calls.find(([path]) =>
+        path === 'Get笔记/纯文本/附加笔记正文__1909246675068292528.md'
+      )?.[1] as string;
+      expect(childContent).toContain('parent_id: "1909193892067130512"');
+      expect(childContent).toContain('is_child_note: true');
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
 });
 
 describe('SyncEngine — audio note sync', () => {


### PR DESCRIPTION
## Summary
- explore and implement the official OpenAPI append-note flow: parent list item -> detail children_ids -> child detail
- sync append notes as separate Obsidian notes with stable __note_id filenames
- preserve parent/child relation metadata in frontmatter and string-safe large IDs

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Live API evidence
- Official docs show note/save supports parent_id and note/detail returns data.note with child/audio/attachment fields.
- Live read-only probing found parent notes with children_count, parent detail children_ids, and child detail parent_id/is_child_note.
- A final live temp-vault smoke was blocked by OpenAPI quota exhaustion: API 配额已用完，请明天再试.