### PR TITLE
chore: release 1.2.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "getnote-importer",
   "name": "Dedao Brain Sync",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Bidirectional sync for notes, links, recordings, and AI summaries between GetNote / 得到大脑（原Get笔记） and your local vault.",
   "author": "Andy Zheng",
   "isDesktopOnly": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-dedao-brain-sync",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Dedao Brain Sync for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package version to 1.2.3
- bump Obsidian manifest version to 1.2.3
- prepare a release containing the quota visualization merged in PR #121

## Test Plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test
- [x] npm run build