### PR TITLE
refactor(settings): share input suggest helper

### DIFF
--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -13,20 +13,26 @@ import { fetchNotes } from '../api';
 import { t } from '../i18n';
 import { ExternalLink } from './external-link';
 
-class FolderSuggest extends AbstractInputSuggest<string> {
-  private el: HTMLInputElement;
+type SuggestionProvider = (query: string) => string[];
 
-  constructor(app: App, inputEl: HTMLInputElement, onSelect: (value: string) => void) {
+class PathSuggest extends AbstractInputSuggest<string> {
+  private readonly el: HTMLInputElement;
+  private readonly getPaths: SuggestionProvider;
+
+  constructor(
+    app: App,
+    inputEl: HTMLInputElement,
+    getPaths: SuggestionProvider,
+    onSelect: (value: string) => void,
+  ) {
     super(app, inputEl);
     this.el = inputEl;
+    this.getPaths = getPaths;
     this.onSelect((value) => onSelect(value));
   }
 
   getSuggestions(query: string): string[] {
-    return this.app.vault
-      .getAllFolders()
-      .map(f => f.path)
-      .filter(path => !query || path.toLowerCase().includes(query.toLowerCase()));
+    return this.getPaths(query);
   }
 
   renderSuggestion(value: string, el: HTMLElement): void {
@@ -40,37 +46,25 @@ class FolderSuggest extends AbstractInputSuggest<string> {
   }
 }
 
-class TemplateFileSuggest extends AbstractInputSuggest<string> {
-  private el: HTMLInputElement;
+function getFolderSuggestions(app: App, query: string): string[] {
+  const normalizedQuery = (query ?? '').toLowerCase();
+  return app.vault
+    .getAllFolders()
+    .map(folder => folder.path)
+    .filter(path => !normalizedQuery || path.toLowerCase().includes(normalizedQuery));
+}
 
-  constructor(app: App, inputEl: HTMLInputElement, onSelect: (value: string) => void) {
-    super(app, inputEl);
-    this.el = inputEl;
-    this.onSelect((value) => onSelect(value));
-  }
-
-  getSuggestions(query: string): string[] {
-    const normalizedQuery = (query ?? '').trim().toLowerCase();
-    return Array.from(new Set(
-      this.app.vault
-        .getMarkdownFiles()
-        .map(file => file.path)
-        .filter(Boolean),
-    ))
-      .filter(path => !normalizedQuery || path.toLowerCase().includes(normalizedQuery))
-      .sort((a, b) => a.localeCompare(b))
-      .slice(0, 50);
-  }
-
-  renderSuggestion(value: string, el: HTMLElement): void {
-    el.setText(value);
-  }
-
-  selectSuggestion(value: string): void {
-    this.el.value = value;
-    this.el.dispatchEvent(new Event('input'));
-    this.close();
-  }
+function getTemplateFileSuggestions(app: App, query: string): string[] {
+  const normalizedQuery = (query ?? '').trim().toLowerCase();
+  return Array.from(new Set(
+    app.vault
+      .getMarkdownFiles()
+      .map(file => file.path)
+      .filter(Boolean),
+  ))
+    .filter(path => !normalizedQuery || path.toLowerCase().includes(normalizedQuery))
+    .sort((a, b) => a.localeCompare(b))
+    .slice(0, 50);
 }
 
 interface SettingsComponentProps {
@@ -219,7 +213,7 @@ export function SettingsComponent({
     const inputEl = folderInputRef.current;
     if (!inputEl) return;
 
-    const suggest = new FolderSuggest(app, inputEl, (value) => {
+    const suggest = new PathSuggest(app, inputEl, (query) => getFolderSuggestions(app, query), (value) => {
       setFolderName(value);
       updateSetting('folderName', value);
     });
@@ -231,7 +225,7 @@ export function SettingsComponent({
     const inputEl = templateFileInputRef.current;
     if (!inputEl) return;
 
-    const suggest = new TemplateFileSuggest(app, inputEl, (value) => {
+    const suggest = new PathSuggest(app, inputEl, (query) => getTemplateFileSuggestions(app, query), (value) => {
       setTemplateFilePath(value);
       updateSetting('templateFilePath', value);
     });

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -210,6 +210,47 @@ describe('SettingsComponent auth credentials', () => {
     expect(updateSetting).toHaveBeenCalledWith('templateFilePath', 'Templates/reading-note.md');
   });
 
+  it('suggests vault folders for the target folder path', async () => {
+    const app = new App();
+    vi.spyOn(app.vault, 'getAllFolders').mockReturnValue([
+      { path: 'Templates' } as any,
+      { path: '得到大脑' } as any,
+      { path: 'Projects/Archive' } as any,
+    ]);
+
+    let rendered!: ReturnType<typeof renderSettings>;
+    await act(async () => {
+      rendered = renderSettings(makeSettings(), vi.fn(), vi.fn(), { app });
+      await Promise.resolve();
+    });
+
+    const { container } = rendered;
+    const input = Array.from(container.querySelectorAll('input'))
+      .find((item): item is HTMLInputElement => item.placeholder === '得到大脑');
+    expect(input).toBeTruthy();
+
+    const folderSuggest = abstractInputSuggestInstances.find(instance => instance.inputEl === input);
+    expect(folderSuggest).toBeTruthy();
+    expect(folderSuggest!.getSuggestions('')).toEqual([
+      'Templates',
+      '得到大脑',
+      'Projects/Archive',
+    ]);
+    expect(folderSuggest!.getSuggestions('arch')).toEqual([
+      'Projects/Archive',
+    ]);
+
+    const inputListener = vi.fn();
+    input!.addEventListener('input', inputListener);
+    await act(() => {
+      folderSuggest!.selectSuggestion('Projects/Archive', new KeyboardEvent('keydown'));
+    });
+
+    expect(input!.value).toBe('Projects/Archive');
+    expect(inputListener).toHaveBeenCalledTimes(1);
+    expect(rendered.updateSetting).toHaveBeenCalledWith('folderName', 'Projects/Archive');
+  });
+
   it('suggests vault Markdown files for the template file path', async () => {
     const app = new App();
     vi.spyOn(app.vault, 'getMarkdownFiles').mockReturnValue([


### PR DESCRIPTION
## Summary
- deduplicate the folder and template input suggest implementations in `src/settings/index.tsx`
- keep folder and template suggestion rules in focused provider helpers instead of parallel class copies
- add regression coverage for folder suggestions and selection updates in `tests/settings.spec.ts`

## Audit findings
- Larger cross-module API transport/parsing duplication remains tracked in #178 and was intentionally left untouched because it exceeds the low-risk automation boundary.
- `src/settings/index.tsx` still has broader file-size pressure, but this pass only removed a local duplicated helper without changing sync or API semantics.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
