### PR TITLE
feat(sync): 附件下载走本地 vault 零拷贝快路径 (#114)

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -11,5 +11,16 @@ await esbuild.build({
   sourcemap: isDev ? 'inline' : false,
   minify: !isDev,
   format: 'cjs',
-  external: ['obsidian'],
+  // Obsidian's desktop build runs in Electron's renderer, which exposes Node
+  // builtins. Mobile (Capacitor) does not, so anything Node-specific must
+  // guard with `hasLocalVaultBase()` or feature-detect `getBasePath()`.
+  external: [
+    'obsidian',
+    'electron',
+    'fs',
+    'fs/promises',
+    'path',
+    'os',
+    'crypto',
+  ],
 });

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5,6 +5,7 @@ import { getCategoryDir } from './types';
 import { getAuthCredentials, type GetNoteNote, type Settings, type SyncResult, type SyncResultItem, type SyncScopeOptions } from './types';
 import type { SyncModal } from './ui/sync-modal';
 import { t } from './i18n';
+import { tryWriteBinary } from './utils/vault-fs';
 
 const AUDIO_NOTE_TYPES = new Set([
   'recorder_audio',
@@ -244,7 +245,7 @@ export class SyncEngine {
         return null;
       }
       const arrayBuffer = await res.arrayBuffer();
-      await this.app.vault.createBinary(targetPath, arrayBuffer);
+      await tryWriteBinary(this.app, targetPath, arrayBuffer);
       return targetPath;
     } catch (err) {
       console.error(`[DedaoBrain] Audio download error:`, err);
@@ -282,7 +283,7 @@ export class SyncEngine {
         return null;
       }
       const arrayBuffer = await res.arrayBuffer();
-      await this.app.vault.createBinary(targetPath, arrayBuffer);
+      await tryWriteBinary(this.app, targetPath, arrayBuffer);
       return targetPath;
     } catch (err) {
       console.error(`[DedaoBrain] Image download error:`, err);

--- a/src/utils/vault-fs.ts
+++ b/src/utils/vault-fs.ts
@@ -1,0 +1,50 @@
+/// <reference types="node" />
+import type { App } from 'obsidian';
+import { writeFile, mkdir } from 'fs/promises';
+import * as path from 'path';
+
+/**
+ * Returns true when the vault is backed by a local filesystem adapter that
+ * exposes `getBasePath()`. On mobile and Remote vaults this is undefined, and
+ * the caller must fall back to `app.vault.createBinary`.
+ */
+export function hasLocalVaultBase(app: App): boolean {
+  const adapter = app.vault.adapter as { getBasePath?: () => string } | undefined;
+  if (!adapter) return false;
+  const base = adapter.getBasePath?.();
+  return typeof base === 'string' && base.length > 0;
+}
+
+/**
+ * Write binary data to a vault-relative path, preferring the local Node fs
+ * fast path on desktop. Falls back to `app.vault.createBinary()` on any
+ * failure (Remote vault, permission error, missing fs module, etc.).
+ *
+ * This exists because `app.vault.createBinary()` always copies through
+ * ArrayBuffer, which is wasteful for large attachments (mp3, mp4, pdf) when
+ * the vault is local.
+ */
+export async function tryWriteBinary(
+  app: App,
+  vaultPath: string,
+  data: ArrayBuffer
+): Promise<void> {
+  const adapter = app.vault.adapter as { getBasePath?: () => string } | undefined;
+  const base = adapter?.getBasePath?.();
+
+  if (typeof base === 'string' && base.length > 0) {
+    try {
+      const absPath = path.join(base, vaultPath);
+      const absDir = path.dirname(absPath);
+      await mkdir(absDir, { recursive: true });
+      // Buffer.from(ArrayBuffer) is a zero-copy view (same underlying memory),
+      // so writeFile writes the bytes directly without an extra allocation.
+      await writeFile(absPath, Buffer.from(data));
+      return;
+    } catch (err) {
+      console.warn('[DedaoBrain] Local fs write failed, falling back to vault.createBinary', err);
+    }
+  }
+
+  await app.vault.createBinary(vaultPath, data);
+}

--- a/tests/vault-fs.spec.ts
+++ b/tests/vault-fs.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { App } from 'obsidian';
+
+// vi.mock factories are hoisted above all imports; vi.hoisted creates a stable
+// ref that the hoisted factory can capture and that test bodies can also read.
+const { writeFileMock, mkdirMock } = vi.hoisted(() => ({
+  writeFileMock: vi.fn(),
+  mkdirMock: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  default: { writeFile: writeFileMock, mkdir: mkdirMock },
+  writeFile: writeFileMock,
+  mkdir: mkdirMock,
+}));
+
+// Import after mock is registered
+import { tryWriteBinary, hasLocalVaultBase } from '../src/utils/vault-fs';
+
+interface WriteableAdapter {
+  getBasePath?: () => string;
+  writeBinary: (path: string, data: ArrayBuffer) => Promise<void>;
+  mkdir: (path: string) => Promise<void>;
+}
+
+function makeAppWithAdapter(adapter: Partial<WriteableAdapter>): Pick<App, 'vault'> {
+  return {
+    vault: {
+      adapter: adapter as App['vault']['adapter'],
+    },
+  } as unknown as Pick<App, 'vault'>;
+}
+
+describe('hasLocalVaultBase', () => {
+  it('returns true when adapter exposes a non-empty getBasePath()', () => {
+    const app = makeAppWithAdapter({ getBasePath: () => '/Users/test/vault' });
+    expect(hasLocalVaultBase(app as unknown as App)).toBe(true);
+  });
+
+  it('returns false when adapter is missing getBasePath', () => {
+    const app = makeAppWithAdapter({});
+    expect(hasLocalVaultBase(app as unknown as App)).toBe(false);
+  });
+
+  it('returns false when getBasePath returns an empty string', () => {
+    const app = makeAppWithAdapter({ getBasePath: () => '' });
+    expect(hasLocalVaultBase(app as unknown as App)).toBe(false);
+  });
+});
+
+describe('tryWriteBinary', () => {
+  beforeEach(() => {
+    writeFileMock.mockReset();
+    mkdirMock.mockReset();
+    mkdirMock.mockResolvedValue(undefined);
+    writeFileMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes via Node fs when adapter has getBasePath', async () => {
+    const createBinarySpy = vi.fn().mockResolvedValue(undefined);
+    const app = makeAppWithAdapter({
+      getBasePath: () => '/Users/test/vault',
+    }) as unknown as App;
+    (app as unknown as { vault: { createBinary: typeof createBinarySpy } }).vault.createBinary = createBinarySpy;
+
+    const data = new Uint8Array([1, 2, 3, 4]).buffer;
+    await tryWriteBinary(app, 'subdir/file.bin', data);
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [calledPath, calledBuffer] = writeFileMock.mock.calls[0] as [string, Buffer];
+    expect(calledPath.replace(/\\/g, '/')).toBe('/Users/test/vault/subdir/file.bin');
+    expect(calledBuffer).toBeInstanceOf(Buffer);
+    expect(Array.from(calledBuffer)).toEqual([1, 2, 3, 4]);
+    expect(createBinarySpy).not.toHaveBeenCalled();
+    expect(mkdirMock).toHaveBeenCalled();
+  });
+
+  it('falls back to app.vault.createBinary when getBasePath is missing', async () => {
+    const createBinarySpy = vi.fn().mockResolvedValue(undefined);
+    const app = makeAppWithAdapter({}) as unknown as App;
+    (app as unknown as { vault: { createBinary: typeof createBinarySpy } }).vault.createBinary = createBinarySpy;
+
+    const data = new Uint8Array([9, 9, 9]).buffer;
+    await tryWriteBinary(app, 'note.md', data);
+
+    expect(writeFileMock).not.toHaveBeenCalled();
+    expect(createBinarySpy).toHaveBeenCalledTimes(1);
+    expect(createBinarySpy).toHaveBeenCalledWith('note.md', data);
+  });
+
+  it('falls back to app.vault.createBinary when getBasePath is empty', async () => {
+    const createBinarySpy = vi.fn().mockResolvedValue(undefined);
+    const app = {
+      vault: {
+        adapter: { getBasePath: () => '' },
+        createBinary: createBinarySpy,
+      },
+    } as unknown as App;
+
+    await tryWriteBinary(app, 'note.md', new ArrayBuffer(4));
+
+    expect(writeFileMock).not.toHaveBeenCalled();
+    expect(createBinarySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back when Node fs.writeFile throws (e.g. Remote vault mounted via custom adapter)', async () => {
+    writeFileMock.mockRejectedValueOnce(new Error('EROFS: read-only filesystem'));
+    const createBinarySpy = vi.fn().mockResolvedValue(undefined);
+    const app = makeAppWithAdapter({
+      getBasePath: () => '/Users/test/vault',
+    }) as unknown as App;
+    (app as unknown as { vault: { createBinary: typeof createBinarySpy } }).vault.createBinary = createBinarySpy;
+
+    const data = new Uint8Array([0xff]).buffer;
+    await tryWriteBinary(app, 'asset/photo.jpg', data);
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    expect(createBinarySpy).toHaveBeenCalledTimes(1);
+    expect(createBinarySpy).toHaveBeenCalledWith('asset/photo.jpg', data);
+  });
+});


### PR DESCRIPTION
## 关闭

Closes #114

## 改动

| 文件 | 变更 |
|---|---|
| `src/utils/vault-fs.ts` | **新增** — `tryWriteBinary()` + `hasLocalVaultBase()` 工具函数 |
| `src/sync.ts` | `downloadAudioAsset` / `downloadImageAsset` 的 `createBinary` 调用替换为 `tryWriteBinary` |
| `esbuild.config.mjs` | external 加 `fs` / `fs/promises` / `path` / `os` / `crypto`（Electron renderer 可用） |
| `tests/vault-fs.spec.ts` | **新增** — 7 个单测覆盖本地/远程/失败回退三种分支 |

## 性能预期

桌面端用本地 vault 时，大附件（>50MB mp3/mp4/pdf）写入耗时对比基线（`app.vault.createBinary`）应有 3-10× 加速——**未在 CI 跑基准测试**，用户可在 dev 自测对比。

## 回退行为

- 移动端（`getBasePath` 不存在）→ 自动走 `app.vault.createBinary`
- Remote vault 走自定义 adapter（即使有 `getBasePath`，写也可能失败）→ 错误被 catch 后回退
- `app.vault.adapter` 完全缺失（仅发生在测试 mock 缺漏）→ 不抛错，直接走 createBinary

## 验证

- ✅ `tsc --noEmit` 通过
- ✅ 全量测试 397 pass / 1 fail（pre-existing baseline 失败，与本 PR 无关）
- ✅ `npm run build` 通过
- ✅ 我新增的 2 个文件 lint 0 errors
- ⚠️ 全量 lint 139 errors，**全部是 main 上的 baseline pre-existing**（用 `git stash` 对比验证过）

## 风险

- **未在真实 Obsidian 环境跑端到端**：移动端和 desktop 的回退路径在测试中模拟过，但 Electron renderer 真实环境的 fs 权限边界没验证。需在本地 vault 跑一次手动同步确认
- esbuild `platform: 'browser'` + Node external 组合理论上兼容（Obsidian 官方插件都这么做），但没在 CI 验证 bundle 产物在 desktop/mobile 实际加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)