### PR TITLE
refactor(settings): reuse external browser helper

### DIFF
--- a/src/settings/oauth-button.tsx
+++ b/src/settings/oauth-button.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'preact/hooks';
 import { fetchOAuthDeviceCode, pollOAuthToken } from '../api';
 import { t } from '../i18n';
+import { openExternalUrl } from './external-link';
 
 interface OAuthButtonProps {
   onAuthorize: (apiToken: string, clientId: string) => void;
@@ -8,27 +9,6 @@ interface OAuthButtonProps {
 }
 
 type OAuthStep = 'idle' | 'opening' | 'code' | 'polling' | 'success' | 'error';
-
-type ElectronWindow = Window & {
-  require?: (moduleName: 'electron') => {
-    shell?: {
-      openExternal: (uri: string) => void;
-    };
-  };
-};
-
-function openVerificationPage(uri: string) {
-  try {
-    const electron = (window as ElectronWindow).require?.('electron');
-    if (electron?.shell) {
-      electron.shell.openExternal(uri);
-      return;
-    }
-  } catch {
-    // Fall back to window.open below.
-  }
-  window.open(uri, '_blank');
-}
 
 export function OAuthButton({ onAuthorize, onTestConnection }: OAuthButtonProps) {
   const [step, setStep] = useState<OAuthStep>('idle');
@@ -83,7 +63,7 @@ export function OAuthButton({ onAuthorize, onTestConnection }: OAuthButtonProps)
 
       // Let Obsidian render the user code first, then open the verification page.
       await new Promise(resolve => window.setTimeout(resolve, 0));
-      openVerificationPage(dc.verification_uri);
+      openExternalUrl(dc.verification_uri);
 
       // Step 2: poll for token
       setIsPolling(true);
@@ -139,7 +119,7 @@ export function OAuthButton({ onAuthorize, onTestConnection }: OAuthButtonProps)
 
   if (step === 'code') {
     const openBrowser = () => {
-      openVerificationPage(verificationUri);
+      openExternalUrl(verificationUri);
     };
     return (
       <div className="getnote-oauth-code-section">

--- a/tests/external-link.spec.ts
+++ b/tests/external-link.spec.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { openExternalUrl } from '../src/settings/external-link';
+
+type ElectronWindow = Window & {
+  require?: (moduleName: 'electron') => {
+    shell?: {
+      openExternal: (uri: string) => void;
+    };
+  };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as ElectronWindow).require;
+});
+
+describe('openExternalUrl', () => {
+  it('uses the Electron shell when available', () => {
+    const openExternal = vi.fn();
+    (window as ElectronWindow).require = vi.fn(() => ({ shell: { openExternal } }));
+    const windowOpen = vi.spyOn(window, 'open');
+
+    openExternalUrl('https://example.com/docs');
+
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/docs');
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it('falls back to window.open with noopener when Electron is unavailable', () => {
+    const windowOpen = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    openExternalUrl('https://example.com/docs');
+
+    expect(windowOpen).toHaveBeenCalledWith('https://example.com/docs', '_blank', 'noopener');
+  });
+});


### PR DESCRIPTION
## Summary
- reuse the existing external browser helper for OAuth verification links
- remove duplicated Electron/browser fallback logic from `OAuthButton`
- add focused coverage for the helper's Electron and `window.open` paths

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Debt scan notes
- Larger API transport/parsing duplication remains tracked in #178 and was intentionally not refactored in this low-risk pass.
