### PR TITLE
fix: restore manifest id to getnote-importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 
 3. 重启 Obsidian 并启用 `Dedao Brain Sync`。
 
-> 插件目录名为 `dedao-brain-sync`，需与 `manifest.json` 中的 `id` 一致。旧版 GetNote Importer 的本地 `data.json` 会在首次启动时自动迁移。
+> 插件目录名为 `getnote-importer`（与 `manifest.json` 中的 `id` 一致，保持与历史 listing 的兼容性），仓库本身已重命名为 `obsidian-dedao-brain-sync`。旧版 GetNote Importer 的本地 `data.json` 会在首次启动时自动迁移。
 
 ## 获取 API 凭证
 
@@ -260,7 +260,7 @@ tags: ["work"]
 
 ## English Summary
 
-`Dedao Brain Sync` is an Obsidian plugin for bidirectional sync with Dedao Brain / 得到大脑（原Get笔记）. It syncs remote notes into local Markdown files, supports selective and scheduled sync, downloads audio assets when available, and can manually upload selected local Markdown notes back to Dedao Brain. The plugin id is `dedao-brain-sync`, and legacy GetNote Importer data is migrated on first startup.
+`Dedao Brain Sync` is an Obsidian plugin for bidirectional sync with Dedao Brain / 得到大脑（原Get笔记）. It syncs remote notes into local Markdown files, supports selective and scheduled sync, downloads audio assets when available, and can manually upload selected local Markdown notes back to Dedao Brain. The plugin id is `getnote-importer` (kept for compatibility with the existing community-plugin listing), while the repository has been renamed to `obsidian-dedao-brain-sync`. Legacy GetNote Importer data is migrated on first startup.
 
 ## 开发
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -74,7 +74,7 @@
 
 3. 重启 Obsidian 并启用 `Dedao Brain Sync`。
 
-> 插件目录名为 `dedao-brain-sync`，需与 `manifest.json` 中的 `id` 一致。旧版 GetNote Importer 的本地 `data.json` 会在首次启动时自动迁移。
+> 插件目录名为 `getnote-importer`（与 `manifest.json` 中的 `id` 一致，保持与历史 listing 的兼容性），仓库本身已重命名为 `obsidian-dedao-brain-sync`。旧版 GetNote Importer 的本地 `data.json` 会在首次启动时自动迁移。
 
 ## 获取 API 凭证
 
@@ -260,7 +260,7 @@ tags: ["work"]
 
 ## English Summary
 
-`Dedao Brain Sync` is an Obsidian plugin for bidirectional sync with Dedao Brain / 得到大脑（原Get笔记）. It syncs remote notes into local Markdown files, supports selective and scheduled sync, downloads audio assets when available, and can manually upload selected local Markdown notes back to Dedao Brain. The plugin id is `dedao-brain-sync`, and legacy GetNote Importer data is migrated on first startup.
+`Dedao Brain Sync` is an Obsidian plugin for bidirectional sync with Dedao Brain / 得到大脑（原Get笔记）. It syncs remote notes into local Markdown files, supports selective and scheduled sync, downloads audio assets when available, and can manually upload selected local Markdown notes back to Dedao Brain. The plugin id is `getnote-importer` (kept for compatibility with the existing community-plugin listing), while the repository has been renamed to `obsidian-dedao-brain-sync`. Legacy GetNote Importer data is migrated on first startup.
 
 ## 开发
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "id": "dedao-brain-sync",
+  "id": "getnote-importer",
   "name": "Dedao Brain Sync",
   "version": "1.1.0",
   "description": "Bidirectional sync for notes, links, recordings, and AI summaries between GetNote / 得到大脑（原Get笔记） and your local vault.",


### PR DESCRIPTION
## 背景

Obsidian 社区插件 review 对 v1.1.0 (commit c4587c6) 返回 `MANIFEST Failed`：
- `manifest.json` 的 `id` 是 `dedao-brain-sync`，与已有注册 id `getnote-importer` 不匹配

本 PR 修复这个唯一阻塞项。

## 改动

### `manifest.json`
- `id`: `dedao-brain-sync` → `getnote-importer`

仓库本身已重命名为 `obsidian-dedao-brain-sync`（URL、badge、GitHub 文件夹），但 manifest id 是 Obsidian 用来标识 community-plugin listing 和 on-disk 插件目录的公开标识符。恢复成 `getnote-importer` 保留现有 listing 和 on-disk 安装路径。

### `README.md` / `README_zh.md`
- 更新两处提到旧 id 的描述（安装说明 line 77 和 English Summary line 263），与 manifest 一致
- 不动仓库 URL、community-plugins URL、GitHub 仓库引用、README H1

## 不在范围内

- 未删 `src/main.tsx` 里的 legacy data migration 代码、未删 `tests/plugin-data-migration.spec.ts`：这些是 PR #91 引入的，与本次 review 修复无直接关系，留在后续 PR 处理
- 未改 README H1：与 H1 相关的两条 bot 警告（"no English text"、"title 不匹配"）是 review 里的 Warning 级别而非 Failed 级别，不阻塞 review，可单独处理
- 工作区里有 5 个未提交改动（`api-clients/`、`api.ts`、`sync.ts`、`topic-picker-modal.tsx`、新增 `subscribed-knowledge-topic-filter.spec.ts`）也都不在本 PR 范围

## 验证

- diff 范围：`+5 / -5`，3 files
- 改动前 CI 因 working tree 未提交改动里的 type error 而失败；本次改动与那些改动无交集
- manifest id 修复后的合并结果应不再引入新的 type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)