### PR TITLE
[codex] Migrate legacy GetNote Importer data

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import { App, Modal, Plugin, getLanguage, type TFile } from 'obsidian';
+import { App, Modal, Notice, Plugin, getLanguage, type DataAdapter, type TFile } from 'obsidian';
 import ReactDOM from 'react-dom';
 import { DEFAULT_SETTINGS, getAuthCredentials, type Settings, type SyncHistoryScope, type SyncProgressDetail, type SyncHistoryEntry, type SyncResult, type SyncScopeOptions } from './types';
 import { GetNoteSettingsTab } from './settings-tab';
@@ -12,6 +12,42 @@ import { initI18n, t } from './i18n';
 import { ReverseSyncEngine, type ReverseSyncResult } from './reverse-sync';
 
 const MAX_SYNC_HISTORY = 20;
+const LEGACY_PLUGIN_IDS = ['obsidian-getnote-importer', 'getnote-importer'] as const;
+const PLUGIN_DATA_FILE = 'data.json';
+const LEGACY_PLUGIN_MIGRATION_NOTICE = '已经从旧的 GetNote Importer 迁移成功，请手动停止和卸载 GetNote Importer';
+
+type PluginDataMigrationAdapter = Pick<DataAdapter, 'exists' | 'mkdir' | 'copy'>;
+
+export async function migrateLegacyPluginData(adapter: PluginDataMigrationAdapter, currentPluginId: string): Promise<boolean> {
+  if (!currentPluginId || LEGACY_PLUGIN_IDS.includes(currentPluginId as typeof LEGACY_PLUGIN_IDS[number])) return false;
+
+  const currentDir = `.obsidian/plugins/${currentPluginId}`;
+  const currentDataPath = `${currentDir}/${PLUGIN_DATA_FILE}`;
+
+  if (await adapter.exists(currentDataPath)) return false;
+
+  const legacyDataPath = await findExistingLegacyDataPath(adapter);
+  if (!legacyDataPath) return false;
+
+  if (!(await adapter.exists(currentDir))) {
+    await adapter.mkdir(currentDir);
+  }
+  await adapter.copy(legacyDataPath, currentDataPath);
+  return true;
+}
+
+export function notifyLegacyPluginDataMigrated(migrated: boolean): void {
+  if (!migrated) return;
+  new Notice(LEGACY_PLUGIN_MIGRATION_NOTICE, 10000);
+}
+
+async function findExistingLegacyDataPath(adapter: PluginDataMigrationAdapter): Promise<string | null> {
+  for (const legacyPluginId of LEGACY_PLUGIN_IDS) {
+    const legacyDataPath = `.obsidian/plugins/${legacyPluginId}/${PLUGIN_DATA_FILE}`;
+    if (await adapter.exists(legacyDataPath)) return legacyDataPath;
+  }
+  return null;
+}
 
 function emptySyncResult(): SyncResult {
   return { created: 0, updated: 0, skipped: 0, failed: 0, total: 0, items: [] };
@@ -92,6 +128,13 @@ export default class GetNoteSyncPlugin extends Plugin {
 
   async onload(): Promise<void> {
     initI18n(getLanguage());
+
+    try {
+      const migratedLegacyData = await migrateLegacyPluginData(this.app.vault.adapter, this.manifest.id);
+      notifyLegacyPluginDataMigrated(migratedLegacyData);
+    } catch {
+      // Migration is best-effort; startup should continue even if the vault adapter refuses the copy.
+    }
 
     const loaded = (await this.loadData()) as Partial<Settings> | null;
     const migratedOpenApiToken = loaded?.openApiToken ?? (loaded?.authMode === 'openapi' ? loaded?.apiToken : '') ?? '';

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -102,8 +102,16 @@ export class Modal {
 }
 
 // ---- Notice ----
+export const issuedNotices: Array<{ message: string; timeout?: number }> = [];
+
+export function resetIssuedNotices(): void {
+  issuedNotices.length = 0;
+}
+
 export class Notice {
-  constructor(_message: string, _timeout?: number) {}
+  constructor(message: string, timeout?: number) {
+    issuedNotices.push({ message, timeout });
+  }
 }
 
 // ---- Setting ----

--- a/tests/plugin-data-migration.spec.ts
+++ b/tests/plugin-data-migration.spec.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { issuedNotices, resetIssuedNotices } from 'obsidian';
+import { migrateLegacyPluginData, notifyLegacyPluginDataMigrated } from '../src/main';
+
+function makeAdapter(existingPaths: string[]) {
+  const existing = new Set(existingPaths);
+  return {
+    exists: vi.fn(async (path: string) => existing.has(path)),
+    mkdir: vi.fn(async (path: string) => {
+      existing.add(path);
+    }),
+    copy: vi.fn(async (_from: string, to: string) => {
+      existing.add(to);
+    }),
+  };
+}
+
+describe('migrateLegacyPluginData', () => {
+  beforeEach(() => {
+    resetIssuedNotices();
+  });
+
+  it('copies legacy data.json when the current plugin has no data yet', async () => {
+    const adapter = makeAdapter([
+      '.obsidian/plugins/obsidian-getnote-importer/data.json',
+    ]);
+
+    const migrated = await migrateLegacyPluginData(adapter, 'dedao-brain-sync');
+
+    expect(migrated).toBe(true);
+    expect(adapter.mkdir).toHaveBeenCalledWith('.obsidian/plugins/dedao-brain-sync');
+    expect(adapter.copy).toHaveBeenCalledWith(
+      '.obsidian/plugins/obsidian-getnote-importer/data.json',
+      '.obsidian/plugins/dedao-brain-sync/data.json'
+    );
+  });
+
+  it('does not overwrite data.json that already exists for the current plugin', async () => {
+    const adapter = makeAdapter([
+      '.obsidian/plugins/dedao-brain-sync/data.json',
+      '.obsidian/plugins/obsidian-getnote-importer/data.json',
+    ]);
+
+    const migrated = await migrateLegacyPluginData(adapter, 'dedao-brain-sync');
+
+    expect(migrated).toBe(false);
+    expect(adapter.copy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the later getnote-importer directory when the original directory has no data', async () => {
+    const adapter = makeAdapter([
+      '.obsidian/plugins/getnote-importer/data.json',
+    ]);
+
+    const migrated = await migrateLegacyPluginData(adapter, 'dedao-brain-sync');
+
+    expect(migrated).toBe(true);
+    expect(adapter.copy).toHaveBeenCalledWith(
+      '.obsidian/plugins/getnote-importer/data.json',
+      '.obsidian/plugins/dedao-brain-sync/data.json'
+    );
+  });
+
+  it('shows an official Obsidian notice after a successful legacy migration', () => {
+    notifyLegacyPluginDataMigrated(true);
+
+    expect(issuedNotices).toEqual([
+      {
+        message: '已经从旧的 GetNote Importer 迁移成功，请手动停止和卸载 GetNote Importer',
+        timeout: 10000,
+      },
+    ]);
+  });
+
+  it('does not show the migration notice when no legacy data was migrated', () => {
+    notifyLegacyPluginDataMigrated(false);
+
+    expect(issuedNotices).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Copy `data.json` from legacy GetNote Importer plugin directories when `dedao-brain-sync` has no data yet.
- Preserve any existing `dedao-brain-sync/data.json` instead of overwriting it.
- Show an Obsidian Notice after a successful migration asking the user to stop and uninstall the old GetNote Importer.

Closes #90

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Notes

The local vault deployment was refreshed after build. This PR intentionally excludes the unrelated subscribed-knowledge worktree changes that remain unstaged locally.