### PR TITLE
Hide redundant sync history failure summary

### DIFF
--- a/src/ui/sync-history-modal.tsx
+++ b/src/ui/sync-history-modal.tsx
@@ -44,6 +44,18 @@ export function formatHistoryMode(entry: SyncHistoryEntry): string {
   return t('syncHistory.mode.time');
 }
 
+export function shouldRenderHistoryEntryError(entry: SyncHistoryEntry): entry is SyncHistoryEntry & { error: string } {
+  if (!entry.error) return false;
+
+  const failed = entry.result.failed;
+  const aggregateFailureMessages = [
+    `失败 ${failed} 篇`,
+    `${failed} failed`,
+  ];
+
+  return !aggregateFailureMessages.includes(entry.error.trim());
+}
+
 export function openSyncHistoryModal(app: App, history: SyncHistoryEntry[]) {
   const modal = new SyncHistoryModal(app, history);
   modal.open();
@@ -210,7 +222,7 @@ class SyncHistoryModal extends Modal {
           );
         }
 
-        if (entry.error) {
+        if (shouldRenderHistoryEntryError(entry)) {
           detailEl.createDiv('getnote-history-error').setText(entry.error);
         }
       };

--- a/tests/sync-history.spec.ts
+++ b/tests/sync-history.spec.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { SyncHistoryEntry, SyncResult } from '../src/types';
 import { initI18n } from '../src/i18n';
-import { formatHistoryFilter, formatHistoryMode, formatHistoryNoteType, formatHistoryScope } from '../src/ui/sync-history-modal';
+import { formatHistoryFilter, formatHistoryMode, formatHistoryNoteType, formatHistoryScope, shouldRenderHistoryEntryError } from '../src/ui/sync-history-modal';
 
 function makeResult(overrides: Partial<SyncResult> = {}): SyncResult {
   return { created: 0, updated: 0, skipped: 0, failed: 0, total: 0, ...overrides };
@@ -142,6 +142,28 @@ describe('sync history scrolling', () => {
 
     expect(match?.[0]).not.toContain('max-height');
     expect(match?.[0]).not.toContain('overflow-y: auto');
+  });
+});
+
+describe('sync history entry error display', () => {
+  it('hides aggregate failed-count errors after per-note details are shown', () => {
+    const entry = makeEntry({
+      status: 'failed',
+      error: '失败 1 篇',
+      result: makeResult({ failed: 1 }),
+    });
+
+    expect(shouldRenderHistoryEntryError(entry)).toBe(false);
+  });
+
+  it('keeps actionable entry-level errors visible', () => {
+    const entry = makeEntry({
+      status: 'failed',
+      error: 'network error',
+      result: makeResult({ failed: 1 }),
+    });
+
+    expect(shouldRenderHistoryEntryError(entry)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Hide aggregate entry-level failure summaries like `失败 1 篇` in sync history when per-note details already show the actionable errors
- Keep real entry-level errors such as network failures visible

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Local validation
- Built and deployed main.js, manifest.json, and styles.css to the local Obsidian vault plugin directory: /Users/zhengyan/Downloads/同步空间/9_个人笔记/郑大师的笔记本/.obsidian/plugins/getnote-importer/