### PR TITLE
fix(ui): address card preview review findings

### DIFF
--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -429,7 +429,17 @@ export async function fetchTopicContentPreviewPage(
   cursor: { bloggerIndex: number; page: number } = { bloggerIndex: 0, page: 1 },
   topicSource?: SubscribedTopic['source']
 ): Promise<{
-  items: { note_id: string; title: string; updated_at: string; blogger_name: string; topic_id: string; blogger_id: string }[];
+  items: {
+    note_id: string;
+    title: string;
+    updated_at: string;
+    blogger_name: string;
+    topic_id: string;
+    blogger_id: string;
+    summary?: string;
+    content?: string;
+    tags?: { name: string }[];
+  }[];
   nextCursor?: { bloggerIndex: number; page: number };
 }> {
   if (topicSource === 'created') {
@@ -442,6 +452,8 @@ export async function fetchTopicContentPreviewPage(
       blogger_name: '',
       topic_id: topicId,
       blogger_id: '',
+      content: note.content,
+      tags: note.tags,
     }));
     return { items };
   }

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -49,11 +49,10 @@ function formatRelativeTime(iso: string): string {
 
 function ContentRow({ item, checked, onChange, onTagClick }: { item: ContentPreview; checked: boolean; onChange: (noteId: string, v: boolean) => void; onTagClick?: (tagName: string) => void }) {
   const displayTitle = item.title || t('picker.noTitle');
-  const rawPreview = item.summary
-    || item.content
-    || '';
-  const summaryText = rawPreview ? rawPreview.replace(/\n+/g, ' ').slice(0, 80) : '';
-  const previewText = rawPreview ? rawPreview.replace(/\n+/g, ' ').slice(0, 150) : '';
+  const summarySource = item.summary || item.content || '';
+  const previewSource = item.content || item.summary || '';
+  const summaryText = summarySource ? summarySource.replace(/\n+/g, ' ').slice(0, 80) : '';
+  const previewText = previewSource ? previewSource.replace(/\n+/g, ' ').slice(0, 150) : '';
   const tags = item.tags ?? [];
   return (
     <div className="getnote-note-card">
@@ -237,6 +236,7 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
   };
 
   const handleTagClick = (tagName: string) => {
+    setSelectAllActive(false);
     setSearchQuery((prev) => {
       const tag = tagName.trim();
       if (!tag) return prev;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -569,6 +569,41 @@ describe('OpenAPI knowledge previews', () => {
       vi.mocked(globalThis.fetch).mockRestore();
     }
   });
+
+  it('keeps created knowledge-base content and tags in preview items', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(mockFetchResponse({
+      data: {
+        notes: [{
+          note_id: 'created-note-1',
+          title: '创建型知识库笔记',
+          content: '创建型知识库正文预览',
+          updated_at: '2026-06-01 10:00:00',
+        }],
+        has_more: false,
+      },
+    }) as Response);
+
+    try {
+      const page = await fetchTopicContentPreviewPage(
+        'created-1',
+        '我创建的知识库',
+        'token',
+        'client',
+        'openapi',
+        undefined,
+        undefined,
+        'created'
+      );
+
+      expect(page.items[0]).toMatchObject({
+        note_id: 'created-note-1',
+        content: '创建型知识库正文预览',
+        tags: [{ name: '我创建的知识库' }],
+      });
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
 });
 
 describe('createNote', () => {

--- a/tests/topic-picker-modal.spec.ts
+++ b/tests/topic-picker-modal.spec.ts
@@ -245,6 +245,61 @@ describe('TopicPickerModal', () => {
     expect(container.textContent).not.toContain('管理文章');
   });
 
+  it('stops auto-selecting newly loaded contents after a tag chip changes the filter', async () => {
+    vi.mocked(fetchSubscribedTopics).mockResolvedValue([{ topic_id: 'luo', name: '罗振宇学习笔记' }]);
+    vi.mocked(fetchTopicContentPreviewPage)
+      .mockResolvedValueOnce({
+        items: [{
+          note_id: 'note-1',
+          title: 'AI 第一篇',
+          updated_at: '2026-06-01T10:00:00+08:00',
+          tags: [{ name: 'AI' }],
+        }],
+        nextCursor: { bloggerIndex: 0, page: 2 },
+      })
+      .mockResolvedValueOnce({
+        items: [{
+          note_id: 'note-2',
+          title: 'AI 第二篇',
+          updated_at: '2026-06-01T11:00:00+08:00',
+          tags: [{ name: 'AI' }],
+        }],
+      });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(h(TopicPickerModal, {
+        token: 'token',
+        clientId: 'client',
+        authMode: 'openapi',
+        onConfirm: vi.fn(),
+        onCancel: vi.fn(),
+      }), container);
+    });
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-topic-id="luo"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-topic-select-all]') as HTMLButtonElement).click();
+    });
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-tag-name="AI"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-topic-load-more]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(container.textContent).toContain('已选 1 个');
+    expect(Array.from(container.querySelectorAll('input[type="checkbox"]'))
+      .filter(input => (input as HTMLInputElement).checked)).toHaveLength(1);
+  });
+
   it('renders topic filters outside the scrollable article list', async () => {
     vi.mocked(fetchSubscribedTopics).mockResolvedValue([{ topic_id: 'luo', name: '罗振宇学习笔记' }]);
     vi.mocked(fetchTopicContentPreviewPage).mockResolvedValue({
@@ -611,6 +666,7 @@ describe('TopicPickerModal card layout (#138)', () => {
           blogger_name: '罗振宇',
           topic_id: 'luo',
           summary: '这是一段 AI 生成的摘要，用于验证卡片显示摘要区域。',
+          content: '这是与摘要不同的正文预览内容。',
         } as never,
       ],
     });
@@ -637,7 +693,8 @@ describe('TopicPickerModal card layout (#138)', () => {
     expect(card).not.toBeNull();
 
     expect(card!.querySelector('.getnote-note-card-title')).not.toBeNull();
-    expect(card!.querySelector('.getnote-note-card-summary')).not.toBeNull();
+    expect(card!.querySelector('.getnote-note-card-summary')?.textContent).toContain('AI 生成的摘要');
+    expect(card!.querySelector('.getnote-note-card-preview')?.textContent).toContain('与摘要不同的正文预览');
     expect(card!.querySelector('.getnote-note-card-time')).not.toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- preserve content and tags for created knowledge-base preview cards
- render distinct summary and body preview text
- clear select-all mode when tag chips change the active filter

## Test Plan
- npm run typecheck
- npm run lint
- npm test
- npm run build