### PR TITLE
fix: normalize invalid Obsidian tags

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,8 +10,10 @@ import { ManualSyncModal } from './ui/manual-sync-modal';
 import { LocalUploadModal } from './ui/local-upload-modal';
 import { initI18n, t } from './i18n';
 import { ReverseSyncEngine, type ReverseSyncResult } from './reverse-sync';
+import { migrateSyncedNoteTags } from './tag-migration';
 
 const MAX_SYNC_HISTORY = 20;
+const TAG_MIGRATION_VERSION = 1;
 const LEGACY_PLUGIN_IDS = ['obsidian-getnote-importer', 'getnote-importer'] as const;
 const PLUGIN_DATA_FILE = 'data.json';
 const LEGACY_PLUGIN_MIGRATION_NOTICE = '已经从旧的 GetNote Importer 迁移成功，请手动停止和卸载 GetNote Importer';
@@ -158,6 +160,16 @@ export default class GetNoteSyncPlugin extends Plugin {
     };
     this.syncHistory = this.settings.syncHistory;
     this.lastSyncResult = this.syncHistory.at(-1) ?? null;
+
+    if (this.settings.tagMigrationVersion < TAG_MIGRATION_VERSION) {
+      try {
+        await migrateSyncedNoteTags(this.app.vault, this.settings.folderName);
+        this.settings.tagMigrationVersion = TAG_MIGRATION_VERSION;
+        await this.saveSettings();
+      } catch (error) {
+        console.error('[DedaoBrain] Failed to migrate synced note tags', error);
+      }
+    }
 
     this.settingsTab = new GetNoteSettingsTab(this.app, this);
     this.addSettingTab(this.settingsTab);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import { ReverseSyncEngine, type ReverseSyncResult } from './reverse-sync';
 import { migrateSyncedNoteTags } from './tag-migration';
 
 const MAX_SYNC_HISTORY = 20;
-const TAG_MIGRATION_VERSION = 1;
+const TAG_MIGRATION_VERSION = 2;
 const LEGACY_PLUGIN_IDS = ['obsidian-getnote-importer', 'getnote-importer'] as const;
 const PLUGIN_DATA_FILE = 'data.json';
 const LEGACY_PLUGIN_MIGRATION_NOTICE = '已经从旧的 GetNote Importer 迁移成功，请手动停止和卸载 GetNote Importer';
