### PR TITLE
[codex] Fix clarified picker modal UI issues

### DIFF
--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -58,6 +58,13 @@ interface SettingsComponentProps {
   initialKnowledgeBaseCache?: { entries: Array<{ topicId: string; name: string; source?: 'subscribed' | 'created' }>; cacheUpdatedAt?: number };
 }
 
+function getLocalDateInputValue(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function SettingsComponent({
   settings,
   updateSetting,
@@ -135,11 +142,7 @@ export function SettingsComponent({
 
   useEffect(() => {
     if (!settings.syncStartDate && !settings.lastSyncEndTimestamp) {
-      const d = new Date();
-      const y = d.getFullYear();
-      const m = String(d.getMonth() + 1).padStart(2, '0');
-      const day = String(d.getDate()).padStart(2, '0');
-      updateSetting('syncStartDate', `${y}-${m}-${day}`);
+      updateSetting('syncStartDate', getLocalDateInputValue());
     }
   }, []);
 
@@ -251,7 +254,7 @@ export function SettingsComponent({
 
   const handleResetCheckpointClick = () => {
     if (isSyncing) return;
-    setPendingStartDate(settings.syncStartDate);
+    setPendingStartDate(getLocalDateInputValue());
     setResetDialogOpen(true);
   };
 

--- a/src/ui/manual-sync-modal.tsx
+++ b/src/ui/manual-sync-modal.tsx
@@ -27,9 +27,16 @@ function resolveInitialSyncMode(initialOptions: SyncScopeOptions): SyncMode {
   return daysCutoff >= startTime ? 'days' : 'date';
 }
 
+function getLocalDateInputValue(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function ManualSyncModal({ initialOptions, tagOptions = [], onConfirm, onCancel }: ManualSyncModalProps) {
   const [syncMode, setSyncMode] = useState<SyncMode>(resolveInitialSyncMode(initialOptions));
-  const [syncStartDate, setSyncStartDate] = useState(initialOptions.syncStartDate);
+  const [syncStartDate, setSyncStartDate] = useState(initialOptions.syncStartDate || getLocalDateInputValue());
   const [maxDays, setMaxDays] = useState(String(initialOptions.maxDays));
   const [enabledNoteTypes, setEnabledNoteTypes] = useState<string[] | undefined>(initialOptions.enabledNoteTypes);
   const [syncTags, setSyncTags] = useState<string[]>(initialOptions.syncTags ?? []);

--- a/src/ui/note-picker-modal.tsx
+++ b/src/ui/note-picker-modal.tsx
@@ -66,6 +66,7 @@ function NoteRow({ note, checked, onChange, onTagClick }: { note: GetNoteNote; c
       tabIndex={0}
       onClick={toggleSelection}
       onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
         if (e.key !== ' ' && e.key !== 'Enter') return;
         e.preventDefault();
         toggleSelection();

--- a/src/ui/note-picker-modal.tsx
+++ b/src/ui/note-picker-modal.tsx
@@ -57,12 +57,25 @@ function NoteRow({ note, checked, onChange, onTagClick }: { note: GetNoteNote; c
   const title = generateDisplayTitle(note);
   const displayTitle = title || t('picker.noTitle');
   const previewText = compactCardText(note.content).slice(0, 150);
+  const toggleSelection = () => onChange(note.note_id, !checked);
   return (
-    <div className="getnote-note-card">
+    <div
+      className={`getnote-note-card${checked ? ' is-selected' : ''}`}
+      role="checkbox"
+      aria-checked={checked}
+      tabIndex={0}
+      onClick={toggleSelection}
+      onKeyDown={(e) => {
+        if (e.key !== ' ' && e.key !== 'Enter') return;
+        e.preventDefault();
+        toggleSelection();
+      }}
+    >
       <input
         type="checkbox"
         className="getnote-note-card-checkbox"
         checked={checked}
+        onClick={(e) => e.stopPropagation()}
         onChange={(e) => onChange(note.note_id, (e.target as HTMLInputElement).checked)}
       />
       <div className="getnote-note-card-body">

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -310,7 +310,6 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
           ? { createdTopicIds: [activeTopic.topic.topic_id] }
           : { topicIds: [activeTopic.topic.topic_id] }),
         knowledgeBaseName: activeTopic.topic.name || activeTopic.topic.topic_id,
-        ...(syncTags.length > 0 ? { syncTags } : {}),
       });
       return;
     }

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -409,48 +409,47 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
               <span>{t('topicPicker.scope.selected')}</span>
             </label>
           </div>
-          {syncAllActive && (
-            <div className="getnote-input-hint getnote-topic-scope-hint">{t('topicPicker.scope.allHint')}</div>
-          )}
-          <div className="getnote-topic-filter-bar">
-            <TagSelect
-              value={syncTags}
-              options={activeTagOptions}
-              onChange={(value) => {
-                setSelectAllActive(false);
-                pruneSelectedItemsByTags(value);
-                setSyncTags(value);
-              }}
-              placeholder={t('noteTags.searchPlaceholder')}
-              allowCreate={false}
-            />
-            {!syncAllActive && activeTopic.contents.length > 0 && (
-              <input
-                data-topic-search
-                type="text"
-                className="getnote-input"
-                placeholder={t('picker.search')}
-                value={searchQuery}
-                onInput={(event) => {
+          {!syncAllActive && (
+            <div className="getnote-topic-filter-bar">
+              <TagSelect
+                value={syncTags}
+                options={activeTagOptions}
+                onChange={(value) => {
                   setSelectAllActive(false);
-                  setSearchQuery((event.target as HTMLInputElement).value);
+                  pruneSelectedItemsByTags(value);
+                  setSyncTags(value);
                 }}
+                placeholder={t('noteTags.searchPlaceholder')}
+                allowCreate={false}
               />
-            )}
-            {bloggers.length > 0 && (
-              <select
-                data-topic-blogger-filter
-                value={bloggerFilter}
-                onChange={(event) => {
-                  setSelectAllActive(false);
-                  setBloggerFilter((event.target as HTMLSelectElement).value);
-                }}
-              >
-                <option value="">{t('topicPicker.allBloggers')}</option>
-                {bloggers.map(blogger => <option key={blogger} value={blogger}>{blogger}</option>)}
-              </select>
-            )}
-          </div>
+              {activeTopic.contents.length > 0 && (
+                <input
+                  data-topic-search
+                  type="text"
+                  className="getnote-input"
+                  placeholder={t('picker.search')}
+                  value={searchQuery}
+                  onInput={(event) => {
+                    setSelectAllActive(false);
+                    setSearchQuery((event.target as HTMLInputElement).value);
+                  }}
+                />
+              )}
+              {bloggers.length > 0 && (
+                <select
+                  data-topic-blogger-filter
+                  value={bloggerFilter}
+                  onChange={(event) => {
+                    setSelectAllActive(false);
+                    setBloggerFilter((event.target as HTMLSelectElement).value);
+                  }}
+                >
+                  <option value="">{t('topicPicker.allBloggers')}</option>
+                  {bloggers.map(blogger => <option key={blogger} value={blogger}>{blogger}</option>)}
+                </select>
+              )}
+            </div>
+          )}
         </div>
       )}
       {!activeTopic && !topicsLoading && !topicsError && topics.length > 0 && (
@@ -533,7 +532,10 @@ export function TopicPickerModal({ token, clientId, authMode, onConfirm, onCance
             <button onClick={() => void openTopic(activeTopic.topic)}>{t('topicPicker.retry')}</button>
           </div>
         )}
-        {activeTopic && !activeTopic.loading && !activeTopic.error && activeTopic.contents.length === 0 && (
+        {activeTopic && syncAllActive && !activeTopic.loading && !activeTopic.error && (
+          <div className="getnote-picker-empty getnote-topic-scope-hint">{t('topicPicker.scope.allHint')}</div>
+        )}
+        {activeTopic && !syncAllActive && !activeTopic.loading && !activeTopic.error && activeTopic.contents.length === 0 && (
           <div className="getnote-picker-empty">{t('topicPicker.emptyContent')}</div>
         )}
         {activeTopic && !syncAllActive && !activeTopic.loading && !activeTopic.error && visibleItems.map(item => (

--- a/styles.css
+++ b/styles.css
@@ -1225,12 +1225,19 @@
   border-radius: 8px;
   background: var(--background-primary);
   box-sizing: border-box;
+  cursor: pointer;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .getnote-note-card:hover {
   border-color: var(--interactive-accent);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.getnote-note-card.is-selected {
+  border-color: var(--interactive-accent);
+  background: var(--background-modifier-hover);
+  box-shadow: 0 0 0 1px var(--interactive-accent);
 }
 
 .getnote-note-card-checkbox {

--- a/tests/manual-sync-modal.spec.ts
+++ b/tests/manual-sync-modal.spec.ts
@@ -18,6 +18,8 @@ function renderModal(initialOptions: { syncStartDate: string; maxDays: number; e
 }
 
 afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   render(null, document.body);
   document.body.innerHTML = '';
 });
@@ -59,6 +61,35 @@ describe('ManualSyncModal filters', () => {
     });
 
     expect(onConfirm).toHaveBeenCalledWith({ syncStartDate: '2026-05-09', maxDays: 0 });
+  });
+
+  it('defaults the date field to local today when entering date mode without overwriting manual edits', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 27, 8, 30));
+    const { container } = renderModal({ syncStartDate: '', maxDays: 30 });
+
+    const [dateMode, daysMode] = Array.from(container.querySelectorAll('input[name="syncMode"]')) as HTMLInputElement[];
+
+    await act(() => {
+      dateMode.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    expect(dateInput).toBeTruthy();
+    expect(dateInput.value).toBe('2026-06-27');
+
+    await act(() => {
+      dateInput.value = '2026-06-12';
+      dateInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await act(() => {
+      daysMode.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await act(() => {
+      dateMode.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect((container.querySelector('input[type="date"]') as HTMLInputElement).value).toBe('2026-06-12');
   });
 
   it('prefers the stricter filter when both date and days are present: days', async () => {

--- a/tests/note-picker.spec.ts
+++ b/tests/note-picker.spec.ts
@@ -569,6 +569,37 @@ describe('NotePickerModal card layout (#138)', () => {
     const searchInput = container.querySelector('.getnote-picker-search input') as HTMLInputElement;
     expect(searchInput.value).toContain('工作');
   });
+
+  it('selects a note when clicking anywhere on its card', async () => {
+    const onConfirm = vi.fn();
+    const notes: GetNoteNote[] = [
+      makeNote({ note_id: 'card-click', title: '点击整卡选中' }),
+    ];
+    const container = await renderPickerWithNotes(notes, {
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    }, onConfirm);
+
+    const card = container.querySelector('.getnote-note-card') as HTMLElement;
+    expect(card).not.toBeNull();
+    expect(card.classList.contains('is-selected')).toBe(false);
+
+    await act(() => {
+      card.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const checkbox = card.querySelector('.getnote-note-card-checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(card.classList.contains('is-selected')).toBe(true);
+    expect(container.querySelector('.getnote-picker-count')?.textContent).toBe('已选 1 条');
+
+    await act(() => {
+      container.querySelector('.mod-cta')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith(['card-click'], undefined, []);
+  });
 });
 
 describe('NotePickerModal type label folding (#141 follow-up)', () => {

--- a/tests/note-picker.spec.ts
+++ b/tests/note-picker.spec.ts
@@ -570,6 +570,30 @@ describe('NotePickerModal card layout (#138)', () => {
     expect(searchInput.value).toContain('工作');
   });
 
+  it('does not toggle card selection when a tag chip handles keyboard activation', async () => {
+    const notes: GetNoteNote[] = [
+      makeNote({ note_id: 'tagged', title: '笔记', tags: [{ name: '工作' }] }),
+    ];
+    const container = await renderPickerWithNotes(notes, {
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    });
+
+    const tagButton = container.querySelector('.getnote-note-card-tag') as HTMLButtonElement;
+    const card = container.querySelector('.getnote-note-card') as HTMLElement;
+    const checkbox = card.querySelector('.getnote-note-card-checkbox') as HTMLInputElement;
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+
+    await act(() => {
+      tagButton.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(checkbox.checked).toBe(false);
+    expect(card.classList.contains('is-selected')).toBe(false);
+  });
+
   it('selects a note when clicking anywhere on its card', async () => {
     const onConfirm = vi.fn();
     const notes: GetNoteNote[] = [

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -123,6 +123,8 @@ function mockOpenExternal() {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   vi.mocked(fetchNotes).mockClear();
   initI18n('zh-CN');
   render(null, document.body);
@@ -520,6 +522,8 @@ describe('SettingsComponent auth credentials', () => {
   });
 
   it('reveals the inline start date editor when the reset button is clicked', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 27, 8, 30));
     const { container } = renderSettings(makeSettings({
       syncStartDate: '2026-01-01',
       lastSyncEndTimestamp: '2026-06-12T15:30:00+08:00',
@@ -539,7 +543,7 @@ describe('SettingsComponent auth credentials', () => {
     expect(editorRow).toBeTruthy();
     const dateInput = editorRow!.querySelector('input[type="date"]') as HTMLInputElement;
     expect(dateInput).toBeTruthy();
-    expect(dateInput.value).toBe('2026-01-01');
+    expect(dateInput.value).toBe('2026-06-27');
     expect(dateInput.readOnly).toBe(false);
 
     const saveButton = Array.from(container.querySelectorAll('button'))
@@ -652,7 +656,9 @@ describe('SettingsComponent auth credentials', () => {
     expect(checkpointRow!.textContent).toContain(expectedLocal);
   });
 
-  it('uses the previous syncStartDate as the default value when reset is clicked', async () => {
+  it('uses local today as the default value when reset is clicked', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 27, 8, 30));
     const { container } = renderSettings(makeSettings({
       syncStartDate: '2025-12-15',
       lastSyncEndTimestamp: '2026-06-12T15:30:00+08:00',
@@ -667,7 +673,7 @@ describe('SettingsComponent auth credentials', () => {
     const editorRow = Array.from(container.querySelectorAll('.getnote-scheduled-row'))
       .find(node => node.textContent?.includes('同步起始日期'));
     const dateInput = editorRow!.querySelector('input[type="date"]') as HTMLInputElement;
-    expect(dateInput.value).toBe('2025-12-15');
+    expect(dateInput.value).toBe('2026-06-27');
   });
 
   it('renders the attachment download section with a master toggle and four child toggles', async () => {

--- a/tests/topic-picker-modal.spec.ts
+++ b/tests/topic-picker-modal.spec.ts
@@ -658,6 +658,12 @@ describe('TopicPickerModal', () => {
     expect(container.textContent).toContain('同步该知识库的全部内容');
     expect(container.textContent).toContain('将同步全部内容');
     expect(container.querySelector('[data-topic-select-all]')).toBeNull();
+    expect(container.querySelector('.getnote-topic-filter-bar')).toBeNull();
+    expect(container.querySelector('[data-topic-search]')).toBeNull();
+    expect(container.querySelector('[data-topic-blogger-filter]')).toBeNull();
+    expect(container.querySelector('.getnote-note-card')).toBeNull();
+    expect(container.querySelector('.getnote-picker-body .getnote-topic-scope-hint')?.textContent)
+      .toContain('同步该知识库的全部内容');
     expect((container.querySelector('.mod-cta') as HTMLButtonElement).disabled).toBe(false);
     await act(async () => {
       (container.querySelector('.mod-cta') as HTMLButtonElement).click();

--- a/tests/topic-picker-modal.spec.ts
+++ b/tests/topic-picker-modal.spec.ts
@@ -676,6 +676,56 @@ describe('TopicPickerModal', () => {
     });
   });
 
+  it('does not forward hidden tag filters for all-content sync', async () => {
+    const onConfirm = vi.fn();
+    vi.mocked(fetchSubscribedTopics).mockResolvedValue([
+      { topic_id: 'luo', name: '罗振宇学习笔记' },
+    ]);
+    vi.mocked(fetchTopicContentPreviewPage).mockResolvedValue({
+      items: [
+        {
+          note_id: 'blogger_note-1',
+          title: '第一篇内容',
+          updated_at: '2026-06-01T10:00:00+08:00',
+          topic_id: 'luo',
+          tags: [{ name: 'AI' }],
+        },
+      ],
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(h(TopicPickerModal, {
+        token: 'token',
+        clientId: 'client',
+        authMode: 'openapi',
+        initialSyncTags: ['AI'],
+        tagOptions: ['AI'],
+        onConfirm,
+        onCancel: vi.fn(),
+      }), container);
+    });
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-topic-id="luo"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    await act(async () => {
+      (container.querySelector('[data-topic-scope-all]') as HTMLInputElement).click();
+    });
+    await act(async () => {
+      (container.querySelector('.mod-cta') as HTMLButtonElement).click();
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      syncAll: true,
+      topicIds: ['luo'],
+      knowledgeBaseName: '罗振宇学习笔记',
+    });
+  });
+
   it('allows all-content sync when the knowledge-base preview is empty', async () => {
     vi.mocked(fetchSubscribedTopics).mockResolvedValue([
       { topic_id: 'empty', name: '待完整同步的知识库' },


### PR DESCRIPTION
## Summary
- Also defaults the scheduled auto-sync checkpoint reset editor to the local current date.
- Fixes #164: default the manual sync date field to the local current date when entering date mode, without overwriting user edits.
- Fixes #165: allow clicking the whole note card to select it, with selected-card visual state and keyboard affordance.
- Fixes #166: hide per-content filters in knowledge-base all-content mode and move the all-content hint into the lower body panel.

## Validation
- npm test -- tests/settings.spec.ts
- npm test -- tests/manual-sync-modal.spec.ts tests/note-picker.spec.ts tests/topic-picker-modal.spec.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run test:e2e:openapi (environment-gated: 2 skipped)
- Built artifacts deployed to local Obsidian vault plugin directory `.obsidian/plugins/getnote-importer/` and SHA-256 hashes verified.
- Obsidian opened and `View > Force Reload` completed; plugin loaded in the test vault.

## Notes
- No package.json or manifest.json version bump.
- During Obsidian reload, the configured plugin startup behavior showed `[得到大脑] 同步开始...`; I did not continue interacting with the sync UI after that.
