### PR TITLE
Fix sync history details clipping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1039,9 +1039,6 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-height: min(64vh, 620px);
-  overflow-y: auto;
-  padding-right: 4px;
 }
 
 .getnote-history-pagination {

--- a/tests/sync-history.spec.ts
+++ b/tests/sync-history.spec.ts
@@ -136,12 +136,12 @@ describe('recordSyncHistory', () => {
 });
 
 describe('sync history scrolling', () => {
-  it('keeps the history list in an independently scrollable container', () => {
+  it('lets expanded history entries render full details without nested clipping', () => {
     const css = readFileSync(resolve(process.cwd(), 'styles.css'), 'utf8');
     const match = css.match(/\.getnote-history-list\s*\{[^}]+\}/);
 
-    expect(match?.[0]).toContain('max-height');
-    expect(match?.[0]).toContain('overflow-y: auto');
+    expect(match?.[0]).not.toContain('max-height');
+    expect(match?.[0]).not.toContain('overflow-y: auto');
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove the nested scroll constraint from the sync history list so expanded entries render all per-note details naturally
- Update the sync history CSS regression test to guard against clipping expanded entries

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Local validation
- Built and deployed main.js, manifest.json, and styles.css to the local Obsidian vault plugin directory: /Users/zhengyan/Downloads/同步空间/9_个人笔记/郑大师的笔记本/.obsidian/plugins/getnote-importer/