### PR TITLE
chore: release 1.2.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "getnote-importer",
   "name": "Dedao Brain Sync",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Bidirectional sync for notes, links, recordings, and AI summaries between GetNote / 得到大脑（原Get笔记） and your local vault.",
   "author": "Andy Zheng",
   "isDesktopOnly": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-dedao-brain-sync",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Dedao Brain Sync for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump plugin version to 1.2.4

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run test:e2e:openapi (skipped: credentials unavailable)