### PR TITLE
Complete manual knowledge-base sync

### DIFF
--- a/docs/superpowers/plans/2026-06-10-complete-knowledge-base-sync.md
+++ b/docs/superpowers/plans/2026-06-10-complete-knowledge-base-sync.md
@@ -1,0 +1,59 @@
+# Complete Knowledge-Base Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish and ship the existing manual knowledge-base sync flow so users can choose a knowledge base and specific articles, then sync exactly those articles through either supported API mode.
+
+**Architecture:** Keep knowledge-base sync as a separate manual workflow. The picker returns selected note IDs plus the smallest available API scope; the sync engine forwards that scope to the OpenAPI or Web API client, and explicit article selections bypass generic date and note-type filters.
+
+**Tech Stack:** TypeScript, Preact-compatible React APIs, Vitest, Obsidian plugin APIs
+
+---
+
+### Task 1: Restore the manual settings entry
+
+**Files:**
+- Modify: `src/settings/index.tsx`
+- Modify: `src/settings-tab.tsx`
+- Test: `tests/settings.spec.ts`
+
+- [x] Replace the release-only absence assertion with a test that renders the `按知识库同步` button and verifies its click handler.
+- [x] Run `npm test -- tests/settings.spec.ts --run` and confirm the new test fails.
+- [x] Add `startSubscribedKnowledgeSync` to the settings component props, render the button in the manual download actions, and wire it from the settings tab.
+- [x] Run `npm test -- tests/settings.spec.ts --run` and confirm it passes.
+
+### Task 2: Complete exact-selection behavior for both API modes
+
+**Files:**
+- Modify: `src/api-clients/openapi-client.ts`
+- Modify: `src/api-clients/webapi-client.ts`
+- Modify: `src/api.ts`
+- Modify: `src/sync.ts`
+- Modify: `tests/sync-engine.spec.ts`
+
+- [x] Add a Web API regression proving a selected old knowledge-base article syncs despite generic date/type filters and stops after the selected article is found.
+- [x] Recover the existing uncommitted scope-filtering implementation after verifying its focused tests.
+- [x] Forward selected topic/note scope to both clients, stop fetching after all selected IDs are found, and bypass generic filters only for explicit article selections.
+- [x] Run the focused OpenAPI and Web API sync tests and confirm they pass.
+
+### Task 3: Verify picker scope and integration
+
+**Files:**
+- Modify: `src/ui/topic-picker-modal.tsx`
+- Modify: `src/main.tsx`
+- Modify: `tests/topic-picker-modal.spec.ts`
+
+- [x] Verify picker tests cover returned note, topic, and OpenAPI blogger IDs, including fallback to the active topic.
+- [x] Run `npm test -- tests/topic-picker-modal.spec.ts --run`.
+- [x] Resolve any integration or type errors without expanding the feature into scheduled sync.
+
+### Task 4: Validate and integrate
+
+**Files:**
+- Verify all changed files
+
+- [x] Run `npm run typecheck`.
+- [x] Run `npm run lint`.
+- [x] Run `npm test`.
+- [x] Run `npm run build`.
+- [ ] Commit the completed feature, push `codex/complete-knowledge-base-sync`, create a PR targeting `main`, wait for required checks, and merge after they pass.

--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -153,6 +153,8 @@ export interface FetchNotesOptions {
   limit?: number;
   signal?: AbortSignal;
   topicIds?: string[];
+  bloggerIds?: string[];
+  selectedNoteIds?: string[];
 }
 
 export interface CreateNoteOptions {
@@ -302,8 +304,8 @@ export async function fetchTopicContentPreviews(
   clientId: string,
   signal?: AbortSignal,
   options: { maxPages?: number; maxBloggers?: number } = {}
-): Promise<{ note_id: string; title: string; updated_at: string; blogger_name: string }[]> {
-  const items: { note_id: string; title: string; updated_at: string; blogger_name: string }[] = [];
+): Promise<{ note_id: string; title: string; updated_at: string; blogger_name: string; topic_id: string; blogger_id: string }[]> {
+  const items: { note_id: string; title: string; updated_at: string; blogger_name: string; topic_id: string; blogger_id: string }[] = [];
   const bloggers = await fetchTopicBloggers(topicId, token, clientId, signal);
   const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
   const maxBloggers = options.maxBloggers ?? Number.POSITIVE_INFINITY;
@@ -323,6 +325,8 @@ export async function fetchTopicContentPreviews(
           title: content.title ?? '',
           updated_at: updated,
           blogger_name: blogger.name ?? '',
+          topic_id: topicId,
+          blogger_id: blogger.follow_id,
         });
       }
       if (!readHasMore(source) || contents.length === 0) break;
