### PR TITLE
chore: bump version to 1.1.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "getnote-importer",
   "name": "Dedao Brain Sync",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Bidirectional sync for notes, links, recordings, and AI summaries between GetNote / 得到大脑（原Get笔记） and your local vault.",
   "author": "Andy Zheng",
   "isDesktopOnly": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-dedao-brain-sync",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Dedao Brain Sync for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package and plugin manifest version from 1.1.2 to 1.1.3
- prepare a release for the completed knowledge-base sync and tag normalization changes already merged to main

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build