### PR TITLE
Hide knowledge-base sync entry for 1.1.0

### DIFF
--- a/src/settings-tab.tsx
+++ b/src/settings-tab.tsx
@@ -23,7 +23,6 @@ export class GetNoteSettingsTab extends PluginSettingTab {
         settings={this.plugin.settings}
         updateSetting={this.updateSetting}
         startSync={() => this.plugin.openManualSyncModal()}
-        startSubscribedKnowledgeSync={() => this.plugin.syncSubscribedKnowledge()}
         isSyncing={this.plugin.isSyncing}
         syncProgress={this.plugin.syncProgress}
         openNotePicker={() => this.plugin.openNotePicker()}

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -40,7 +40,6 @@ interface SettingsComponentProps {
   settings: Settings;
   updateSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
   startSync: () => void;
-  startSubscribedKnowledgeSync: () => void;
   isSyncing: boolean;
   openNotePicker: () => void;
   openLocalUpload: () => void;
@@ -57,7 +56,6 @@ export function SettingsComponent({
   settings,
   updateSetting,
   startSync,
-  startSubscribedKnowledgeSync,
   isSyncing,
   openNotePicker,
   openLocalUpload,
@@ -541,13 +539,6 @@ export function SettingsComponent({
                 onClick={openNotePicker}
               >
                 {t('settings.syncPicker.button')}
-              </button>
-              <button
-                className="mod-secondary getnote-sync-action-button"
-                disabled={!hasCredentials || isSyncing}
-                onClick={startSubscribedKnowledgeSync}
-              >
-                {t('settings.subscribedKnowledge.button')}
               </button>
             </div>
           </div>

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -68,6 +68,13 @@ afterEach(() => {
 });
 
 describe('SettingsComponent auth credentials', () => {
+  it('does not show the knowledge-base sync entry in the 1.1.0 release UI', () => {
+    const { container } = renderSettings(makeSettings());
+
+    expect(container.textContent).not.toContain('按知识库同步');
+    expect(container.textContent).not.toContain('Sync by Knowledge Base');
+  });
+
   it('does not render a separate upload permission switch', () => {
     const { container } = renderSettings(makeSettings({
       reverseSync: { enabled: false },


### PR DESCRIPTION
## Summary
- Hide the knowledge-base sync button from the settings UI for the 1.1.0 release path.
- Remove the now-unused settings prop wiring for that entry point.
- Add regression coverage that the release UI does not expose the knowledge-base sync entry.

## Test Plan
- npm run typecheck
- npm run lint
- npm test
- npm run build