@@ -340,7 +344,7 @@ export async function fetchTopicContentPreviewPage(
   signal?: AbortSignal,
   cursor: { bloggerIndex: number; page: number } = { bloggerIndex: 0, page: 1 }
 ): Promise<{
-  items: { note_id: string; title: string; updated_at: string; blogger_name: string }[];
+  items: { note_id: string; title: string; updated_at: string; blogger_name: string; topic_id: string; blogger_id: string }[];
   nextCursor?: { bloggerIndex: number; page: number };
 }> {
   const bloggers = await fetchTopicBloggers(topicId, token, clientId, signal);
@@ -366,6 +370,8 @@ export async function fetchTopicContentPreviewPage(
       title: content.title ?? '',
       updated_at: updated,
       blogger_name: blogger.name ?? '',
+      topic_id: topicId,
+      blogger_id: blogger.follow_id,
     };
   });
   const nextCursor = readHasMore(source) && contents.length > 0
@@ -377,7 +383,7 @@ export async function fetchTopicContentPreviewPage(
   return nextCursor ? { items, nextCursor } : { items };
 }
 
-async function fetchBloggerContents(topicId: string, blogger: Blogger, token: string, clientId: string, signal?: AbortSignal): Promise<BloggerContent[]> {
+async function fetchBloggerContents(topicId: string, blogger: Blogger, token: string, clientId: string, signal?: AbortSignal, remainingNoteIds?: Set<string>): Promise<BloggerContent[]> {
   const contents: BloggerContent[] = [];
   let page = 1;
   while (true) {
@@ -385,7 +391,14 @@ async function fetchBloggerContents(topicId: string, blogger: Blogger, token: st
     const url = `https://openapi.biji.com/open/api/v1/resource/knowledge/blogger/contents?${params.toString()}`;
     const data = await apiRequest<Record<string, unknown>>(url, { method: 'GET', headers: buildHeaders(token, clientId) }, 2, signal);
     const source = normalizeData(data);
-    contents.push(...readArray(source, ['contents', 'posts', 'list', 'items']).map(normalizeContent).filter((item): item is BloggerContent => Boolean(item)));
+    const pageContents = readArray(source, ['contents', 'posts', 'list', 'items']).map(normalizeContent).filter((item): item is BloggerContent => Boolean(item));
+    for (const content of pageContents) {
+      const noteId = `blogger_${content.post_id_alias}`;
+      if (remainingNoteIds && !remainingNoteIds.has(noteId)) continue;
+      contents.push(content);
+      remainingNoteIds?.delete(noteId);
+    }
+    if (remainingNoteIds?.size === 0) break;
     if (!readHasMore(source)) break;
     page++;
   }
@@ -403,15 +416,21 @@ async function fetchBloggerContentDetail(topicId: string, content: BloggerConten
 export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions): Promise<GetNoteNote[]> {
   const { token, clientId, signal } = options;
   const notes: GetNoteNote[] = [];
+  const topicIdSet = options.topicIds?.length ? new Set(options.topicIds) : undefined;
+  const bloggerIdSet = options.bloggerIds?.length ? new Set(options.bloggerIds) : undefined;
+  const remainingNoteIds = options.selectedNoteIds?.length ? new Set(options.selectedNoteIds) : undefined;
   const topics = await fetchSubscribedTopics(token, clientId, signal);
   for (const topic of topics) {
+    if (topicIdSet && !topicIdSet.has(topic.topic_id)) continue;
     const bloggers = await fetchTopicBloggers(topic.topic_id, token, clientId, signal);
     for (const blogger of bloggers) {
-      const contents = await fetchBloggerContents(topic.topic_id, blogger, token, clientId, signal);
+      if (bloggerIdSet && !bloggerIdSet.has(blogger.follow_id)) continue;
+      const contents = await fetchBloggerContents(topic.topic_id, blogger, token, clientId, signal, remainingNoteIds);
       for (const content of contents) {
         const detail = await fetchBloggerContentDetail(topic.topic_id, content, token, clientId, signal);
         notes.push(bloggerContentToNote(detail, topic, blogger));
       }
+      if (remainingNoteIds?.size === 0) return notes;
     }
   }
   return notes;

--- a/src/api-clients/webapi-client.ts
+++ b/src/api-clients/webapi-client.ts
@@ -157,6 +157,8 @@ export interface FetchNotesOptions {
   sinceId?: string;
   limit?: number;
   signal?: AbortSignal;
+  topicIds?: string[];
+  selectedNoteIds?: string[];
 }
 
 export interface CreateNoteOptions {
@@ -266,6 +268,8 @@ export async function fetchSubscribedTopics(token: string, signal?: AbortSignal)
 
 export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions): Promise<GetNoteNote[]> {
   const notes: GetNoteNote[] = [];
+  const topicIdSet = options.topicIds?.length ? new Set(options.topicIds) : undefined;
+  const remainingNoteIds = options.selectedNoteIds?.length ? new Set(options.selectedNoteIds) : undefined;
   const listUrl = 'https://knowledge-api.trytalks.com/v1/web/subscribe/topic/list?page=1&size=200&exclude_mine=true';
   const listData = await apiRequest<Record<string, unknown>>(listUrl, {
     method: 'GET',
@@ -276,6 +280,7 @@ export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions):
   for (const topic of topics) {
     if (!isRecord(topic)) continue;
     const topicAlias = topic.id_alias ?? topic.id;
+    if (topicIdSet && !topicIdSet.has(String(topicAlias))) continue;
     const rootDir = isRecord(topic.root_dir) ? topic.root_dir : {};
     const directoryId = rootDir.id;
     if ((typeof topicAlias !== 'string' && typeof topicAlias !== 'number') || (typeof directoryId !== 'string' && typeof directoryId !== 'number')) {
@@ -300,8 +305,12 @@ export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions):
       const resources = Array.isArray(source.resources) ? source.resources : [];
       for (const resource of resources) {
         const note = noteFromKnowledgeResource(resource, typeof topic.name === 'string' ? topic.name : undefined);
-        if (note) notes.push(note);
+        if (!note) continue;
+        if (remainingNoteIds && !remainingNoteIds.has(note.note_id)) continue;
+        notes.push(note);
+        remainingNoteIds?.delete(note.note_id);
       }
+      if (remainingNoteIds?.size === 0) return notes;
       if (!source.has_next || resources.length === 0) break;
       page++;
     }
@@ -314,8 +323,8 @@ export async function fetchTopicContentPreviews(
   token: string,
   signal?: AbortSignal,
   options: { maxPages?: number; maxBloggers?: number } = {}
-): Promise<{ note_id: string; title: string; updated_at: string }[]> {
-  const items: { note_id: string; title: string; updated_at: string }[] = [];
+): Promise<{ note_id: string; title: string; updated_at: string; topic_id: string }[]> {
+  const items: { note_id: string; title: string; updated_at: string; topic_id: string }[] = [];
   const listUrl = 'https://knowledge-api.trytalks.com/v1/web/subscribe/topic/list?page=1&size=200&exclude_mine=true';
   const listData = await apiRequest<Record<string, unknown>>(listUrl, { method: 'GET', headers: buildKnowledgeHeaders(token) }, 2, signal);
   const topicsData = normalizeWebData(listData);
@@ -343,7 +352,7 @@ export async function fetchTopicContentPreviews(
     const resources = Array.isArray(source.resources) ? source.resources : [];
     for (const resource of resources) {
       const note = noteFromKnowledgeResource(resource, typeof rawTopic.name === 'string' ? rawTopic.name : undefined);
-      if (note) items.push({ note_id: note.note_id, title: note.title, updated_at: note.updated_at });
+      if (note) items.push({ note_id: note.note_id, title: note.title, updated_at: note.updated_at, topic_id: topicId });
     }
     if (!source.has_next || resources.length === 0) break;
     page++;
@@ -357,7 +366,7 @@ export async function fetchTopicContentPreviewPage(
   signal?: AbortSignal,
   cursor: { bloggerIndex: number; page: number } = { bloggerIndex: 0, page: 1 }
 ): Promise<{
-  items: { note_id: string; title: string; updated_at: string }[];
+  items: { note_id: string; title: string; updated_at: string; topic_id: string }[];
   nextCursor?: { bloggerIndex: number; page: number };
 }> {
   const listUrl = 'https://knowledge-api.trytalks.com/v1/web/subscribe/topic/list?page=1&size=200&exclude_mine=true';
@@ -388,7 +397,7 @@ export async function fetchTopicContentPreviewPage(
   const items = resources
     .map(resource => noteFromKnowledgeResource(resource, typeof rawTopic.name === 'string' ? rawTopic.name : undefined))
     .filter((note): note is GetNoteNote => Boolean(note))
-    .map(note => ({ note_id: note.note_id, title: note.title, updated_at: note.updated_at }));
+    .map(note => ({ note_id: note.note_id, title: note.title, updated_at: note.updated_at, topic_id: topicId }));
   const nextCursor = source.has_next && resources.length > 0
     ? { bloggerIndex: 0, page: cursor.page + 1 }
     : undefined;

--- a/src/api.ts
+++ b/src/api.ts
@@ -15,6 +15,9 @@ export interface FetchNotesOptions {
   signal?: AbortSignal;
   authMode?: AuthMode;
   webCsrfToken?: string;
+  topicIds?: string[];
+  bloggerIds?: string[];
+  selectedNoteIds?: string[];
 }
 
 export async function fetchNotes(options: FetchNotesOptions): Promise<{
@@ -66,6 +69,8 @@ export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions):
       sinceId: options.sinceId,
       limit: options.limit,
       signal: options.signal,
+      topicIds: options.topicIds,
+      selectedNoteIds: options.selectedNoteIds,
     });
   }
   return openapiFetchSubscribedKnowledgeNotes({
@@ -74,6 +79,9 @@ export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions):
     sinceId: options.sinceId,
     limit: options.limit,
     signal: options.signal,
+    topicIds: options.topicIds,
+    bloggerIds: options.bloggerIds,
+    selectedNoteIds: options.selectedNoteIds,
   });
 }
 
@@ -82,6 +90,8 @@ export interface ContentPreview {
   title: string;
   updated_at: string;
   blogger_name?: string;
+  topic_id?: string;
+  blogger_id?: string;
 }
 
 export interface TopicContentPreviewOptions {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { GetNoteSettingsTab } from './settings-tab';
 import { SyncEngine, SyncCancelledError } from './sync';
 import { showError, showNotice, showSuccess } from './ui/notice';
 import { NotePickerModal } from './ui/note-picker-modal';
-import { TopicPickerModal } from './ui/topic-picker-modal';
+import { TopicPickerModal, type TopicPickerSelection } from './ui/topic-picker-modal';
 import { ManualSyncModal } from './ui/manual-sync-modal';
 import { LocalUploadModal } from './ui/local-upload-modal';
 import { initI18n, t } from './i18n';
@@ -413,11 +413,14 @@ export default class GetNoteSyncPlugin extends Plugin {
     wrapper.open();
   }
 
-  syncSubscribedKnowledgeNotes(noteIds: string[]): void {
-    void this.runSubscribedKnowledgeSync(noteIds);
+  syncSubscribedKnowledgeNotes(selection: string[] | TopicPickerSelection): void {
+    const syncOptions = Array.isArray(selection)
+      ? { selectedNoteIds: selection }
+      : selection;
+    void this.runSubscribedKnowledgeSync(syncOptions);
   }
 
-  private async runSubscribedKnowledgeSync(selectedNoteIds?: string[]): Promise<void> {
+  private async runSubscribedKnowledgeSync(syncOptions?: TopicPickerSelection): Promise<void> {
     if (this.isSyncing) return;
     const credentials = getAuthCredentials(this.settings);
     if (!credentials.token || (credentials.authMode !== 'web' && !credentials.clientId)) {
@@ -437,7 +440,7 @@ export default class GetNoteSyncPlugin extends Plugin {
     engine.setOnCancel(() => this.cancelSync());
 
     try {
-      const result = await engine.syncSubscribedKnowledge(undefined, selectedNoteIds);
+      const result = await engine.syncSubscribedKnowledge(undefined, syncOptions);
       await this.recordSyncHistory(result, 'full', startedAt, {
         maxDays: this.settings.maxDays,
         syncStartDate: this.settings.syncStartDate,
@@ -659,10 +662,10 @@ class TopicPickerModalWrapper extends Modal {
         clientId={getAuthCredentials(this.plugin.settings).clientId}
         authMode={getAuthCredentials(this.plugin.settings).authMode}
         abortSignal={this.abortController.signal}
-        onConfirm={async (noteIds) => {
+        onConfirm={async (selection) => {
           this.abortController.abort();
           this.close();
-          this.plugin.syncSubscribedKnowledgeNotes(noteIds);
+          this.plugin.syncSubscribedKnowledgeNotes(selection);
         }}
         onCancel={() => {
           this.abortController.abort();

--- a/src/settings-tab.tsx
+++ b/src/settings-tab.tsx
@@ -26,6 +26,7 @@ export class GetNoteSettingsTab extends PluginSettingTab {
         isSyncing={this.plugin.isSyncing}
         syncProgress={this.plugin.syncProgress}
         openNotePicker={() => this.plugin.openNotePicker()}
+        startSubscribedKnowledgeSync={() => this.plugin.syncSubscribedKnowledge()}
         openLocalUpload={() => this.plugin.openLocalUploadModal()}
         startAutoSync={() => this.plugin.startAutoSync()}
         stopAutoSync={() => this.plugin.stopAutoSync()}

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -43,6 +43,7 @@ interface SettingsComponentProps {
   startSync: () => void;
   isSyncing: boolean;
   openNotePicker: () => void;
+  startSubscribedKnowledgeSync: () => void;
   openLocalUpload: () => void;
   startAutoSync: () => void;
   stopAutoSync: () => void;
@@ -59,6 +60,7 @@ export function SettingsComponent({
   startSync,
   isSyncing,
   openNotePicker,
+  startSubscribedKnowledgeSync,
   openLocalUpload,
   startAutoSync,
   stopAutoSync,
@@ -546,6 +548,13 @@ export function SettingsComponent({
                 onClick={openNotePicker}
               >
                 {t('settings.syncPicker.button')}
+              </button>
+              <button
+                className="mod-secondary getnote-sync-action-button"
+                disabled={!hasCredentials || isSyncing}
+                onClick={startSubscribedKnowledgeSync}
+              >
+                {t('settings.subscribedKnowledge.button')}
               </button>
             </div>
           </div>

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -109,6 +109,12 @@ export interface SyncProgressCallback {
   (info: { page?: number; processed?: number; total?: number; created?: number; updated?: number; skipped?: number; failed?: number; percent?: number }): void;
 }
 
+export interface SubscribedKnowledgeSyncOptions {
+  selectedNoteIds?: string[];
+  topicIds?: string[];
+  bloggerIds?: string[];
+}
+
 type WriteStatus = SyncResultItem['status'];
 
 interface WriteNoteResult {
@@ -905,7 +911,7 @@ export class SyncEngine {
     }
   }
 
-  async syncSubscribedKnowledge(modal?: SyncModal, selectedNoteIds?: string[]): Promise<SyncResult> {
+  async syncSubscribedKnowledge(modal?: SyncModal, options?: string[] | SubscribedKnowledgeSyncOptions): Promise<SyncResult> {
     const result: SyncResult = { created: 0, updated: 0, skipped: 0, failed: 0, total: 0, items: [] };
     const uidIndex = this.buildUidIndex();
     const seenNoteIds = new Set<string>();
@@ -922,20 +928,27 @@ export class SyncEngine {
 
     try {
       const credentials = getAuthCredentials(this.settings);
+      const syncOptions: SubscribedKnowledgeSyncOptions = Array.isArray(options)
+        ? { selectedNoteIds: options }
+        : options ?? {};
+      const selectedNoteIds = syncOptions.selectedNoteIds;
       const notes = await fetchSubscribedKnowledgeNotes({
         token: credentials.token,
         clientId: credentials.clientId,
         signal: controller.signal,
         authMode: credentials.authMode,
+        topicIds: syncOptions.topicIds,
+        bloggerIds: syncOptions.bloggerIds,
+        selectedNoteIds,
       });
-      const recentNotes = this.filterRecentNotes(notes);
-      const filtered = this.filterNotesByDateRange(recentNotes);
-      const typeFiltered = this.filterNotesByType(filtered);
       const noteIdFiltered = selectedNoteIds
-        ? typeFiltered.filter(n => selectedNoteIds.includes(n.note_id))
-        : typeFiltered;
+        ? notes.filter(n => selectedNoteIds.includes(n.note_id))
+        : notes;
+      const filteredNotes = selectedNoteIds
+        ? noteIdFiltered
+        : this.filterNotesByType(this.filterNotesByDateRange(this.filterRecentNotes(noteIdFiltered)));
 
-      for (const note of noteIdFiltered) {
+      for (const note of filteredNotes) {
         if (this.cancelled || modal?.isCancelled()) throw new SyncCancelledError();
         if (seenNoteIds.has(note.note_id)) continue;
         seenNoteIds.add(note.note_id);
@@ -945,12 +958,12 @@ export class SyncEngine {
         this.recordItem(result, note, writeResult);
         this.onProgress?.({
           processed: result.total,
-          total: noteIdFiltered.length,
+          total: filteredNotes.length,
           created: result.created,
           updated: result.updated,
           skipped: result.skipped,
           failed: result.failed,
-          percent: noteIdFiltered.length ? Math.round((result.total / noteIdFiltered.length) * 100) : 100,
+          percent: filteredNotes.length ? Math.round((result.total / filteredNotes.length) * 100) : 100,
         });
       }
 

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -13,8 +13,14 @@ interface TopicData {
   error?: string;
 }
 
+export interface TopicPickerSelection {
+  selectedNoteIds: string[];
+  topicIds?: string[];
+  bloggerIds?: string[];
+}
+
 interface TopicPickerModalProps {
-  onConfirm: (selectedNoteIds: string[]) => void;
+  onConfirm: (selection: TopicPickerSelection) => void;
   onCancel: () => void;
   token: string;
   clientId: string;
@@ -63,6 +69,7 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
   const [topicsError, setTopicsError] = useState<string | null>(null);
   const [activeTopicId, setActiveTopicId] = useState<string | null>(null);
   const [selectedNoteIds, setSelectedNoteIds] = useState<Set<string>>(new Set());
+  const [selectedItems, setSelectedItems] = useState<Map<string, ContentPreview>>(new Map());
 
   const loadTopics = useCallback(() => {
     setTopicsLoading(true);
@@ -150,9 +157,31 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
       else next.delete(noteId);
       return next;
     });
+    setSelectedItems(prev => {
+      const next = new Map(prev);
+      if (!checked) {
+        next.delete(noteId);
+        return next;
+      }
+      const item = Object.values(topicData)
+        .flatMap(data => data.contents)
+        .find(content => content.note_id === noteId);
+      if (item) next.set(noteId, item);
+      return next;
+    });
   };
 
-  const handleConfirm = () => onConfirm(Array.from(selectedNoteIds));
+  const handleConfirm = () => {
+    const selected = Array.from(selectedItems.values());
+    const topicIds = Array.from(new Set(selected.map(item => item.topic_id).filter((id): id is string => Boolean(id))));
+    const bloggerIds = Array.from(new Set(selected.map(item => item.blogger_id).filter((id): id is string => Boolean(id))));
+    if (topicIds.length === 0 && activeTopicId) topicIds.push(activeTopicId);
+    onConfirm({
+      selectedNoteIds: Array.from(selectedNoteIds),
+      ...(topicIds.length > 0 ? { topicIds } : {}),
+      ...(bloggerIds.length > 0 ? { bloggerIds } : {}),
+    });
+  };
 
   const totalItems = Object.values(topicData).reduce((sum, d) => sum + d.contents.length, 0);
   const activeTopic = activeTopicId ? topicData[activeTopicId] : null;

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -29,6 +29,7 @@ function renderSettings(
   options: {
     isSyncing?: boolean;
     syncProgress?: { message: string; count: string; percent: number };
+    startSubscribedKnowledgeSync?: () => void;
   } = {}
 ) {
   const container = document.createElement('div');
@@ -40,6 +41,7 @@ function renderSettings(
       startSync: vi.fn(),
       isSyncing: options.isSyncing ?? false,
       openNotePicker: vi.fn(),
+      startSubscribedKnowledgeSync: options.startSubscribedKnowledgeSync ?? vi.fn(),
       openLocalUpload,
       startAutoSync: vi.fn(),
       stopAutoSync: vi.fn(),
@@ -81,11 +83,24 @@ afterEach(() => {
 });
 
 describe('SettingsComponent auth credentials', () => {
-  it('does not show the knowledge-base sync entry in the 1.1.0 release UI', () => {
-    const { container } = renderSettings(makeSettings());
+  it('opens knowledge-base sync from the manual download actions', async () => {
+    const startSubscribedKnowledgeSync = vi.fn();
+    const { container } = renderSettings(makeSettings({
+      authMode: 'web',
+      webApiToken: 'web-token',
+      apiToken: 'web-token',
+    }), vi.fn(), vi.fn(), { startSubscribedKnowledgeSync });
 
-    expect(container.textContent).not.toContain('按知识库同步');
-    expect(container.textContent).not.toContain('Sync by Knowledge Base');
+    const button = Array.from(container.querySelectorAll('button'))
+      .find((item): item is HTMLButtonElement => item.textContent === '按知识库同步');
+    expect(button).toBeTruthy();
+    expect(button!.disabled).toBe(false);
+
+    await act(() => {
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(startSubscribedKnowledgeSync).toHaveBeenCalledTimes(1);
   });
 
   it('does not render a separate upload permission switch', () => {
@@ -172,6 +187,7 @@ describe('SettingsComponent auth credentials', () => {
             startSync: vi.fn(),
             isSyncing: true,
             openNotePicker: vi.fn(),
+            startSubscribedKnowledgeSync: vi.fn(),
             openLocalUpload: vi.fn(),
             startAutoSync: vi.fn(),
             stopAutoSync: vi.fn(),

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -584,6 +584,97 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
       vi.useRealTimers();
     }
   });
+
+  it('syncs exactly the selected Web API knowledge-base note and skips unrelated topics', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-04T12:00:00+08:00'));
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('/subscribe/topic/list')) {
+        return mockFetchResponse({
+          c: {
+            list: [
+              { id_alias: 'other_topic', name: '其他知识库', root_dir: { id: 'other_dir' } },
+              { id_alias: 'selected_topic', name: '选中的知识库', root_dir: { id: 'selected_dir' } },
+            ],
+          },
+        }) as Response;
+      }
+      if (requestUrl.includes('/topic/resource/list/mix')) {
+        const request = new URL(requestUrl);
+        if (request.searchParams.get('topic_id_alias') !== 'selected_topic') {
+          throw new Error(`Unexpected topic request: ${requestUrl}`);
+        }
+        if (request.searchParams.get('page') === '2') {
+          throw new Error(`Unexpected second page request: ${requestUrl}`);
+        }
+        return mockFetchResponse({
+          c: {
+            resources: [
+              {
+                resource_type: 'BLOGGER_POST',
+                resource_note_meta_data: {
+                  note_id: 'blogger_old_web_post',
+                  title: 'Web API 旧文章',
+                  content: '用户明确选择的旧文章',
+                  note_type: 'blogger_post',
+                  source: 'blogger',
+                  created_at: '2026-01-01T10:00:00+08:00',
+                  edit_time: '2026-01-01T10:00:00+08:00',
+                },
+              },
+              {
+                resource_type: 'BLOGGER_POST',
+                resource_note_meta_data: {
+                  note_id: 'blogger_unselected_post',
+                  title: '未选择文章',
+                  content: '不应写入',
+                  note_type: 'blogger_post',
+                  source: 'blogger',
+                  created_at: '2026-06-01T10:00:00+08:00',
+                  edit_time: '2026-06-01T10:00:00+08:00',
+                },
+              },
+            ],
+            has_next: 1,
+          },
+        }) as Response;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app as any, makeSettings({
+        authMode: 'web',
+        webApiToken: 'web-token',
+        apiToken: 'web-token',
+        maxDays: 30,
+      }), undefined, {
+        maxDays: 30,
+        syncStartDate: '2026-05-01',
+        enabledNoteTypes: ['plain_text'],
+      });
+
+      const result = await engine.syncSubscribedKnowledge(undefined, {
+        selectedNoteIds: ['blogger_old_web_post'],
+        topicIds: ['selected_topic'],
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.created).toBe(1);
+      expect(result.items).toEqual([
+        expect.objectContaining({
+          noteId: 'blogger_old_web_post',
+          status: 'created',
+        }),
+      ]);
+      expect(app.vault.create).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('SyncEngine — sync lastNoteTimestamp tracking', () => {

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -479,6 +479,113 @@ describe('SyncEngine — filterNotesByDateRange', () => {
   });
 });
 
+describe('SyncEngine — subscribed knowledge selected notes', () => {
+  it('syncs exactly the selected subscribed-knowledge note regardless of manual sync filters', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-04T12:00:00+08:00'));
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('/resource/knowledge/subscribe/list')) {
+        return mockFetchResponse({
+          data: {
+            topics: [{ topic_id: 'topic_1', name: '长期专题' }],
+            has_more: false,
+          },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/bloggers')) {
+        return mockFetchResponse({
+          data: {
+            bloggers: [{ follow_id: 'blogger_1', name: '主理人' }],
+            has_more: false,
+          },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/contents')) {
+        const url = new URL(requestUrl);
+        if (url.searchParams.get('page') === '2') {
+          return mockFetchResponse({
+            data: {
+              contents: [
+                {
+                  post_id_alias: 'should_not_fetch',
+                  title: '不应该继续翻页',
+                  summary: '已经找到勾选文章后不应继续请求',
+                  created_at: '2026-06-01T10:00:00+08:00',
+                  updated_at: '2026-06-01T10:00:00+08:00',
+                },
+              ],
+              has_more: false,
+            },
+          }) as Response;
+        }
+        return mockFetchResponse({
+          data: {
+            contents: [
+              {
+                post_id_alias: 'old_post',
+                title: '旧文章',
+                summary: '用户手动勾选的旧内容',
+                created_at: '2026-01-01T10:00:00+08:00',
+                updated_at: '2026-01-01T10:00:00+08:00',
+              },
+            ],
+            has_more: true,
+          },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/content/detail')) {
+        return mockFetchResponse({
+          data: {
+            post_id_alias: 'old_post',
+            title: '旧文章',
+            content: '用户手动勾选的旧内容详情',
+            created_at: '2026-01-01T10:00:00+08:00',
+            updated_at: '2026-01-01T10:00:00+08:00',
+          },
+        }) as Response;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app as any, makeSettings({
+        authMode: 'openapi',
+        openApiToken: 'openapi-token',
+        openApiClientId: 'openapi-client',
+        maxDays: 30,
+      }), undefined, {
+        maxDays: 30,
+        syncStartDate: '2026-05-01',
+        enabledNoteTypes: ['plain_text'],
+      });
+
+      const result = await engine.syncSubscribedKnowledge(undefined, {
+        selectedNoteIds: ['blogger_old_post'],
+        topicIds: [],
+        bloggerIds: [],
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.created).toBe(1);
+      expect(result.items).toEqual([
+        expect.objectContaining({
+          noteId: 'blogger_old_post',
+          status: 'created',
+        }),
+      ]);
+      expect(app.vault.create).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(globalThis.fetch).mock.calls.map(call => String(call[0]))).not.toContain(
+        'https://openapi.biji.com/open/api/v1/resource/knowledge/blogger/contents?topic_id=topic_1&follow_id=blogger_1&page=2'
+      );
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('SyncEngine — sync lastNoteTimestamp tracking', () => {
   it('records the newest updated_at as lastNoteTimestamp', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/tests/topic-picker-modal.spec.ts
+++ b/tests/topic-picker-modal.spec.ts
@@ -151,4 +151,111 @@ describe('TopicPickerModal', () => {
     expect(container.textContent).toContain('第二页内容');
     expect(container.textContent).not.toContain('加载更多');
   });
+
+  it('confirms selected note ids with topic and blogger scope', async () => {
+    const onConfirm = vi.fn();
+    vi.mocked(fetchSubscribedTopics).mockResolvedValue([
+      { topic_id: 'luo', name: '罗振宇学习笔记' },
+    ]);
+    vi.mocked(fetchTopicContentPreviewPage).mockResolvedValue({
+      items: [
+        {
+          note_id: 'blogger_note-1',
+          title: '第一篇内容',
+          updated_at: '2026-06-01T10:00:00+08:00',
+          blogger_name: '罗振宇',
+          topic_id: 'luo',
+          blogger_id: 'follow_luo',
+        },
+      ],
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(
+        h(TopicPickerModal, {
+          token: 'token',
+          clientId: 'client',
+          authMode: 'openapi',
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+        container
+      );
+      await Promise.resolve();
+    });
+    await flush();
+
+    await act(async () => {
+      (container.querySelector('[data-topic-id="luo"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    await act(async () => {
+      (container.querySelector('input[type="checkbox"]') as HTMLInputElement).click();
+    });
+
+    await act(async () => {
+      (container.querySelector('.mod-cta') as HTMLButtonElement).click();
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      selectedNoteIds: ['blogger_note-1'],
+      topicIds: ['luo'],
+      bloggerIds: ['follow_luo'],
+    });
+  });
+
+  it('falls back to the active topic when selected content has no topic metadata', async () => {
+    const onConfirm = vi.fn();
+    vi.mocked(fetchSubscribedTopics).mockResolvedValue([
+      { topic_id: 'luo', name: '罗振宇学习笔记' },
+    ]);
+    vi.mocked(fetchTopicContentPreviewPage).mockResolvedValue({
+      items: [
+        {
+          note_id: 'blogger_note-1',
+          title: '第一篇内容',
+          updated_at: '2026-06-01T10:00:00+08:00',
+          blogger_name: '罗振宇',
+        },
+      ],
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(
+        h(TopicPickerModal, {
+          token: 'token',
+          clientId: 'client',
+          authMode: 'openapi',
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+        container
+      );
+      await Promise.resolve();
+    });
+    await flush();
+
+    await act(async () => {
+      (container.querySelector('[data-topic-id="luo"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    await act(async () => {
+      (container.querySelector('input[type="checkbox"]') as HTMLInputElement).click();
+    });
+
+    await act(async () => {
+      (container.querySelector('.mod-cta') as HTMLButtonElement).click();
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      selectedNoteIds: ['blogger_note-1'],
+      topicIds: ['luo'],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- restore the manual **Sync by Knowledge Base** settings entry
- scope selected knowledge-base sync requests to selected topics, bloggers, and note IDs for OpenAPI and Web API
- bypass generic date/type filters for explicitly selected knowledge-base articles and stop fetching once selections are found

## Test Plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test
- [x] npm run build
- [x] deploy `main.js`, `manifest.json`, and `styles.css` to the local Obsidian test vault