### PR TITLE
Fix sync early stop for created-time pagination

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -33,10 +33,15 @@ function parseNoteUpdatedTime(note: GetNoteNote): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-function isSortedByUpdatedDesc(notes: GetNoteNote[]): boolean {
+function parseNoteCreatedTime(note: GetNoteNote): number | null {
+  const parsed = Date.parse(note.created_at);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function isSortedByCreatedDesc(notes: GetNoteNote[]): boolean {
   let previous: number | null = null;
   for (const note of notes) {
-    const current = parseNoteUpdatedTime(note);
+    const current = parseNoteCreatedTime(note);
     if (current === null) return false;
     if (previous !== null && current > previous) return false;
     previous = current;
@@ -478,12 +483,12 @@ export class SyncEngine {
           }
         }
 
-        // Notes are sorted by updated_at DESC. Once the oldest note in this page
+        // List APIs page by created_at DESC. Once the oldest created note in this page
         // is older than the cutoff, later pages can be skipped after this page's
         // still-valid notes have been processed.
-        if (cutoffTime !== null && notes.length > 0 && isSortedByUpdatedDesc(notes)) {
+        if (cutoffTime !== null && notes.length > 0 && isSortedByCreatedDesc(notes)) {
           const oldestNote = notes[notes.length - 1];
-          const oldestTime = parseNoteUpdatedTime(oldestNote);
+          const oldestTime = parseNoteCreatedTime(oldestNote);
           if (oldestTime !== null && oldestTime < cutoffTime) {
             break;
           }

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -243,6 +243,147 @@ describe('SyncEngine — page cutoff', () => {
       vi.useRealTimers();
     }
   });
+
+  it('stops OpenAPI pagination when maxDays reaches a stale created_at tail page', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00+08:00'));
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('since_id=old_tail')) {
+        return mockFetchResponse({
+          data: {
+            notes: [
+              makeNote({
+                note_id: 'should_not_fetch_page_2',
+                title: '不应该翻到第二页',
+                created_at: '2026-05-11T10:00:00+08:00',
+                updated_at: '2026-05-11T10:00:00+08:00',
+              }),
+            ],
+            has_more: false,
+            next_cursor: '',
+          },
+        }) as Response;
+      }
+
+      return mockFetchResponse({
+        data: {
+          notes: [
+            makeNote({
+              note_id: 'fresh',
+              title: '一天内',
+              created_at: '2026-05-11T11:30:00+08:00',
+              updated_at: '2026-05-11T11:30:00+08:00',
+            }),
+            makeNote({
+              note_id: 'old_created_recently_updated',
+              title: '旧创建但刚更新',
+              created_at: '2026-05-09T12:00:00+08:00',
+              updated_at: '2026-05-11T11:00:00+08:00',
+            }),
+            makeNote({
+              note_id: 'old_tail',
+              title: '超过一天',
+              created_at: '2026-05-09T11:30:00+08:00',
+              updated_at: '2026-05-09T11:30:00+08:00',
+            }),
+          ],
+          has_more: true,
+          next_cursor: 'old_tail',
+        },
+      }) as Response;
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app as any, makeSettings({
+        authMode: 'openapi',
+        openApiToken: 'openapi-token',
+        openApiClientId: 'openapi-client',
+        maxDays: 1,
+      }));
+
+      const result = await engine.sync();
+
+      expect(result.items?.map(item => item.noteId)).toEqual(['fresh', 'old_created_recently_updated']);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(String(vi.mocked(globalThis.fetch).mock.calls[0][0])).toBe(
+        'https://openapi.biji.com/open/api/v1/resource/note/list?since_id=0'
+      );
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops Web API pagination when maxDays reaches a stale created_at tail page', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00+08:00'));
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('since_id=old_tail')) {
+        return mockFetchResponse({
+          h: {},
+          c: {
+            list: [
+              makeNote({
+                note_id: 'should_not_fetch_page_2',
+                title: '不应该翻到第二页',
+                created_at: '2026-05-11T10:00:00+08:00',
+                updated_at: '2026-05-11T10:00:00+08:00',
+              }),
+            ],
+            has_more: false,
+          },
+        }) as Response;
+      }
+
+      return mockFetchResponse({
+        h: {},
+        c: {
+          list: [
+            makeNote({
+              note_id: 'fresh',
+              title: '一天内',
+              created_at: '2026-05-11T11:30:00+08:00',
+              updated_at: '2026-05-11T11:30:00+08:00',
+            }),
+            makeNote({
+              note_id: 'old_created_recently_updated',
+              title: '旧创建但刚更新',
+              created_at: '2026-05-09T12:00:00+08:00',
+              updated_at: '2026-05-11T11:00:00+08:00',
+            }),
+            makeNote({
+              note_id: 'old_tail',
+              title: '超过一天',
+              created_at: '2026-05-09T11:30:00+08:00',
+              updated_at: '2026-05-09T11:30:00+08:00',
+            }),
+          ],
+          has_more: true,
+        },
+      }) as Response;
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app as any, makeSettings({
+        authMode: 'web',
+        webApiToken: 'web-token',
+        maxDays: 1,
+      }));
+
+      const result = await engine.sync();
+
+      expect(result.items?.map(item => item.noteId)).toEqual(['fresh', 'old_created_recently_updated']);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(String(vi.mocked(globalThis.fetch).mock.calls[0][0])).toContain('sort=create_desc');
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('SyncEngine — filterNotesByDateRange', () => {


### PR DESCRIPTION
## Summary
- align sync early-stop checks with GetNote list pagination order (created_at descending)
- keep page-local updated-time filtering before stopping
- add paired OpenAPI and Web API pagination coverage for maxDays early stop

## Tests
- npm run typecheck
- npm run lint
- npm test
- npm run build
