### PR TITLE
Fix local upload payload sanitization

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -495,7 +495,15 @@ export default class GetNoteSyncPlugin extends Plugin {
     this.refreshSettingsTab();
 
     try {
-      const engine = new ReverseSyncEngine(this.app, this.settings);
+      const engine = new ReverseSyncEngine(this.app, this.settings, (progress) => {
+        const percent = progress.total > 0 ? Math.round((progress.processed / progress.total) * 100) : 0;
+        this.syncProgress = {
+          message: t('reverseSync.running'),
+          count: `${t('modal.countProgress', { processed: progress.processed })} ${progress.title}`,
+          percent,
+        };
+        this.refreshSettingsTab();
+      });
       this.currentSyncEngine = engine;
       const result = files ? await engine.syncFiles(files) : await engine.syncBack();
       await this.recordUploadHistory(result, startedAt, files?.map(file => file.path));

--- a/src/reverse-sync.ts
+++ b/src/reverse-sync.ts
@@ -29,6 +29,7 @@ interface LocalReadResult {
 }
 
 const SUPPORTED_NOTE_TYPES = new Set(['plain_text', 'link']);
+const MAX_UPLOAD_TAGS = 4;
 
 interface ParsedFrontmatterBlock {
   frontmatter: Record<string, string>;
@@ -90,6 +91,20 @@ function readTags(frontmatter: Record<string, unknown>): string[] {
     .split(',')
     .map(stripQuotes)
     .filter(Boolean);
+}
+
+function prepareUploadTags(tags: string[]): string[] {
+  return [...new Set(tags.map(tag => tag.trim()).filter(Boolean))].slice(0, MAX_UPLOAD_TAGS);
+}
+
+function markdownImageToPlainLink(_match: string, alt: string, rawTarget: string): string {
+  const target = rawTarget.trim().replace(/^<|>$/g, '');
+  const label = alt.trim() || target;
+  return `[${label}](${target})`;
+}
+
+function prepareUploadContent(content: string): string {
+  return content.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, markdownImageToPlainLink);
 }
 
 function fileBasename(file: TFile): string {
@@ -229,9 +244,9 @@ export class ReverseSyncEngine {
       clientId: credentials.clientId,
       authMode: credentials.authMode,
       title: note.title,
-      content: note.body,
+      content: prepareUploadContent(note.body),
       noteType: note.noteType,
-      tags: note.tags,
+      tags: prepareUploadTags(note.tags),
       signal: this.abortController.signal,
     });
     const currentContent = await this.app.vault.read(note.file);

--- a/src/reverse-sync.ts
+++ b/src/reverse-sync.ts
@@ -11,6 +11,13 @@ export interface ReverseSyncResult {
   items: SyncResultItem[];
 }
 
+export interface ReverseSyncProgress {
+  processed: number;
+  total: number;
+  title: string;
+  status: SyncResultItem['status'];
+}
+
 interface LocalMarkdownNote {
   file: TFile;
   content: string;
@@ -152,7 +159,11 @@ function isInsideFolder(file: TFile, folderName: string): boolean {
 export class ReverseSyncEngine {
   private abortController = new AbortController();
 
-  constructor(private app: App, private settings: Settings) {}
+  constructor(
+    private app: App,
+    private settings: Settings,
+    private onProgress?: (progress: ReverseSyncProgress) => void
+  ) {}
 
   cancel(): void {
     this.abortController.abort();
@@ -257,9 +268,19 @@ export class ReverseSyncEngine {
     return created;
   }
 
+  private reportProgress(item: SyncResultItem, processed: number, total: number): void {
+    this.onProgress?.({
+      processed,
+      total,
+      title: item.title,
+      status: item.status,
+    });
+  }
+
   async syncFiles(files: TFile[]): Promise<ReverseSyncResult> {
     const credentials = this.requireCredentials();
     const result: ReverseSyncResult = { created: 0, skipped: 0, failed: 0, total: 0, items: [] };
+    const totalFiles = files.length;
 
     for (const file of files) {
       if (this.abortController.signal.aborted) throw new DOMException('Aborted', 'AbortError');
@@ -270,14 +291,17 @@ export class ReverseSyncEngine {
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') throw err;
         result.failed++;
-        result.items.push(this.createLocalItem(file, 'failed', {
+        const item = this.createLocalItem(file, 'failed', {
           error: err instanceof Error ? err.message : String(err),
-        }));
+        });
+        result.items.push(item);
+        this.reportProgress(item, result.total, totalFiles);
         continue;
       }
       if (local.skippedItem) {
         result.skipped++;
         result.items.push(local.skippedItem);
+        this.reportProgress(local.skippedItem, result.total, totalFiles);
         continue;
       }
       const note = local.note;
@@ -286,42 +310,50 @@ export class ReverseSyncEngine {
       try {
         if (credentials.authMode === 'web' && note.uid && !note.primeId) {
           result.skipped++;
-          result.items.push(this.createLocalItem(file, 'skipped', {
+          const item = this.createLocalItem(file, 'skipped', {
             noteId: note.uid,
             title: note.title,
             noteType: note.noteType,
             error: t('reverseSync.skip.missingWebDetailId'),
-          }));
+          });
+          result.items.push(item);
+          this.reportProgress(item, result.total, totalFiles);
           continue;
         }
         const detailId = credentials.authMode === 'web' ? note.primeId : note.uid;
         if (detailId && await this.remoteExists(detailId, credentials)) {
           result.skipped++;
-          result.items.push(this.createLocalItem(file, 'skipped', {
+          const item = this.createLocalItem(file, 'skipped', {
             noteId: note.uid,
             title: note.title,
             noteType: note.noteType,
             error: t('reverseSync.skip.remoteExists'),
-          }));
+          });
+          result.items.push(item);
+          this.reportProgress(item, result.total, totalFiles);
           continue;
         }
         const created = await this.createRemoteNote(note, credentials);
         result.created++;
-        result.items.push(this.createLocalItem(file, 'created', {
+        const item = this.createLocalItem(file, 'created', {
           noteId: created.noteId,
           title: note.title,
           noteType: note.noteType,
-        }));
+        });
+        result.items.push(item);
+        this.reportProgress(item, result.total, totalFiles);
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') throw err;
         console.error(`[DedaoBrain] Reverse sync failed [${file.path}]:`, err);
         result.failed++;
-        result.items.push(this.createLocalItem(file, 'failed', {
+        const item = this.createLocalItem(file, 'failed', {
           noteId: note.uid || file.path,
           title: note.title,
           noteType: note.noteType,
           error: err instanceof Error ? err.message : String(err),
-        }));
+        });
+        result.items.push(item);
+        this.reportProgress(item, result.total, totalFiles);
       }
     }
 

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -256,6 +256,12 @@ export function SettingsComponent({
     : Boolean(apiTokenOpenapi.trim() && clientIdOpenapi.trim());
   const { scheduledSync } = settings;
   const currentSyncHistory = syncHistory.length > 0 ? syncHistory : settings.syncHistory;
+  const syncStatusRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isSyncing) return;
+    syncStatusRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [isSyncing, syncProgress?.message, syncProgress?.count, syncProgress?.percent]);
 
   // Format last sync time
   const formatLastSync = (timestamp?: number): string => {
@@ -584,7 +590,7 @@ export function SettingsComponent({
 
       {/* 同步进度条 */}
       {isSyncing && (
-        <div className="getnote-settings-sync-status">
+        <div className="getnote-settings-sync-status" ref={syncStatusRef}>
           <div className="getnote-settings-sync-status-header">
             <span className="getnote-mono-text">{syncProgress?.message || t('sync.syncing')}</span>
             <button className="mod-warning getnote-settings-cancel-button" onClick={cancelSync}>

--- a/styles.css
+++ b/styles.css
@@ -1039,6 +1039,9 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  max-height: min(64vh, 620px);
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .getnote-history-pagination {

--- a/tests/reverse-sync-engine.spec.ts
+++ b/tests/reverse-sync-engine.spec.ts
@@ -597,6 +597,43 @@ describe('ReverseSyncEngine', () => {
     expect(app.vault._getFile('得到大脑/b.md')?.content).toContain('uid: "selected-created"');
   });
 
+  it('reports progress after each selected local file is processed', async () => {
+    const app = makeMockApp();
+    app.vault._addFile('得到大脑/a.md', [
+      '---',
+      'title: "A"',
+      '---',
+      'Body A',
+    ].join('\n'));
+    app.vault._addFile('得到大脑/b.md', [
+      '---',
+      'title: "B"',
+      '---',
+      'Body B',
+    ].join('\n'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ success: true, data: { note: { note_id: 'created' } } })
+    );
+    const progress = vi.fn();
+    const selectedFiles = app.vault.getMarkdownFiles();
+
+    await new ReverseSyncEngine(app as any, makeSettings(), progress).syncFiles(selectedFiles as any);
+
+    expect(progress).toHaveBeenCalledTimes(2);
+    expect(progress).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      processed: 1,
+      total: 2,
+      title: 'A',
+      status: 'created',
+    }));
+    expect(progress).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      processed: 2,
+      total: 2,
+      title: 'B',
+      status: 'created',
+    }));
+  });
+
   it('counts selected markdown files that cannot be uploaded as skipped', async () => {
     const app = makeMockApp();
     app.vault._addFile('得到大脑/empty.md', [

--- a/tests/reverse-sync-engine.spec.ts
+++ b/tests/reverse-sync-engine.spec.ts
@@ -168,6 +168,111 @@ describe('ReverseSyncEngine', () => {
     ].join('\n'));
   });
 
+  it('limits uploaded tags to the OpenAPI create-note maximum', async () => {
+    const app = makeMockApp();
+    app.vault._addFile('得到大脑/many-tags.md', [
+      '---',
+      'title: "Many tags"',
+      'note_type: plain_text',
+      'tags: ["one", "two", "three", "four", "five", "six"]',
+      '---',
+      'Body',
+    ].join('\n'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ success: true, data: { note: { note_id: 'many-tags-created' } } })
+    );
+
+    await new ReverseSyncEngine(app as any, makeSettings()).syncBack();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://openapi.biji.com/open/api/v1/resource/note/save',
+      expect.objectContaining({
+        body: JSON.stringify({
+          title: 'Many tags',
+          content: 'Body',
+          note_type: 'plain_text',
+          source: 'app',
+          tags: ['one', 'two', 'three', 'four'],
+        }),
+      })
+    );
+  });
+
+  it('uploads Markdown image embeds as plain links so create-note does not reject third-party images', async () => {
+    const app = makeMockApp();
+    app.vault._addFile('得到大脑/with-image.md', [
+      '---',
+      'title: "With image"',
+      'note_type: plain_text',
+      '---',
+      'Before',
+      '![](asset/local image.png)',
+      '![diagram](https://cdn.example.com/diagram.png)',
+      'After',
+    ].join('\n'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ success: true, data: { note: { note_id: 'with-image-created' } } })
+    );
+
+    await new ReverseSyncEngine(app as any, makeSettings()).syncBack();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://openapi.biji.com/open/api/v1/resource/note/save',
+      expect.objectContaining({
+        body: JSON.stringify({
+          title: 'With image',
+          content: [
+            'Before',
+            '[asset/local image.png](asset/local image.png)',
+            '[diagram](https://cdn.example.com/diagram.png)',
+            'After',
+          ].join('\n'),
+          note_type: 'plain_text',
+          source: 'app',
+          tags: [],
+        }),
+      })
+    );
+  });
+
+  it('applies upload-safe tags and image links in Web API mode too', async () => {
+    const app = makeMockApp();
+    app.vault._addFile('得到大脑/web-safe.md', [
+      '---',
+      'title: "Web safe"',
+      'note_type: plain_text',
+      'tags: ["one", "two", "three", "four", "five"]',
+      '---',
+      'Before',
+      '![chart](https://cdn.example.com/chart.png)',
+      'After',
+    ].join('\n'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ h: {}, c: { note_id: 'web-safe-created', prime_id: 'web-safe-prime' } })
+    );
+
+    await new ReverseSyncEngine(app as any, makeSettings({
+      authMode: 'web',
+      webApiToken: 'web-token',
+    })).syncBack();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://get-notes.luojilab.com/voicenotes/web/notes',
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    const payload = JSON.parse(String((init as RequestInit).body));
+    expect(payload).toEqual(expect.objectContaining({
+      title: 'Web safe',
+      note_type: 'plain_text',
+      tags: ['one', 'two', 'three', 'four'],
+    }));
+    expect(payload.content).toContain('[chart](https://cdn.example.com/chart.png)');
+    expect(payload.content).not.toContain('![chart]');
+  });
+
   it('skips notes whose uid still exists remotely', async () => {
     const app = makeMockApp();
     app.vault._addFile('得到大脑/imported.md', [

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -26,7 +26,10 @@ function renderSettings(
   settings: Settings,
   updateSetting = vi.fn(),
   openLocalUpload = vi.fn(),
-  options: { isSyncing?: boolean } = {}
+  options: {
+    isSyncing?: boolean;
+    syncProgress?: { message: string; count: string; percent: number };
+  } = {}
 ) {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -42,6 +45,7 @@ function renderSettings(
       stopAutoSync: vi.fn(),
       cancelSync: vi.fn(),
       app: new App(),
+      syncProgress: options.syncProgress,
     }),
     container
   );
@@ -143,6 +147,46 @@ describe('SettingsComponent auth credentials', () => {
       .find((button): button is HTMLButtonElement => button.textContent === '按笔记上传');
     expect(uploadButton).toBeTruthy();
     expect(uploadButton!.disabled).toBe(true);
+  });
+
+  it('keeps the syncing progress block visible when upload progress changes', async () => {
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollIntoView;
+    try {
+      const settings = makeSettings({
+        authMode: 'web',
+        webApiToken: 'web-token',
+        apiToken: 'web-token',
+      });
+      const { container } = renderSettings(settings, vi.fn(), vi.fn(), {
+        isSyncing: true,
+        syncProgress: { message: '正在上传到得到大脑...', count: '处理中 1 条...', percent: 50 },
+      });
+
+      await act(async () => {
+        render(
+          h(SettingsComponent, {
+            settings,
+            updateSetting: vi.fn(),
+            startSync: vi.fn(),
+            isSyncing: true,
+            openNotePicker: vi.fn(),
+            openLocalUpload: vi.fn(),
+            startAutoSync: vi.fn(),
+            stopAutoSync: vi.fn(),
+            cancelSync: vi.fn(),
+            app: new App(),
+            syncProgress: { message: '正在上传到得到大脑...', count: '处理中 2 条...', percent: 100 },
+          }),
+          container
+        );
+      });
+
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
+    } finally {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    }
   });
 
   it('writes the visible mode token back when switching auth modes', async () => {

--- a/tests/sync-history.spec.ts
+++ b/tests/sync-history.spec.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { SyncHistoryEntry, SyncResult } from '../src/types';
 import { initI18n } from '../src/i18n';
 import { formatHistoryFilter, formatHistoryMode, formatHistoryNoteType, formatHistoryScope } from '../src/ui/sync-history-modal';
@@ -130,6 +132,16 @@ describe('recordSyncHistory', () => {
     }
 
     expect(h.length).toBe(10);
+  });
+});
+
+describe('sync history scrolling', () => {
+  it('keeps the history list in an independently scrollable container', () => {
+    const css = readFileSync(resolve(process.cwd(), 'styles.css'), 'utf8');
+    const match = css.match(/\.getnote-history-list\s*\{[^}]+\}/);
+
+    expect(match?.[0]).toContain('max-height');
+    expect(match?.[0]).toContain('overflow-y: auto');
   });
 });
 


### PR DESCRIPTION
## Summary
- cap local-upload tags to the create-note API maximum before sending requests
- convert Markdown image embeds to plain links in upload payloads so third-party/local images do not make create-note reject the note
- report per-note local upload progress and keep the settings progress block scrolled into view while batch uploads run
- constrain the sync history modal list to an independently scrollable area for long result details
- cover both OpenAPI and Web API upload payloads in reverse-sync tests

Fixes #98

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Local deploy
- copied main.js, manifest.json, and styles.css to /Users/zhengyan/Downloads/同步空间/9_个人笔记/郑大师的笔记本/.obsidian/plugins/obsidian-getnote-importer/