@@ -161,15 +161,9 @@ export default class GetNoteSyncPlugin extends Plugin {
     this.syncHistory = this.settings.syncHistory;
     this.lastSyncResult = this.syncHistory.at(-1) ?? null;
 
-    if (this.settings.tagMigrationVersion < TAG_MIGRATION_VERSION) {
-      try {
-        await migrateSyncedNoteTags(this.app.vault, this.settings.folderName);
-        this.settings.tagMigrationVersion = TAG_MIGRATION_VERSION;
-        await this.saveSettings();
-      } catch (error) {
-        console.error('[DedaoBrain] Failed to migrate synced note tags', error);
-      }
-    }
+    this.app.workspace.onLayoutReady(() => {
+      void this.migrateExistingTags();
+    });
 
     this.settingsTab = new GetNoteSettingsTab(this.app, this);
     this.addSettingTab(this.settingsTab);
@@ -203,6 +197,19 @@ export default class GetNoteSyncPlugin extends Plugin {
 
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
+  }
+
+  private async migrateExistingTags(): Promise<void> {
+    if (this.settings.tagMigrationVersion >= TAG_MIGRATION_VERSION) return;
+
+    try {
+      const result = await migrateSyncedNoteTags(this.app.vault, this.settings.folderName);
+      if (result.scanned === 0) return;
+      this.settings.tagMigrationVersion = TAG_MIGRATION_VERSION;
+      await this.saveSettings();
+    } catch (error) {
+      console.error('[DedaoBrain] Failed to migrate synced note tags', error);
+    }
   }
 
   getVaultFolders(): string[] {

--- a/src/note-parser.ts
+++ b/src/note-parser.ts
@@ -24,6 +24,10 @@ function escapeYamlDoubleQuoted(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ');
 }
 
+function sanitizeObsidianTag(tag: string): string {
+  return tag.trim().replace(/\s+/g, '-');
+}
+
 /**
  * 从笔记内容生成回退标题（取第一个标点前的文字，不超过20字）
  */
@@ -72,7 +76,11 @@ export function formatTimestampPrefix(format: string, isoDate: string): string {
  * 生成 frontmatter
  */
 function buildFrontmatter(note: GetNoteNote): string {
-  const tags = note.tags.map(t => `"${t.name}"`).join(', ');
+  const tags = note.tags
+    .map(t => sanitizeObsidianTag(t.name))
+    .filter(Boolean)
+    .map(tag => `"${escapeYamlDoubleQuoted(tag)}"`)
+    .join(', ');
   const tagBlock = tags ? `[${tags}]` : '[]';
   const childrenIds = note.children_ids?.map(id => `"${escapeYamlDoubleQuoted(id)}"`).join(', ');
 

--- a/src/tag-migration.ts
+++ b/src/tag-migration.ts
@@ -1,0 +1,46 @@
+import type { TFile, Vault } from 'obsidian';
+
+const SYNCED_NOTE_SOURCES = new Set(['得到大脑', 'Get笔记']);
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/;
+
+type TagMigrationVault = Pick<Vault, 'getMarkdownFiles' | 'read' | 'modify'>;
+
+export interface TagMigrationResult {
+  scanned: number;
+  updated: number;
+}
+
+function normalizeFrontmatterTags(content: string): string | null {
+  const frontmatterMatch = FRONTMATTER_PATTERN.exec(content);
+  if (!frontmatterMatch) return null;
+
+  const frontmatter = frontmatterMatch[1];
+  const sourceMatch = /^source:\s*(.+?)\s*$/m.exec(frontmatter);
+  if (!sourceMatch || !SYNCED_NOTE_SOURCES.has(sourceMatch[1])) return null;
+
+  const normalizedFrontmatter = frontmatter.replace(/^tags:\s*\[(.*)\]\s*$/m, (line, values: string) => {
+    const normalized = values.replace(/"([^"]*)"/g, (_tag, value: string) => `"${value.trim().replace(/\s+/g, '-')}"`);
+    return normalized === values ? line : `tags: [${normalized}]`;
+  });
+
+  if (normalizedFrontmatter === frontmatter) return null;
+  return content.slice(0, frontmatterMatch.index) +
+    frontmatterMatch[0].replace(frontmatter, normalizedFrontmatter) +
+    content.slice(frontmatterMatch.index + frontmatterMatch[0].length);
+}
+
+export async function migrateSyncedNoteTags(vault: TagMigrationVault, folderName: string): Promise<TagMigrationResult> {
+  const prefix = `${folderName.replace(/\/+$/, '')}/`;
+  const files = vault.getMarkdownFiles().filter((file: TFile) => file.path.startsWith(prefix));
+  let updated = 0;
+
+  for (const file of files) {
+    const content = await vault.read(file);
+    const migrated = normalizeFrontmatterTags(content);
+    if (migrated === null) continue;
+    await vault.modify(file, migrated);
+    updated++;
+  }
+
+  return { scanned: files.length, updated };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface Settings {
   scheduledSync: ScheduledSyncSettings;
   reverseSync: ReverseSyncSettings;
   syncHistory: SyncHistoryEntry[];
+  tagMigrationVersion: number;
 }
 
 export interface SyncScopeOptions {
@@ -118,6 +119,7 @@ export const DEFAULT_SETTINGS: Settings = {
   reverseSync: {
     enabled: false,
   },
+  tagMigrationVersion: 0,
   syncHistory: [],
 };
 

--- a/tests/note-parser.spec.ts
+++ b/tests/note-parser.spec.ts
@@ -70,6 +70,11 @@ describe('renderNote', () => {
     expect(result).toContain('tags: []');
   });
 
+  it('将包含空格的标签转换为 Obsidian 支持的标签名', () => {
+    const result = renderNote(makeNote({ tags: [{ name: '本体 is all you need' }] }));
+    expect(result).toContain('tags: ["本体-is-all-you-need"]');
+  });
+
   it('附加笔记输出 parent_id 与 child 标识', () => {
     const result = renderNote(makeNote({
       note_id: '1909246675068292528',

--- a/tests/tag-migration.spec.ts
+++ b/tests/tag-migration.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TFile } from 'obsidian';
+import { migrateSyncedNoteTags } from '../src/tag-migration';
+
+function makeVault(entries: Record<string, string>) {
+  const files = new Map(Object.entries(entries));
+  return {
+    getMarkdownFiles: vi.fn(() => [...files.keys()].map(path => new TFile(path))),
+    read: vi.fn(async (file: TFile) => files.get(file.path) ?? ''),
+    modify: vi.fn(async (file: TFile, content: string) => {
+      files.set(file.path, content);
+    }),
+    content(path: string) {
+      return files.get(path);
+    },
+  };
+}
+
+describe('migrateSyncedNoteTags', () => {
+  it('normalizes invalid tags in synced notes without changing the body', async () => {
+    const vault = makeVault({
+      '得到大脑/note.md': [
+        '---',
+        'uid: "123"',
+        'source: 得到大脑',
+        'tags: ["本体 is all you need", "AI"]',
+        '---',
+        '# 正文',
+      ].join('\n'),
+    });
+
+    const result = await migrateSyncedNoteTags(vault, '得到大脑');
+
+    expect(result).toEqual({ scanned: 1, updated: 1 });
+    expect(vault.content('得到大脑/note.md')).toContain('tags: ["本体-is-all-you-need", "AI"]');
+    expect(vault.content('得到大脑/note.md')).toContain('---\n# 正文');
+  });
+
+  it('also migrates notes written by the old Get笔记 version', async () => {
+    const vault = makeVault({
+      '得到大脑/legacy.md': '---\nsource: Get笔记\ntags: ["old tag"]\n---\nbody',
+    });
+
+    const result = await migrateSyncedNoteTags(vault, '得到大脑');
+
+    expect(result).toEqual({ scanned: 1, updated: 1 });
+    expect(vault.content('得到大脑/legacy.md')).toContain('tags: ["old-tag"]');
+  });
+
+  it('does not modify notes outside the sync folder or without the synced source', async () => {
+    const vault = makeVault({
+      '其他/note.md': '---\nsource: 得到大脑\ntags: ["bad tag"]\n---\nbody',
+      '得到大脑/local.md': '---\nsource: local\ntags: ["bad tag"]\n---\nbody',
+    });
+
+    const result = await migrateSyncedNoteTags(vault, '得到大脑');
+
+    expect(result).toEqual({ scanned: 1, updated: 0 });
+    expect(vault.modify).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tag-migration.spec.ts
+++ b/tests/tag-migration.spec.ts
@@ -58,4 +58,12 @@ describe('migrateSyncedNoteTags', () => {
     expect(result).toEqual({ scanned: 1, updated: 0 });
     expect(vault.modify).not.toHaveBeenCalled();
   });
+
+  it('reports zero scanned files so startup does not mark an early migration complete', async () => {
+    const vault = makeVault({});
+
+    const result = await migrateSyncedNoteTags(vault, '得到大脑');
+
+    expect(result).toEqual({ scanned: 0, updated: 0 });
+  });
 });


### PR DESCRIPTION
## Summary

- normalize whitespace in newly synced tags to hyphens before writing Obsidian frontmatter
- migrate existing synced notes once on plugin startup, including legacy `source: Get笔记` notes
- scope migration to the configured sync folder and preserve note bodies
- add regression coverage for new and existing notes

Closes #111

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`