### PR TITLE
chore: bump GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
 
@@ -33,11 +33,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,6 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/dependency-review-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci


### PR DESCRIPTION
## Summary

GitHub is deprecating Node 20 actions on the runner:
- **2026-06-16**: Node 24 becomes the default for all actions
- **2026-09-16**: Node 20 is fully removed from the runner

This PR migrates all workflows to Node 24-compatible action versions and pins `node-version: '24'` where Node is explicitly installed.

## Changes

| File | Action version bumps | Node |
|------|---------------------|------|
| `.github/workflows/ci.yml` | `actions/checkout@v4` → `@v5`, `actions/setup-go@v5` → `@v6`, `actions/setup-node@v4` → `@v6` | `20` → `24` |
| `.github/workflows/release.yml` | `actions/checkout@v4` → `@v5`, `actions/setup-node@v4` → `@v6` | `20` → `24` |
| `.github/workflows/codeql.yml` | `actions/checkout@v4` → `@v5` | (n/a) |
| `.github/workflows/dependency-review.yml` | `actions/checkout@v4` → `@v5` | (n/a) |

`codex-review.yml` was already on `actions/checkout@v5` and needs no change.

## Security

No `github.event.*` inputs are interpolated into `run:` blocks in any modified file, so this bump does not introduce any new command-injection surface.

## Test plan

- [ ] CI workflow re-runs on this PR — verify typecheck/lint/test/build pass on Node 24
- [ ] CodeQL analysis runs on Node 24
- [ ] Dependency Review completes
- [ ] Codex Review completes