### PR TITLE
fix: refresh knowledge-base selector with latest auth mode

### DIFF
--- a/src/ui/knowledge-base-select.tsx
+++ b/src/ui/knowledge-base-select.tsx
@@ -31,6 +31,25 @@ interface AggregateState {
 
 const EMPTY_STATE: AggregateState = { loading: false, error: null, entries: [] };
 
+function createAggregator(
+  authModeRef: { current: AuthMode },
+  initialCache?: { entries: KnowledgeBaseEntry[]; cacheUpdatedAt?: number }
+): KnowledgeBaseAggregator {
+  return new KnowledgeBaseAggregator(
+    subscribedTopicsFetcher((fetchToken, fetchClientId, signal) =>
+      fetchSubscribedTopics({ token: fetchToken, clientId: fetchClientId, authMode: authModeRef.current, signal })
+    ),
+    initialCache ? {
+      cache: initialCache.entries,
+      cacheUpdatedAt: initialCache.cacheUpdatedAt,
+    } : undefined
+  );
+}
+
+function cacheIdentity(authMode: AuthMode, token: string, clientId: string): string {
+  return `${authMode}\n${token}\n${clientId}`;
+}
+
 function summarize(value: string[], entries: KnowledgeBaseEntry[]): string {
   if (value.length === 0) return t('settings.scheduled.syncKnowledgeBases.empty');
   if (entries.length > 0 && value.length === entries.length) return t('knowledgeBases.all');
@@ -64,6 +83,7 @@ export function KnowledgeBaseSelect({
   const aggregatorRef = useRef<KnowledgeBaseAggregator | null>(null);
   const initialCacheRef = useRef(initialCache);
   const authModeRef = useRef(authMode);
+  const cacheIdentityRef = useRef<string | null>(null);
 
   useEffect(() => {
     authModeRef.current = authMode;
@@ -71,15 +91,7 @@ export function KnowledgeBaseSelect({
 
   useEffect(() => {
     if (!aggregatorRef.current) {
-      aggregatorRef.current = new KnowledgeBaseAggregator(
-        subscribedTopicsFetcher((fetchToken, fetchClientId, signal) =>
-          fetchSubscribedTopics({ token: fetchToken, clientId: fetchClientId, authMode: authModeRef.current, signal })
-        ),
-        initialCacheRef.current ? {
-          cache: initialCacheRef.current.entries,
-          cacheUpdatedAt: initialCacheRef.current.cacheUpdatedAt,
-        } : undefined
-      );
+      aggregatorRef.current = createAggregator(authModeRef, initialCacheRef.current);
     }
   }, []);
 
@@ -110,12 +122,20 @@ export function KnowledgeBaseSelect({
       });
       return;
     }
+    const currentCacheIdentity = cacheIdentity(authMode, trimmedToken, trimmedClientId);
+    if (cacheIdentityRef.current !== null && cacheIdentityRef.current !== currentCacheIdentity) {
+      aggregatorRef.current = createAggregator(authModeRef);
+    }
     const aggregator = aggregatorRef.current;
     if (!aggregator) return;
 
     let cancelled = false;
     const cached = aggregator.exportCache();
-    if (cached.entries.length > 0 && (Date.now() - (cached.cacheUpdatedAt ?? 0)) < 5 * 60 * 1000) {
+    if (
+      cacheIdentityRef.current === currentCacheIdentity &&
+      cached.entries.length > 0 &&
+      (Date.now() - (cached.cacheUpdatedAt ?? 0)) < 5 * 60 * 1000
+    ) {
       setState({ loading: false, error: null, entries: cached.entries });
       return;
     }
@@ -125,6 +145,7 @@ export function KnowledgeBaseSelect({
       .refresh({ token: trimmedToken, clientId: trimmedClientId })
       .then(snapshot => {
         if (cancelled) return;
+        cacheIdentityRef.current = currentCacheIdentity;
         setState({ loading: false, error: null, entries: snapshot.entries });
         onCacheUpdate?.({ entries: snapshot.entries, cacheUpdatedAt: snapshot.cacheUpdatedAt ?? Date.now() });
       })

--- a/src/ui/knowledge-base-select.tsx
+++ b/src/ui/knowledge-base-select.tsx
@@ -30,6 +30,7 @@ interface AggregateState {
 }
 
 const EMPTY_STATE: AggregateState = { loading: false, error: null, entries: [] };
+const CACHE_TTL_MS = 5 * 60 * 1000;
 
 function createAggregator(
   authModeRef: { current: AuthMode },
@@ -128,6 +129,13 @@ export function KnowledgeBaseSelect({
       const seedCache = aggregatorIdentityRef.current === null ? initialCacheRef.current : undefined;
       aggregatorRef.current = createAggregator(authModeRef, seedCache);
       aggregatorIdentityRef.current = currentCacheIdentity;
+      cacheIdentityRef.current = (
+        seedCache?.entries.length &&
+        seedCache.cacheUpdatedAt &&
+        (Date.now() - seedCache.cacheUpdatedAt) < CACHE_TTL_MS
+      )
+        ? currentCacheIdentity
+        : null;
     }
     const aggregator = aggregatorRef.current;
     if (!aggregator) return;
@@ -137,7 +145,7 @@ export function KnowledgeBaseSelect({
     if (
       cacheIdentityRef.current === currentCacheIdentity &&
       cached.entries.length > 0 &&
-      (Date.now() - (cached.cacheUpdatedAt ?? 0)) < 5 * 60 * 1000
+      (Date.now() - (cached.cacheUpdatedAt ?? 0)) < CACHE_TTL_MS
     ) {
       setState({ loading: false, error: null, entries: cached.entries });
       return;

--- a/src/ui/knowledge-base-select.tsx
+++ b/src/ui/knowledge-base-select.tsx
@@ -63,12 +63,17 @@ export function KnowledgeBaseSelect({
   const [menuStyle, setMenuStyle] = useState<Record<string, string>>({});
   const aggregatorRef = useRef<KnowledgeBaseAggregator | null>(null);
   const initialCacheRef = useRef(initialCache);
+  const authModeRef = useRef(authMode);
+
+  useEffect(() => {
+    authModeRef.current = authMode;
+  }, [authMode]);
 
   useEffect(() => {
     if (!aggregatorRef.current) {
       aggregatorRef.current = new KnowledgeBaseAggregator(
         subscribedTopicsFetcher((fetchToken, fetchClientId, signal) =>
-          fetchSubscribedTopics({ token: fetchToken, clientId: fetchClientId, authMode, signal })
+          fetchSubscribedTopics({ token: fetchToken, clientId: fetchClientId, authMode: authModeRef.current, signal })
         ),
         initialCacheRef.current ? {
           cache: initialCacheRef.current.entries,

--- a/src/ui/knowledge-base-select.tsx
+++ b/src/ui/knowledge-base-select.tsx
@@ -83,6 +83,7 @@ export function KnowledgeBaseSelect({
   const aggregatorRef = useRef<KnowledgeBaseAggregator | null>(null);
   const initialCacheRef = useRef(initialCache);
   const authModeRef = useRef(authMode);
+  const aggregatorIdentityRef = useRef<string | null>(null);
   const cacheIdentityRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -123,8 +124,10 @@ export function KnowledgeBaseSelect({
       return;
     }
     const currentCacheIdentity = cacheIdentity(authMode, trimmedToken, trimmedClientId);
-    if (cacheIdentityRef.current !== null && cacheIdentityRef.current !== currentCacheIdentity) {
-      aggregatorRef.current = createAggregator(authModeRef);
+    if (aggregatorIdentityRef.current !== currentCacheIdentity) {
+      const seedCache = aggregatorIdentityRef.current === null ? initialCacheRef.current : undefined;
+      aggregatorRef.current = createAggregator(authModeRef, seedCache);
+      aggregatorIdentityRef.current = currentCacheIdentity;
     }
     const aggregator = aggregatorRef.current;
     if (!aggregator) return;
@@ -145,12 +148,14 @@ export function KnowledgeBaseSelect({
       .refresh({ token: trimmedToken, clientId: trimmedClientId })
       .then(snapshot => {
         if (cancelled) return;
+        if (aggregatorRef.current !== aggregator || aggregatorIdentityRef.current !== currentCacheIdentity) return;
         cacheIdentityRef.current = currentCacheIdentity;
         setState({ loading: false, error: null, entries: snapshot.entries });
         onCacheUpdate?.({ entries: snapshot.entries, cacheUpdatedAt: snapshot.cacheUpdatedAt ?? Date.now() });
       })
       .catch(err => {
         if (cancelled) return;
+        if (aggregatorRef.current !== aggregator || aggregatorIdentityRef.current !== currentCacheIdentity) return;
         setState({ loading: false, error: err instanceof Error ? err.message : String(err), entries: aggregator.list() });
       });
 

--- a/tests/knowledge-base-select.spec.ts
+++ b/tests/knowledge-base-select.spec.ts
@@ -208,4 +208,27 @@ describe('KnowledgeBaseSelect', () => {
     expect(container.textContent).toContain('OpenAPI 最新知识库');
     expect(container.textContent).not.toContain('Web 迟到知识库');
   });
+
+  it('uses a fresh seeded cache before refreshing unchanged credentials', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-05T11:00:00+08:00'));
+    vi.mocked(fetchSubscribedTopics).mockRejectedValue(new Error('offline'));
+
+    const { container } = renderSelect({
+      initialCache: {
+        entries: [{ topicId: 'cached-kb', name: '已缓存知识库', source: 'created' }],
+        cacheUpdatedAt: Date.now(),
+      },
+    });
+
+    await openDropdown(container);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchSubscribedTopics).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('已缓存知识库');
+    expect(container.textContent).not.toContain('Failed to load');
+  });
 });

--- a/tests/knowledge-base-select.spec.ts
+++ b/tests/knowledge-base-select.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { KnowledgeBaseSelect } from '../src/ui/knowledge-base-select';
+
+vi.mock('../src/api', () => ({
+  fetchSubscribedTopics: vi.fn(),
+}));
+
+import { fetchSubscribedTopics } from '../src/api';
+
+function renderSelect(props: Partial<Parameters<typeof KnowledgeBaseSelect>[0]> = {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const baseProps = {
+    value: [],
+    onChange: vi.fn(),
+    hasCredentials: true,
+    token: 'openapi-token',
+    clientId: 'openapi-client',
+    authMode: 'openapi' as const,
+  };
+
+  const rerender = (nextProps: Partial<Parameters<typeof KnowledgeBaseSelect>[0]> = {}) => {
+    render(h(KnowledgeBaseSelect, {
+      ...baseProps,
+      ...props,
+      ...nextProps,
+    }), container);
+  };
+
+  rerender();
+  return { container, rerender };
+}
+
+async function openDropdown(container: HTMLElement) {
+  const trigger = container.querySelector('.getnote-knowledge-base-select-trigger') as HTMLButtonElement;
+  expect(trigger).toBeTruthy();
+  await act(async () => {
+    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  render(null, document.body);
+  document.body.innerHTML = '';
+});
+
+describe('KnowledgeBaseSelect', () => {
+  it('uses the latest authMode when refetching after mode switches', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-05T11:00:00+08:00'));
+    vi.mocked(fetchSubscribedTopics).mockResolvedValue([{ topic_id: 'kb-1', name: '知识库 1', source: 'created' }]);
+
+    const { container, rerender } = renderSelect();
+
+    await openDropdown(container);
+
+    expect(fetchSubscribedTopics).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      token: 'openapi-token',
+      clientId: 'openapi-client',
+      authMode: 'openapi',
+    }));
+
+    vi.setSystemTime(new Date('2026-07-05T11:06:00+08:00'));
+    rerender({
+      authMode: 'web',
+      token: 'web-token',
+      clientId: '',
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchSubscribedTopics).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    }));
+  });
+});

--- a/tests/knowledge-base-select.spec.ts
+++ b/tests/knowledge-base-select.spec.ts
@@ -9,6 +9,14 @@ vi.mock('../src/api', () => ({
 
 import { fetchSubscribedTopics } from '../src/api';
 
+function deferredTopics() {
+  let resolve!: (value: Array<{ topic_id: string; name: string; source: 'created' | 'subscribed' }>) => void;
+  const promise = new Promise<Array<{ topic_id: string; name: string; source: 'created' | 'subscribed' }>>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function renderSelect(props: Partial<Parameters<typeof KnowledgeBaseSelect>[0]> = {}) {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -125,5 +133,79 @@ describe('KnowledgeBaseSelect', () => {
       await Promise.resolve();
     });
     expect(container.textContent).toContain('Web 知识库');
+  });
+
+  it('ignores a stale authMode refresh that resolves after switching back', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-05T11:00:00+08:00'));
+    const webRefresh = deferredTopics();
+    const openapiRefresh = deferredTopics();
+    vi.mocked(fetchSubscribedTopics)
+      .mockResolvedValueOnce([{ topic_id: 'openapi-original', name: 'OpenAPI 初始知识库', source: 'created' }])
+      .mockReturnValueOnce(webRefresh.promise)
+      .mockReturnValueOnce(openapiRefresh.promise);
+
+    const { container, rerender } = renderSelect();
+
+    await openDropdown(container);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('OpenAPI 初始知识库');
+
+    await act(async () => {
+      rerender({
+        authMode: 'web',
+        token: 'web-token',
+        clientId: '',
+      });
+      await Promise.resolve();
+    });
+    expect(fetchSubscribedTopics).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    }));
+
+    await act(async () => {
+      rerender({
+        authMode: 'openapi',
+        token: 'openapi-token',
+        clientId: 'openapi-client',
+      });
+      await Promise.resolve();
+    });
+    expect(fetchSubscribedTopics).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      token: 'openapi-token',
+      clientId: 'openapi-client',
+      authMode: 'openapi',
+    }));
+
+    await act(async () => {
+      openapiRefresh.resolve([{ topic_id: 'openapi-latest', name: 'OpenAPI 最新知识库', source: 'created' }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('OpenAPI 最新知识库');
+
+    await act(async () => {
+      webRefresh.resolve([{ topic_id: 'web-late', name: 'Web 迟到知识库', source: 'subscribed' }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('OpenAPI 最新知识库');
+    expect(container.textContent).not.toContain('Web 迟到知识库');
+
+    await openDropdown(container);
+    await openDropdown(container);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('OpenAPI 最新知识库');
+    expect(container.textContent).not.toContain('Web 迟到知识库');
   });
 });

--- a/tests/knowledge-base-select.spec.ts
+++ b/tests/knowledge-base-select.spec.ts
@@ -44,6 +44,7 @@ async function openDropdown(container: HTMLElement) {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.clearAllMocks();
   vi.restoreAllMocks();
   render(null, document.body);
   document.body.innerHTML = '';
@@ -81,5 +82,48 @@ describe('KnowledgeBaseSelect', () => {
       clientId: '',
       authMode: 'web',
     }));
+  });
+
+  it('does not reuse the fresh cache after switching authMode', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-05T11:00:00+08:00'));
+    vi.mocked(fetchSubscribedTopics)
+      .mockResolvedValueOnce([{ topic_id: 'openapi-kb', name: 'OpenAPI 知识库', source: 'created' }])
+      .mockResolvedValueOnce([{ topic_id: 'web-kb', name: 'Web 知识库', source: 'subscribed' }]);
+
+    const { container, rerender } = renderSelect();
+
+    await openDropdown(container);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('OpenAPI 知识库');
+    expect(fetchSubscribedTopics).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date('2026-07-05T11:01:00+08:00'));
+    await act(async () => {
+      rerender({
+        authMode: 'web',
+        token: 'web-token',
+        clientId: '',
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchSubscribedTopics).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('Web 知识库');
   });
 });


### PR DESCRIPTION
## Summary
- keep the knowledge-base dropdown fetcher aligned with the latest auth mode after settings switches
- add a focused regression test that waits for cache expiry before refetching
- leave larger architecture debt tracked separately in #178

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build