### PR TITLE
refactor(settings): 单个 on/off 开关统一改用 Obsidian Toggle（去掉 checkbox）(#136)

### DIFF
--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -4,6 +4,7 @@ import { SyncButton } from './sync-button';
 import { OAuthButton } from './oauth-button';
 import { openSyncHistoryModal } from '../ui/sync-history-modal';
 import { NoteTypeSelect } from '../ui/note-type-select';
+import { Toggle } from './toggle';
 import { type AuthMode, type Settings, type SyncHistoryEntry, type SyncProgressDetail } from '../types';
 import { App, AbstractInputSuggest } from 'obsidian';
 import { fetchNotes } from '../api';
@@ -468,10 +469,9 @@ export function SettingsComponent({
         <div className="getnote-scheduled-control">
           <div className="getnote-scheduled-row">
             <span>{t('settings.scheduled.enabled')}</span>
-            <input
-              type="checkbox"
-              checked={scheduledEnabled}
-              onChange={(e) => handleScheduledEnabled((e.target as HTMLInputElement).checked)}
+            <Toggle
+              value={scheduledEnabled}
+              onChange={handleScheduledEnabled}
             />
           </div>
           <div
@@ -496,10 +496,9 @@ export function SettingsComponent({
             <div className="getnote-scheduled-row">
               <span className="getnote-scheduled-row-label">{t('settings.scheduled.onStart')}</span>
               <span className="getnote-scheduled-row-control">
-                <input
-                  type="checkbox"
-                  checked={scheduledSync.syncOnStart}
-                  onChange={(e) => handleScheduledOnStart((e.target as HTMLInputElement).checked)}
+                <Toggle
+                  value={scheduledSync.syncOnStart}
+                  onChange={handleScheduledOnStart}
                 />
               </span>
             </div>

--- a/src/settings/toggle.tsx
+++ b/src/settings/toggle.tsx
@@ -37,7 +37,7 @@ export function Toggle({ value, onChange }: ToggleProps) {
   };
 
   return (
-    <div className="checkbox-container">
+    <div className={`checkbox-container${currentValue ? ' is-enabled' : ''}`}>
       <input type="checkbox" checked={currentValue} onChange={handleChange} />
     </div>
   );

--- a/src/settings/toggle.tsx
+++ b/src/settings/toggle.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+interface ToggleProps {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+/**
+ * Renders an Obsidian-style toggle switch.
+ *
+ * The markup mirrors the DOM produced by Obsidian's native
+ * `ToggleComponent` (`<div class="checkbox-container"><input type="checkbox" .../></div>`)
+ * which Obsidian's own app.css styles as a switch. Rendering the markup
+ * directly in Preact keeps the test environment synchronous and avoids
+ * relying on the imperative Obsidian constructor inside a `useEffect`.
+ *
+ * In the production Obsidian runtime, the same DOM is also produced by
+ * `new ToggleComponent(hostEl)`; here we just inline the resulting
+ * structure so the visual treatment stays identical.
+ */
+export function Toggle({ value, onChange }: ToggleProps) {
+  const [currentValue, setCurrentValue] = useState(value);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    setCurrentValue(value);
+  }, [value]);
+
+  const handleChange = (event: Event) => {
+    const next = (event.target as HTMLInputElement).checked;
+    setCurrentValue(next);
+    onChangeRef.current(next);
+  };
+
+  return (
+    <div className="checkbox-container">
+      <input type="checkbox" checked={currentValue} onChange={handleChange} />
+    </div>
+  );
+}

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -435,3 +435,90 @@ describe('SettingsComponent auth credentials', () => {
     });
   });
 });
