### PR TITLE
docs: remove duplicate README language links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Bring your GetNote ideas, highlights, links, recordings, and AI summaries into O
 
 GetNote Importer is an Obsidian plugin for people who capture in GetNote but think, connect, and build in Obsidian. It keeps imports readable from day one: title-based filenames, type-based folders, source metadata in frontmatter, incremental updates, selective sync, scheduled sync, and detailed sync history.
 
-[中文版说明](./README_zh.md)
-
 ## Why It Feels Good
 
 - **Readable files, not dumped data**: notes are named from their titles and organized by note type.

--- a/README_zh.md
+++ b/README_zh.md
@@ -12,8 +12,6 @@
 
 GetNote Importer 适合把 Get笔记作为快速捕捉入口、把 Obsidian 作为长期知识库的人。插件会用可读文件名、分类目录、frontmatter、增量更新、选择性同步和同步历史，尽量让导入内容从第一天就能融入你的 vault。
 
-[English version](./README.md)
-
 ## 为什么好用
 
 - **文件可读，不是数据堆**：笔记按标题命名、按类型归档。


### PR DESCRIPTION
## Summary
- remove the duplicate Chinese README link from the English README intro
- remove the matching duplicate English README link from the Chinese README intro
- keep the top language switcher as the single language navigation point

## Checks
- npm run typecheck
- npm run lint
- npm test
- npm run build