### PR TITLE
fix(reverse-sync): tolerate malformed frontmatter lines (#118)

### DIFF
--- a/src/reverse-sync.ts
+++ b/src/reverse-sync.ts
@@ -53,7 +53,7 @@ function parseSimpleFrontmatter(raw: string): Record<string, string> | null {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
     const match = line.match(/^\s*([A-Za-z0-9_-]+)\s*:\s*(.*)\s*$/);
-    if (!match) return null;
+    if (!match) continue;
     hasYamlLine = true;
     result[match[1]] = stripQuotes(match[2].trim());
   }
@@ -93,6 +93,7 @@ function readTags(frontmatter: Record<string, unknown>): string[] {
   if (typeof value !== 'string') return [];
   const trimmed = value.trim();
   if (!trimmed || trimmed === '[]') return [];
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) return [];
   return trimmed
     .replace(/^\[|\]$/g, '')
     .split(',')

--- a/tests/reverse-sync-engine.spec.ts
+++ b/tests/reverse-sync-engine.spec.ts
@@ -500,6 +500,68 @@ describe('ReverseSyncEngine', () => {
     expect(app.vault._getFile('得到大脑/crlf.md')?.content).toContain('uid: "crlf-created"');
   });
 
+  it('keeps valid fields when a closed frontmatter block contains malformed lines', async () => {
+    const app = makeMockApp();
+    app.vault._addFile('得到大脑/partial-frontmatter.md', [
+      '---',
+      'title: "Partial frontmatter"',
+      'this line is not valid yaml',
+      'note_type: plain_text',
+      '---',
+      'Body survives',
+    ].join('\n'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ success: true, data: { note: { note_id: 'partial-created' } } })
+    );
+
+    await new ReverseSyncEngine(app as any, makeSettings()).syncBack();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://openapi.biji.com/open/api/v1/resource/note/save',
+      expect.objectContaining({
+        body: JSON.stringify({
+          title: 'Partial frontmatter',
+          content: 'Body survives',
+          note_type: 'plain_text',
+          source: 'app',
+          tags: [],
+        }),
+      })
+    );
+    expect(app.vault._getFile('得到大脑/partial-frontmatter.md')?.content.match(/^---/g)?.length).toBe(1);
+    expect(app.vault._getFile('得到大脑/partial-frontmatter.md')?.content).toContain('uid: "partial-created"');
+  });
+
+  it('ignores malformed object-shaped tags while keeping the note uploadable', async () => {
+    const app = makeMockApp();
+    app.vault._addFile('得到大脑/object-tags.md', [
+      '---',
+      'title: "Object tags"',
+      'note_type: plain_text',
+      'tags: {"unexpected":"shape"}',
+      '---',
+      'Body survives',
+    ].join('\n'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ success: true, data: { note: { note_id: 'object-tags-created' } } })
+    );
+
+    await new ReverseSyncEngine(app as any, makeSettings()).syncBack();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://openapi.biji.com/open/api/v1/resource/note/save',
+      expect.objectContaining({
+        body: JSON.stringify({
+          title: 'Object tags',
+          content: 'Body survives',
+          note_type: 'plain_text',
+          source: 'app',
+          tags: [],
+        }),
+      })
+    );
+  });
+
   it('does not treat a leading markdown divider block as frontmatter', async () => {
     const app = makeMockApp();
     const content = [


### PR DESCRIPTION
## Summary
- keep valid reverse-sync frontmatter fields when individual YAML lines are malformed
- ignore object-shaped malformed `tags` values instead of uploading them as a tag
- add focused regression coverage for both partial-frontmatter cases

## Root cause
`parseSimpleFrontmatter` aborted the entire block on the first malformed line, so reverse sync uploaded the complete frontmatter block as note content and duplicated frontmatter when writing the returned UID.

## Issue status
- Advances #118 subtask B (reverse-sync frontmatter line-level tolerance)
- Remaining #118 subtasks A, C, and D stay open for later independent batches
- Missing closing frontmatter delimiters remain intentionally conservative because no reliable body boundary exists

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test` (405 passed, 2 skipped)
- `npm run build`
- `npm run test:e2e:openapi` (2 environment-gated tests skipped)
- deployed artifacts to the local Obsidian test vault and reloaded Obsidian successfully
