### PR TITLE
[codex] fix tag whitelist normalization

### DIFF
--- a/src/utils/tag-aggregator.ts
+++ b/src/utils/tag-aggregator.ts
@@ -43,6 +43,17 @@ export function mergeTagNames(...groups: Array<readonly string[] | undefined>): 
   );
 }
 
+function normalizeTagWhitelist(whitelist: string[] | undefined): Set<string> | null {
+  if (!whitelist || whitelist.length === 0) return null;
+  const normalized = new Set<string>();
+  for (const name of whitelist) {
+    const trimmed = name?.trim();
+    if (!trimmed) continue;
+    normalized.add(trimmed.toLowerCase());
+  }
+  return normalized.size > 0 ? normalized : null;
+}
+
 /**
  * Merge an existing tag cache with newly observed tag names.
  * Existing tags are preserved; new tags are appended (case-insensitive dedup).
@@ -73,11 +84,8 @@ export function mergeTagCache(existing: TagCache | undefined, incoming: string[]
  *   tag name with the whitelist (case-insensitive comparison).
  */
 export function applyTagFilter(notes: GetNoteNote[], whitelist: string[] | undefined): GetNoteNote[] {
-  if (!whitelist || whitelist.length === 0) return notes;
-  const normalizedWhitelist = new Set(
-    whitelist.filter(Boolean).map(name => name.toLowerCase())
-  );
-  if (normalizedWhitelist.size === 0) return notes;
+  const normalizedWhitelist = normalizeTagWhitelist(whitelist);
+  if (!normalizedWhitelist) return notes;
   return notes.filter(note => {
     if (!Array.isArray(note.tags) || note.tags.length === 0) return false;
     return note.tags.some(tag => {
@@ -115,9 +123,9 @@ export function updateCacheFromNotes(cache: TagCache | undefined, notes: GetNote
  * Quick check whether a note has at least one tag in the whitelist.
  */
 export function noteMatchesTagWhitelist(note: GetNoteNote, whitelist: string[] | undefined): boolean {
-  if (!whitelist || whitelist.length === 0) return true;
+  const normalizedWhitelist = normalizeTagWhitelist(whitelist);
+  if (!normalizedWhitelist) return true;
   if (!Array.isArray(note.tags) || note.tags.length === 0) return false;
-  const normalizedWhitelist = new Set(whitelist.map(name => name.toLowerCase()));
   return note.tags.some(tag => {
     const name = tag?.name?.trim();
     return name ? normalizedWhitelist.has(name.toLowerCase()) : false;

--- a/tests/tag-aggregator.spec.ts
+++ b/tests/tag-aggregator.spec.ts
@@ -4,6 +4,7 @@ import {
   mergeTagCache,
   applyTagFilter,
   filterNotesByTags,
+  noteMatchesTagWhitelist,
   type TagCache,
 } from '../src/utils/tag-aggregator';
 import type { GetNoteNote } from '../src/types';
@@ -115,6 +116,11 @@ describe('tag-aggregator — applyTagFilter', () => {
     expect(result.map(n => n.note_id)).toEqual(['a']);
   });
 
+  it('trims whitelist values before matching tags', () => {
+    const result = applyTagFilter(notes, ['  work  ', '   ']);
+    expect(result.map(n => n.note_id)).toEqual(['a']);
+  });
+
   it('returns empty when whitelist tags do not exist on any note', () => {
     expect(applyTagFilter(notes, ['nonexistent'])).toEqual([]);
   });
@@ -128,5 +134,12 @@ describe('tag-aggregator — filterNotesByTags (re-exported alias)', () => {
     ];
     expect(filterNotesByTags(notes, ['x']).map(n => n.note_id)).toEqual(['a']);
     expect(filterNotesByTags(notes, [])).toHaveLength(2);
+  });
+});
+
+describe('tag-aggregator — noteMatchesTagWhitelist', () => {
+  it('uses the same trimming and case-insensitive rules as applyTagFilter', () => {
+    const note = makeNote({ note_id: 'a', tags: [{ name: 'Work' }] });
+    expect(noteMatchesTagWhitelist(note, ['  work  ', '   '])).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- normalize tag whitelist values in one shared helper before tag filtering
- make `applyTagFilter` and `noteMatchesTagWhitelist` follow the same trim + case-insensitive rules
- add regression tests for whitespace-padded whitelist values

## Why
Whitespace-padded tag filters could fail to match note tags even though note-side tag names were already trimmed. The normalization logic was also duplicated across two helpers, which made drift easier.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`