### PR TITLE
[codex] docs(readme): add project background link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 把得到大脑（原Get笔记）里的灵感、摘录、链接、录音和 AI 总结与 Obsidian 双向同步，变成可长期整理、搜索和链接的本地 Markdown 知识库。
 
+想了解这个项目的由来和背景，可以阅读这篇文章：[为什么要做得到大脑 Obsidian 插件](https://mp.weixin.qq.com/s/0-d_jLOGr3OhanruPR52vg)。
 
 * * *
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -10,6 +10,7 @@
 
 Bidirectionally sync your notes, highlights, links, recordings, and AI summaries from Dedao Brain (得到大脑, formerly GetNote / Get笔记) into Obsidian as local Markdown files you can organize, search, and link over the long term.
 
+For the project background and origin story, see this Chinese article: [Project background](https://mp.weixin.qq.com/s/0-d_jLOGr3OhanruPR52vg).
 
 * * *
 


### PR DESCRIPTION
## Summary
- add the project background article link near the top of README.md
- add the same background link near the top of README_EN.md

Closes #173

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

No local Obsidian deployment was needed because this is a README-only documentation change.