+
+describe('SettingsComponent scheduled sync toggles (#136)', () => {
+  function findScheduledEnabledRow(container: HTMLElement): HTMLElement {
+    const rows = container.querySelectorAll('.getnote-scheduled-row');
+    const row = Array.from(rows).find((el) => el.textContent === '启用定时同步');
+    expect(row).toBeTruthy();
+    return row!;
+  }
+
+  function findSyncOnStartRow(container: HTMLElement): HTMLElement {
+    const rows = container.querySelectorAll('.getnote-scheduled-row');
+    const row = Array.from(rows).find((el) => el.textContent?.includes('启动时同步'));
+    expect(row).toBeTruthy();
+    return row!;
+  }
+
+  it('renders scheduledEnabled as an Obsidian toggle (not a plain checkbox)', () => {
+    const { container } = renderSettings(makeSettings({
+      scheduledSync: { ...DEFAULT_SETTINGS.scheduledSync, enabled: false },
+    }));
+
+    const row = findScheduledEnabledRow(container);
+    const toggleContainers = row.querySelectorAll('.checkbox-container');
+    const plainCheckboxes = row.querySelectorAll(':scope > input[type="checkbox"]');
+
+    expect(toggleContainers.length).toBe(1);
+    expect(plainCheckboxes.length).toBe(0);
+    const innerCheckbox = toggleContainers[0].querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(innerCheckbox).toBeTruthy();
+    expect(innerCheckbox.checked).toBe(false);
+  });
+
+  it('renders syncOnStart as an Obsidian toggle inside the scheduled sync options', () => {
+    const { container } = renderSettings(makeSettings({
+      scheduledSync: { ...DEFAULT_SETTINGS.scheduledSync, enabled: true, syncOnStart: true },
+    }));
+
+    const row = findSyncOnStartRow(container);
+    const toggleContainers = row.querySelectorAll('.checkbox-container');
+    const plainCheckboxes = row.querySelectorAll(':scope > input[type="checkbox"]');
+
+    expect(toggleContainers.length).toBe(1);
+    expect(plainCheckboxes.length).toBe(0);
+    const innerCheckbox = toggleContainers[0].querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(innerCheckbox).toBeTruthy();
+    expect(innerCheckbox.checked).toBe(true);
+  });
+
+  it('preserves onChange behavior for scheduledEnabled toggle', async () => {
+    const { container, updateSetting } = renderSettings(makeSettings({
+      scheduledSync: { ...DEFAULT_SETTINGS.scheduledSync, enabled: false },
+    }));
+
+    const row = findScheduledEnabledRow(container);
+    const innerCheckbox = row.querySelector('.checkbox-container input[type="checkbox"]') as HTMLInputElement;
+    expect(innerCheckbox).toBeTruthy();
+
+    await act(() => {
+      innerCheckbox.checked = true;
+      innerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(updateSetting).toHaveBeenCalledWith('scheduledSync', expect.objectContaining({
+      enabled: true,
+    }));
+  });
+
+  it('preserves onChange behavior for syncOnStart toggle', async () => {
+    const { container, updateSetting } = renderSettings(makeSettings({
+      scheduledSync: { ...DEFAULT_SETTINGS.scheduledSync, enabled: true, syncOnStart: false },
+    }));
+
+    const row = findSyncOnStartRow(container);
+    const innerCheckbox = row.querySelector('.checkbox-container input[type="checkbox"]') as HTMLInputElement;
+    expect(innerCheckbox).toBeTruthy();
+
+    await act(() => {
+      innerCheckbox.checked = true;
+      innerCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(updateSetting).toHaveBeenCalledWith('scheduledSync', expect.objectContaining({
+      enabled: true,
+      syncOnStart: true,
+    }));
+  });
+});

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -481,6 +481,7 @@ describe('SettingsComponent scheduled sync toggles (#136)', () => {
     const innerCheckbox = toggleContainers[0].querySelector('input[type="checkbox"]') as HTMLInputElement;
     expect(innerCheckbox).toBeTruthy();
     expect(innerCheckbox.checked).toBe(true);
+    expect(toggleContainers[0].classList.contains('is-enabled')).toBe(true);
   });
 
   it('preserves onChange behavior for scheduledEnabled toggle', async () => {
@@ -500,6 +501,7 @@ describe('SettingsComponent scheduled sync toggles (#136)', () => {
     expect(updateSetting).toHaveBeenCalledWith('scheduledSync', expect.objectContaining({
       enabled: true,
     }));
+    expect(row.querySelector('.checkbox-container')?.classList.contains('is-enabled')).toBe(true);
   });
 
   it('preserves onChange behavior for syncOnStart toggle', async () => {


### PR DESCRIPTION
Closes #136

## 范围（只 2 处）
1. settings/index.tsx:471-475 — scheduledEnabled checkbox → Toggle
2. settings/index.tsx:499-503 — syncOnStart checkbox → Toggle

## 不动
- 鉴权模式 radio（互斥单选）
- 附件 4 checkbox（属于 #135）

## 数据/默认值不变
- settings.scheduledSync.enabled / syncOnStart 保持 boolean
- onChange 行为不变

## 验证
- typecheck: pass
- lint: pass
- test: 441 passed, 2 skipped
- build: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)