### PR TITLE
feat(ui): 两个同步 modal 笔记列表改为瀑布流卡片样式（按笔记 + 按知识库详情）(#138)

### DIFF
--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -470,6 +470,12 @@ export async function fetchTopicContentPreviewPage(
       blogger_name: blogger.name ?? '',
       topic_id: topicId,
       blogger_id: blogger.follow_id,
+      summary: content.summary,
+      content: content.content,
+      tags: [
+        ...(_topicName ? [{ name: _topicName }] : []),
+        ...(blogger.name ? [{ name: blogger.name }] : []),
+      ],
     };
   });
   const nextCursor = readHasMore(source) && contents.length > 0

--- a/src/api-clients/webapi-client.ts
+++ b/src/api-clients/webapi-client.ts
@@ -412,7 +412,7 @@ export async function fetchTopicContentPreviewPage(
   const items = resources
     .map(resource => noteFromKnowledgeResource(resource, typeof rawTopic.name === 'string' ? rawTopic.name : undefined))
     .filter((note): note is GetNoteNote => Boolean(note))
-    .map(note => ({ note_id: note.note_id, title: note.title, updated_at: note.updated_at, topic_id: topicId }));
+    .map(note => ({ note_id: note.note_id, title: note.title, updated_at: note.updated_at, topic_id: topicId, content: note.content, tags: note.tags }));
   const nextCursor = source.has_next && resources.length > 0
     ? { bloggerIndex: 0, page: cursor.page + 1 }
     : undefined;

--- a/src/api.ts
+++ b/src/api.ts
@@ -94,6 +94,9 @@ export interface ContentPreview {
   blogger_name?: string;
   topic_id?: string;
   blogger_id?: string;
+  summary?: string;
+  content?: string;
+  tags?: { name: string }[];
 }
 
 export interface TopicContentPreviewOptions {

--- a/src/ui/note-picker-modal.tsx
+++ b/src/ui/note-picker-modal.tsx
@@ -45,21 +45,50 @@ function matchesSearchQuery(note: GetNoteNote, searchQuery: string): boolean {
   return haystacks.some(value => value.toLowerCase().includes(normalizedQuery));
 }
 
-function NoteRow({ note, checked, onChange }: { note: GetNoteNote; checked: boolean; onChange: (id: string, v: boolean) => void }) {
+function NoteRow({ note, checked, onChange, onTagClick }: { note: GetNoteNote; checked: boolean; onChange: (id: string, v: boolean) => void; onTagClick?: (tagName: string) => void }) {
   const title = generateDisplayTitle(note);
   const displayTitle = title || t('picker.noTitle');
+  const summaryText = (note.content || '').replace(/\n+/g, ' ').slice(0, 80);
+  const previewText = (note.content || '').replace(/\n+/g, ' ').slice(0, 150);
   return (
-    <div className="getnote-picker-row">
+    <div className="getnote-note-card">
       <input
         type="checkbox"
+        className="getnote-note-card-checkbox"
         checked={checked}
         onChange={(e) => onChange(note.note_id, (e.target as HTMLInputElement).checked)}
       />
-      <div className="getnote-picker-row-info">
-        <div className="getnote-picker-title">{displayTitle}</div>
-        <div className="getnote-picker-meta">
-          <span className="getnote-picker-type">{getTypeLabel(note.note_type)}</span>
-          <span className="getnote-picker-time">{formatRelativeTime(note.updated_at)}</span>
+      <div className="getnote-note-card-body">
+        <div className="getnote-note-card-header">
+          <div className="getnote-note-card-title">{displayTitle}</div>
+          <span className="getnote-note-card-type">{getTypeLabel(note.note_type)}</span>
+        </div>
+        {summaryText && (
+          <blockquote className="getnote-note-card-summary">{summaryText}</blockquote>
+        )}
+        {previewText && (
+          <div className="getnote-note-card-preview">{previewText}</div>
+        )}
+        <div className="getnote-note-card-footer">
+          {note.tags.length > 0 && (
+            <div className="getnote-note-card-tags">
+              {note.tags.map((tag, index) => (
+                <button
+                  key={`${tag.name}-${index}`}
+                  type="button"
+                  className="getnote-note-card-tag"
+                  data-tag-name={tag.name}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onTagClick?.(tag.name);
+                  }}
+                >
+                  #{tag.name}
+                </button>
+              ))}
+            </div>
+          )}
+          <span className="getnote-note-card-time">{formatRelativeTime(note.updated_at)}</span>
         </div>
       </div>
     </div>
@@ -139,6 +168,13 @@ export function NotePickerModal({ token, clientId, authMode, onConfirm, onCancel
   const handleSelectAll = () => setSelected(new Set(filteredNotes.map(n => n.note_id)));
   const handleSelectNone = () => setSelected(new Set());
   const handleConfirm = () => onConfirm(visibleSelectedIds, enabledNoteTypes);
+  const handleTagClick = (tagName: string) => {
+    setSearchQuery((prev) => {
+      const tag = tagName.trim();
+      if (!tag) return prev;
+      return prev.includes(tag) ? prev : (prev ? `${prev} ${tag}` : tag);
+    });
+  };
 
   return (
     <div className="getnote-picker">
@@ -176,7 +212,13 @@ export function NotePickerModal({ token, clientId, authMode, onConfirm, onCancel
         )}
         {error && !loading && <div className="getnote-picker-error">{error} <button onClick={loadFirstPage}>{t('picker.retry')}</button></div>}
         {!loading && !error && filteredNotes.map(note => (
-          <NoteRow key={note.note_id} note={note} checked={selected.has(note.note_id)} onChange={handleCheck} />
+          <NoteRow
+            key={note.note_id}
+            note={note}
+            checked={selected.has(note.note_id)}
+            onChange={handleCheck}
+            onTagClick={handleTagClick}
+          />
         ))}
         {!loading && !error && !loadingMore && hasMore && notes.length > 0 && (
           <div className="getnote-picker-loadmore">

--- a/src/ui/note-picker-modal.tsx
+++ b/src/ui/note-picker-modal.tsx
@@ -34,15 +34,15 @@ function getTypeLabel(noteType: string): string {
 }
 
 function matchesSearchQuery(note: GetNoteNote, searchQuery: string): boolean {
-  const normalizedQuery = searchQuery.trim().toLowerCase();
-  if (!normalizedQuery) return true;
+  const queryTokens = searchQuery.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (queryTokens.length === 0) return true;
 
   const haystacks = [
     generateDisplayTitle(note),
     ...note.tags.map(tag => tag.name),
   ];
 
-  return haystacks.some(value => value.toLowerCase().includes(normalizedQuery));
+  return queryTokens.every(token => haystacks.some(value => value.toLowerCase().includes(token)));
 }
 
 function NoteRow({ note, checked, onChange, onTagClick }: { note: GetNoteNote; checked: boolean; onChange: (id: string, v: boolean) => void; onTagClick?: (tagName: string) => void }) {

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -49,12 +49,12 @@ function formatRelativeTime(iso: string): string {
 
 function ContentRow({ item, checked, onChange, onTagClick }: { item: ContentPreview; checked: boolean; onChange: (noteId: string, v: boolean) => void; onTagClick?: (tagName: string) => void }) {
   const displayTitle = item.title || t('picker.noTitle');
-  const rawPreview = (item as { summary?: string; content?: string }).summary
-    || (item as { content?: string }).content
+  const rawPreview = item.summary
+    || item.content
     || '';
   const summaryText = rawPreview ? rawPreview.replace(/\n+/g, ' ').slice(0, 80) : '';
   const previewText = rawPreview ? rawPreview.replace(/\n+/g, ' ').slice(0, 150) : '';
-  const tags = ((item as { tags?: { name: string }[] }).tags) ?? [];
+  const tags = item.tags ?? [];
   return (
     <div className="getnote-note-card">
       <input
@@ -117,7 +117,10 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
   const [topicSearchQuery, setTopicSearchQuery] = useState('');
   const matchesActiveFilters = (item: ContentPreview) =>
     (!bloggerFilter || item.blogger_name === bloggerFilter) &&
-    (!searchQuery || item.title.toLowerCase().includes(searchQuery.toLowerCase()));
+    searchQuery.trim().toLowerCase().split(/\s+/).filter(Boolean).every(token =>
+      [item.title, item.blogger_name ?? '', ...(item.tags ?? []).map(tag => tag.name)]
+        .some(value => value.toLowerCase().includes(token))
+    );
 
   const loadTopics = useCallback(() => {
     setTopicsLoading(true);

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -47,19 +47,55 @@ function formatRelativeTime(iso: string): string {
   }
 }
 
-function ContentRow({ item, checked, onChange }: { item: ContentPreview; checked: boolean; onChange: (noteId: string, v: boolean) => void }) {
+function ContentRow({ item, checked, onChange, onTagClick }: { item: ContentPreview; checked: boolean; onChange: (noteId: string, v: boolean) => void; onTagClick?: (tagName: string) => void }) {
+  const displayTitle = item.title || t('picker.noTitle');
+  const rawPreview = (item as { summary?: string; content?: string }).summary
+    || (item as { content?: string }).content
+    || '';
+  const summaryText = rawPreview ? rawPreview.replace(/\n+/g, ' ').slice(0, 80) : '';
+  const previewText = rawPreview ? rawPreview.replace(/\n+/g, ' ').slice(0, 150) : '';
+  const tags = ((item as { tags?: { name: string }[] }).tags) ?? [];
   return (
-    <div className="getnote-picker-row">
+    <div className="getnote-note-card">
       <input
         type="checkbox"
+        className="getnote-note-card-checkbox"
         checked={checked}
         onChange={(e) => onChange(item.note_id, (e.target as HTMLInputElement).checked)}
       />
-      <div className="getnote-picker-row-info">
-        <div className="getnote-picker-title">{item.title || t('picker.noTitle')}</div>
-        <div className="getnote-picker-meta">
-          {item.blogger_name && <span className="getnote-picker-type">{item.blogger_name}</span>}
-          <span className="getnote-picker-time">{formatRelativeTime(item.updated_at)}</span>
+      <div className="getnote-note-card-body">
+        <div className="getnote-note-card-header">
+          <div className="getnote-note-card-title">{displayTitle}</div>
+          {item.blogger_name && (
+            <span className="getnote-note-card-type">{item.blogger_name}</span>
+          )}
+        </div>
+        {summaryText && (
+          <blockquote className="getnote-note-card-summary">{summaryText}</blockquote>
+        )}
+        {previewText && (
+          <div className="getnote-note-card-preview">{previewText}</div>
+        )}
+        <div className="getnote-note-card-footer">
+          {tags.length > 0 && (
+            <div className="getnote-note-card-tags">
+              {tags.map((tag, index) => (
+                <button
+                  key={`${tag.name}-${index}`}
+                  type="button"
+                  className="getnote-note-card-tag"
+                  data-tag-name={tag.name}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onTagClick?.(tag.name);
+                  }}
+                >
+                  #{tag.name}
+                </button>
+              ))}
+            </div>
+          )}
+          <span className="getnote-note-card-time">{formatRelativeTime(item.updated_at)}</span>
         </div>
       </div>
     </div>
@@ -194,6 +230,14 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
         .find(content => content.note_id === noteId);
       if (item) next.set(noteId, item);
       return next;
+    });
+  };
+
+  const handleTagClick = (tagName: string) => {
+    setSearchQuery((prev) => {
+      const tag = tagName.trim();
+      if (!tag) return prev;
+      return prev.includes(tag) ? prev : (prev ? `${prev} ${tag}` : tag);
     });
   };
 
@@ -435,7 +479,7 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
           <div className="getnote-picker-empty">{t('topicPicker.emptyContent')}</div>
         )}
         {activeTopic && !syncAllActive && !activeTopic.loading && !activeTopic.error && visibleItems.map(item => (
-          <ContentRow key={item.note_id} item={item} checked={selectedNoteIds.has(item.note_id)} onChange={handleCheck} />
+          <ContentRow key={item.note_id} item={item} checked={selectedNoteIds.has(item.note_id)} onChange={handleCheck} onTagClick={handleTagClick} />
         ))}
         {activeTopic && !syncAllActive && !activeTopic.loading && !activeTopic.error && activeTopic.contents.length > 0 && visibleItems.length === 0 && (
           <div className="getnote-picker-empty">{t('picker.noMatch')}</div>

--- a/styles.css
+++ b/styles.css
@@ -880,6 +880,139 @@
   border-radius: 3px;
 }
 
+/* === Note Card (瀑布流卡片样式, issue #138) === */
+.getnote-note-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 12px;
+  margin-bottom: 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  background: var(--background-primary);
+  box-sizing: border-box;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.getnote-note-card:hover {
+  border-color: var(--interactive-accent);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.getnote-note-card-checkbox {
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+
+.getnote-note-card-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.getnote-note-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.getnote-note-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--text-normal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  flex: 1;
+  min-width: 0;
+}
+
+.getnote-note-card-type {
+  flex-shrink: 0;
+  background: var(--background-modifier-hover);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.getnote-note-card-summary {
+  margin: 0;
+  padding: 8px 12px;
+  background: var(--background-modifier-border);
+  border-left: 3px solid var(--interactive-accent);
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.getnote-note-card-preview {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-normal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.getnote-note-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.getnote-note-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+.getnote-note-card-tag {
+  display: inline-block;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-accent);
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  cursor: pointer;
+  line-height: 1.4;
+  transition: background 0.15s;
+}
+
+.getnote-note-card-tag:hover {
+  background: var(--background-modifier-hover);
+}
+
+.getnote-note-card-time {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-faint);
+  text-align: right;
+  white-space: nowrap;
+}
+
 /* === Load More === */
 .getnote-picker-loadmore {
   text-align: center;

--- a/tests/note-picker.spec.ts
+++ b/tests/note-picker.spec.ts
@@ -176,7 +176,7 @@ describe('NotePickerModal auth chains', () => {
     expect(container.textContent).not.toContain('纯文本笔记');
     expect(container.textContent).toContain('链接笔记');
 
-    const linkRowCheckbox = Array.from(container.querySelectorAll('.getnote-picker-row input[type="checkbox"]'))[0] as HTMLInputElement;
+    const linkRowCheckbox = Array.from(container.querySelectorAll('.getnote-note-card input[type="checkbox"]'))[0] as HTMLInputElement;
     await act(() => {
       linkRowCheckbox.checked = true;
       linkRowCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
@@ -223,5 +223,121 @@ describe('NotePickerModal auth chains', () => {
     });
 
     expect(onConfirm).toHaveBeenCalledWith(['tagged'], undefined);
+  });
+});
+
+describe('NotePickerModal card layout (#138)', () => {
+  async function renderPickerWithNotes(notes: GetNoteNote[], props: { token: string; clientId: string; authMode: 'openapi' | 'web' }, onConfirm = vi.fn()) {
+    vi.mocked(fetchNotes).mockResolvedValueOnce({ notes, hasMore: false });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(
+        h(NotePickerModal, {
+          ...props,
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+        container
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    return container;
+  }
+
+  it('renders each note as a card containing title, summary, content preview, tags, and timestamp', async () => {
+    const notes: GetNoteNote[] = [
+      {
+        id: 1,
+        note_id: 'card-1',
+        title: 'AI 摘要卡片化测试',
+        content: '这是一段很长的正文内容，用于验证卡片是否正确显示正文预览区域。'.repeat(20),
+        note_type: 'plain_text',
+        source: 'app',
+        tags: [{ name: '工作' }, { name: '重要' }],
+        created_at: '2026-06-01T10:00:00+08:00',
+        updated_at: '2026-06-10T15:30:00+08:00',
+      },
+    ];
+
+    const container = await renderPickerWithNotes(notes, {
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    });
+
+    const card = container.querySelector('.getnote-note-card');
+    expect(card).not.toBeNull();
+
+    // 标题存在（粗体大字号）
+    const title = card!.querySelector('.getnote-note-card-title');
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toContain('AI 摘要卡片化测试');
+
+    // AI 摘要框（灰色背景）
+    const summary = card!.querySelector('.getnote-note-card-summary');
+    expect(summary).not.toBeNull();
+    expect(summary!.textContent).toBeTruthy();
+
+    // 正文预览存在
+    const preview = card!.querySelector('.getnote-note-card-preview');
+    expect(preview).not.toBeNull();
+
+    // 标签 chips
+    const chips = card!.querySelectorAll('.getnote-note-card-tag');
+    expect(chips.length).toBe(2);
+    expect(chips[0].textContent).toContain('工作');
+    expect(chips[1].textContent).toContain('重要');
+
+    // 时间戳存在
+    const time = card!.querySelector('.getnote-note-card-time');
+    expect(time).not.toBeNull();
+    expect(time!.textContent).toBeTruthy();
+  });
+
+  it('renders the card list as a single-column vertical layout (one card per row)', async () => {
+    const notes: GetNoteNote[] = [
+      makeNote({ note_id: 'row-1', title: '卡片 1' }),
+      makeNote({ note_id: 'row-2', title: '卡片 2' }),
+      makeNote({ note_id: 'row-3', title: '卡片 3' }),
+    ];
+    const container = await renderPickerWithNotes(notes, {
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    });
+
+    const cards = Array.from(container.querySelectorAll('.getnote-note-card'));
+    expect(cards.length).toBe(3);
+
+    // 每张卡片都是 block-level（不在一行）
+    cards.forEach(card => {
+      const style = (card as HTMLElement).style.display || window.getComputedStyle(card as HTMLElement).display;
+      expect(['block', 'flex', 'grid'].includes(style) || style === '').toBe(true);
+    });
+  });
+
+  it('clicking a tag chip on a card adds the tag to the search query (issue #106 behavior)', async () => {
+    const notes: GetNoteNote[] = [
+      makeNote({ note_id: 'tagged', title: '笔记', tags: [{ name: '工作' }, { name: 'AI' }] }),
+      makeNote({ note_id: 'plain', title: '无标签' }),
+    ];
+    const container = await renderPickerWithNotes(notes, {
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    });
+
+    const firstTag = container.querySelector('.getnote-note-card-tag') as HTMLElement;
+    expect(firstTag).not.toBeNull();
+    await act(async () => {
+      firstTag.click();
+    });
+
+    const searchInput = container.querySelector('.getnote-picker-search input') as HTMLInputElement;
+    expect(searchInput.value).toContain('工作');
   });
 });

--- a/tests/topic-picker-modal.spec.ts
+++ b/tests/topic-picker-modal.spec.ts
@@ -596,3 +596,82 @@ describe('TopicPickerModal', () => {
     });
   });
 });
+
+describe('TopicPickerModal card layout (#138)', () => {
+  it('renders knowledge-base contents as cards with title, summary, preview, tags and timestamp', async () => {
+    vi.mocked(fetchSubscribedTopics).mockResolvedValue([
+      { topic_id: 'luo', name: '罗振宇学习笔记' },
+    ]);
+    vi.mocked(fetchTopicContentPreviewPage).mockResolvedValue({
+      items: [
+        {
+          note_id: 'kb-card-1',
+          title: 'AI 知识库卡片化测试',
+          updated_at: '2026-06-10T15:30:00+08:00',
+          blogger_name: '罗振宇',
+          topic_id: 'luo',
+          summary: '这是一段 AI 生成的摘要，用于验证卡片显示摘要区域。',
+        } as never,
+      ],
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(h(TopicPickerModal, {
+        token: 'token',
+        clientId: 'client',
+        authMode: 'openapi',
+        onConfirm: vi.fn(),
+        onCancel: vi.fn(),
+      }), container);
+      await Promise.resolve();
+    });
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-topic-id="luo"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const card = container.querySelector('.getnote-note-card');
+    expect(card).not.toBeNull();
+
+    expect(card!.querySelector('.getnote-note-card-title')).not.toBeNull();
+    expect(card!.querySelector('.getnote-note-card-summary')).not.toBeNull();
+    expect(card!.querySelector('.getnote-note-card-time')).not.toBeNull();
+  });
+
+  it('renders multiple knowledge-base contents as a single-column vertical stack of cards', async () => {
+    vi.mocked(fetchSubscribedTopics).mockResolvedValue([
+      { topic_id: 'luo', name: '罗振宇学习笔记' },
+    ]);
+    vi.mocked(fetchTopicContentPreviewPage).mockResolvedValue({
+      items: [
+        { note_id: 'kb-1', title: '内容 1', updated_at: '2026-06-01T10:00:00+08:00', topic_id: 'luo' },
+        { note_id: 'kb-2', title: '内容 2', updated_at: '2026-06-02T10:00:00+08:00', topic_id: 'luo' },
+        { note_id: 'kb-3', title: '内容 3', updated_at: '2026-06-03T10:00:00+08:00', topic_id: 'luo' },
+      ],
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(h(TopicPickerModal, {
+        token: 'token',
+        clientId: 'client',
+        authMode: 'openapi',
+        onConfirm: vi.fn(),
+        onCancel: vi.fn(),
+      }), container);
+      await Promise.resolve();
+    });
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-topic-id="luo"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const cards = Array.from(container.querySelectorAll('.getnote-note-card'));
+    expect(cards.length).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #138

## 范围
- 按笔记同步 modal（note-picker-modal.tsx）
- 按知识库同步详情（topic-picker-modal.tsx ContentRow）

## 卡片结构
- 标题（粗体大字号）
- AI 摘要框（灰色 blockquote，content 前 80 字）
- 正文预览（前 100-150 字 truncate）
- 标签 chips（可点击 → 加入搜索框，保留 #106 行为）
- 右下时间戳（小字）

## 布局
单列纵向，卡片占满 modal 宽度。

## 验证
- typecheck: pass
- lint: pass
- test: 442 passed, 2 skipped
- build: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)