### PR TITLE
[codex] Align scheduled sync toggle label

### DIFF
--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -672,8 +672,8 @@ export function SettingsComponent({
         description={t('settings.scheduled.desc')}
       >
         <div className="getnote-scheduled-control">
-          <div className="getnote-scheduled-row">
-            <span>{t('settings.scheduled.enabled')}</span>
+          <div className="getnote-scheduled-row getnote-scheduled-master-row">
+            <span className="getnote-scheduled-row-label">{t('settings.scheduled.enabled')}</span>
             <span className="getnote-scheduled-row-control">
               <Toggle
                 value={scheduledEnabled}

--- a/styles.css
+++ b/styles.css
@@ -502,12 +502,14 @@
 
 .getnote-scheduled-rows .getnote-scheduled-row-label {
   text-align: right;
+  font-weight: 400;
 }
 
 .getnote-scheduled-options .getnote-scheduled-row-label {
   text-align: right;
 }
 
+.getnote-scheduled-master-row .getnote-scheduled-row-label,
 .getnote-attachment-master-row .getnote-scheduled-row-label {
   text-align: left;
 }

--- a/tests/settings-layout.spec.ts
+++ b/tests/settings-layout.spec.ts
@@ -41,6 +41,12 @@ describe('settings layout CSS', () => {
     expect(syncLogLabels).toContain('text-align: right');
   });
 
+  it('keeps nested scheduled sync option labels at normal weight', () => {
+    const scheduledOptionLabels = ruleFor('.getnote-scheduled-rows .getnote-scheduled-row-label');
+
+    expect(scheduledOptionLabels).toContain('font-weight: 400');
+  });
+
   it('keeps long dropdown option labels aligned after wrapping', () => {
     const knowledgeInput = ruleFor('.getnote-knowledge-base-select-option input');
     const knowledgeLabel = ruleFor('.getnote-knowledge-base-select-option span');

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -1038,6 +1038,18 @@ describe('SettingsComponent scheduled sync toggles (#136)', () => {
     expect(innerCheckbox.checked).toBe(false);
   });
 
+  it('renders the scheduledEnabled label with the scheduled row label styling', () => {
+    const { container } = renderSettings(makeSettings({
+      scheduledSync: { ...DEFAULT_SETTINGS.scheduledSync, enabled: false },
+    }));
+
+    const row = findScheduledEnabledRow(container);
+    const label = row.querySelector(':scope > span:first-child');
+
+    expect(row.classList.contains('getnote-scheduled-master-row')).toBe(true);
+    expect(label?.classList.contains('getnote-scheduled-row-label')).toBe(true);
+  });
+
   it('renders syncOnStart as an Obsidian toggle inside the scheduled sync options', () => {
     const { container } = renderSettings(makeSettings({
       scheduledSync: { ...DEFAULT_SETTINGS.scheduledSync, enabled: true, syncOnStart: true },


### PR DESCRIPTION
## Summary
- align the scheduled sync master toggle label with the attachment master toggle row
- keep nested scheduled sync option labels at normal weight
- add regression coverage for the scheduled sync label styling and nested label weight

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- deployed locally to the enabled Obsidian plugin directory and verified artifact hashes
