### PR TITLE
[codex] Add 得到大脑 alias to plugin description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/AndyZhengyan/obsidian-getnote-importer/ci.yml?branch=main&style=flat-square)](https://github.com/AndyZhengyan/obsidian-getnote-importer/actions)
 [![License](https://img.shields.io/github/license/AndyZhengyan/obsidian-getnote-importer?style=flat-square)](LICENSE)
 
-Bring your GetNote ideas, highlights, links, recordings, and AI summaries into Obsidian as clean, searchable Markdown.
+Bring your GetNote (得到大脑, formerly Get笔记) ideas, highlights, links, recordings, and AI summaries into Obsidian as clean, searchable Markdown.
 
-GetNote Importer is an Obsidian plugin for people who capture in GetNote but think, connect, and build in Obsidian. It keeps imports readable from day one: title-based filenames, type-based folders, source metadata in frontmatter, incremental updates, selective sync, scheduled sync, and detailed sync history.
+GetNote Importer is an Obsidian plugin for people who capture in GetNote (得到大脑, formerly Get笔记) but think, connect, and build in Obsidian. It keeps imports readable from day one: title-based filenames, type-based folders, source metadata in frontmatter, incremental updates, selective sync, scheduled sync, and detailed sync history.
 
 ## Why It Feels Good
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,9 +8,9 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/AndyZhengyan/obsidian-getnote-importer/ci.yml?branch=main&style=flat-square)](https://github.com/AndyZhengyan/obsidian-getnote-importer/actions)
 [![许可证](https://img.shields.io/github/license/AndyZhengyan/obsidian-getnote-importer?style=flat-square)](LICENSE)
 
-把 Get笔记里的灵感、摘录、链接、录音和 AI 总结同步进 Obsidian，变成可长期整理、搜索和链接的本地 Markdown 知识库。
+把 GetNote（得到大脑，原名 Get笔记）里的灵感、摘录、链接、录音和 AI 总结同步进 Obsidian，变成可长期整理、搜索和链接的本地 Markdown 知识库。
 
-GetNote Importer 适合把 Get笔记作为快速捕捉入口、把 Obsidian 作为长期知识库的人。插件会用可读文件名、分类目录、frontmatter、增量更新、选择性同步和同步历史，尽量让导入内容从第一天就能融入你的 vault。
+GetNote Importer 适合把 GetNote（得到大脑，原名 Get笔记）作为快速捕捉入口、把 Obsidian 作为长期知识库的人。插件会用可读文件名、分类目录、frontmatter、增量更新、选择性同步和同步历史，尽量让导入内容从第一天就能融入你的 vault。
 
 ## 为什么好用
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "getnote-importer",
   "name": "GetNote Importer",
   "version": "1.0.12",
-  "description": "Sync notes, links, recordings, and AI summaries from GetNote into your local vault.",
+  "description": "Sync notes, links, recordings, and AI summaries from GetNote (得到大脑, formerly Get笔记) into your local vault.",
   "author": "Andy Zheng",
   "isDesktopOnly": false,
   "minAppVersion": "1.8.7"

--- a/tests/manifest.spec.ts
+++ b/tests/manifest.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import manifest from '../manifest.json';
+
+describe('plugin manifest', () => {
+  it('keeps old and new GetNote brand terms searchable in the description', () => {
+    expect(manifest.description).toContain('GetNote');
+    expect(manifest.description).toContain('得到大脑');
+    expect(manifest.description).toContain('Get笔记');
+  });
+});


### PR DESCRIPTION
## Summary

- add `得到大脑` and `Get笔记` alias text to the Obsidian plugin manifest description
- add a manifest regression test so the searchable brand terms stay present

Closes #76.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
