### PR TITLE
fix(settings): clear pending feedback timers

### DIFF
--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -134,6 +134,8 @@ export function SettingsComponent({
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [connectionErrorMsg, setConnectionErrorMsg] = useState('');
   const [connectionExpiryMin, setConnectionExpiryMin] = useState<number | null>(null);
+  const intervalWarningTimeoutRef = useRef<number | null>(null);
+  const connectionStatusTimeoutRef = useRef<number | null>(null);
   const [intervalWarning, setIntervalWarning] = useState(false);
   const credentials = getAuthCredentials({ ...settings, authMode, openApiToken: apiTokenOpenapi, openApiClientId: clientIdOpenapi, webApiToken: apiTokenWeb });
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
@@ -347,13 +349,19 @@ export function SettingsComponent({
     const n = parseInt(value, 10);
     if (isNaN(n) || n < 5) {
       setIntervalWarning(true);
+      if (intervalWarningTimeoutRef.current !== null) {
+        window.clearTimeout(intervalWarningTimeoutRef.current);
+      }
       updateSetting('scheduledSync', {
         ...settings.scheduledSync,
         enabledNoteTypes: scheduledNoteTypes,
         syncKnowledgeBases: scheduledKnowledgeBases,
         intervalMinutes: 5,
       });
-      window.setTimeout(() => setIntervalWarning(false), 3000);
+      intervalWarningTimeoutRef.current = window.setTimeout(() => {
+        setIntervalWarning(false);
+        intervalWarningTimeoutRef.current = null;
+      }, 3000);
     } else {
       updateSetting('scheduledSync', {
         ...settings.scheduledSync,
@@ -392,6 +400,10 @@ export function SettingsComponent({
     setConnectionStatus('idle');
     setConnectionErrorMsg('');
     setConnectionExpiryMin(null);
+    if (connectionStatusTimeoutRef.current !== null) {
+      window.clearTimeout(connectionStatusTimeoutRef.current);
+      connectionStatusTimeoutRef.current = null;
+    }
     const token = authMode === 'web' ? apiTokenWeb.trim() : apiTokenOpenapi.trim();
     const cid = authMode === 'web' ? '' : clientIdOpenapi.trim();
     try {
@@ -416,15 +428,34 @@ export function SettingsComponent({
         } catch { /* ignore */ }
       }
       setConnectionStatus('success');
-      window.setTimeout(() => { setConnectionStatus('idle'); setConnectionExpiryMin(null); }, 4000);
+      connectionStatusTimeoutRef.current = window.setTimeout(() => {
+        setConnectionStatus('idle');
+        setConnectionExpiryMin(null);
+        connectionStatusTimeoutRef.current = null;
+      }, 4000);
     } catch (err) {
       setConnectionStatus('error');
       setConnectionErrorMsg(err instanceof Error ? err.message : String(err));
-      window.setTimeout(() => { setConnectionStatus('idle'); setConnectionErrorMsg(''); }, 4000);
+      connectionStatusTimeoutRef.current = window.setTimeout(() => {
+        setConnectionStatus('idle');
+        setConnectionErrorMsg('');
+        connectionStatusTimeoutRef.current = null;
+      }, 4000);
     } finally {
       setTestingConnection(false);
     }
   };
+
+  useEffect(() => () => {
+    if (intervalWarningTimeoutRef.current !== null) {
+      window.clearTimeout(intervalWarningTimeoutRef.current);
+      intervalWarningTimeoutRef.current = null;
+    }
+    if (connectionStatusTimeoutRef.current !== null) {
+      window.clearTimeout(connectionStatusTimeoutRef.current);
+      connectionStatusTimeoutRef.current = null;
+    }
+  }, []);
 
   const currentApiToken = authMode === 'web' ? apiTokenWeb : apiTokenOpenapi;
   const currentClientId = clientIdOpenapi;

--- a/src/settings/oauth-button.tsx
+++ b/src/settings/oauth-button.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'preact/hooks';
+import { useState, useCallback, useEffect, useRef } from 'preact/hooks';
 import { fetchOAuthDeviceCode, pollOAuthToken } from '../api';
 import { t } from '../i18n';
 import { openExternalUrl } from './external-link';
@@ -19,10 +19,13 @@ export function OAuthButton({ onAuthorize, onTestConnection }: OAuthButtonProps)
   const [isPolling, setIsPolling] = useState(false);
   const [codeCopied, setCodeCopied] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
+  const feedbackTimeoutsRef = useRef<number[]>([]);
+  const successTimeoutRef = useRef<number | null>(null);
 
   const showCopiedFeedback = (setter: (v: boolean) => void) => {
     setter(true);
-    window.setTimeout(() => setter(false), 3000);
+    const timeoutId = window.setTimeout(() => setter(false), 3000);
+    feedbackTimeoutsRef.current.push(timeoutId);
   };
 
   const copyWithFeedback = (value: string, setter: (v: boolean) => void) => {
@@ -82,7 +85,7 @@ export function OAuthButton({ onAuthorize, onTestConnection }: OAuthButtonProps)
         setErrorMsg(testResult.message);
       } else {
         setStep('success');
-        window.setTimeout(() => setStep('idle'), 3000);
+        successTimeoutRef.current = window.setTimeout(() => setStep('idle'), 3000);
       }
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
@@ -94,6 +97,15 @@ export function OAuthButton({ onAuthorize, onTestConnection }: OAuthButtonProps)
       setErrorMsg(err instanceof Error ? err.message : t('oauth.error'));
     }
   };
+
+  useEffect(() => () => {
+    feedbackTimeoutsRef.current.forEach(timeoutId => window.clearTimeout(timeoutId));
+    feedbackTimeoutsRef.current = [];
+    if (successTimeoutRef.current !== null) {
+      window.clearTimeout(successTimeoutRef.current);
+      successTimeoutRef.current = null;
+    }
+  }, []);
 
   if (step === 'idle') {
     return (

--- a/tests/oauth-button.spec.ts
+++ b/tests/oauth-button.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { OAuthButton } from '../src/settings/oauth-button';
+import { fetchOAuthDeviceCode, pollOAuthToken } from '../src/api';
+import { initI18n } from '../src/i18n';
+
+vi.mock('../src/api', () => ({
+  fetchOAuthDeviceCode: vi.fn(),
+  pollOAuthToken: vi.fn(),
+}));
+
+vi.mock('../src/settings/external-link', () => ({
+  openExternalUrl: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  render(null, document.body);
+  document.body.innerHTML = '';
+  initI18n('zh-CN');
+});
+
+describe('OAuthButton lifecycle cleanup', () => {
+  it('clears the pending success timeout when unmounted', async () => {
+    initI18n('zh-CN');
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+    vi.mocked(fetchOAuthDeviceCode).mockResolvedValue({
+      verification_uri: 'https://biji.com/verify',
+      user_code: 'ABCD-1234',
+      code: 'dev_abc',
+      interval: 5,
+    });
+    vi.mocked(pollOAuthToken).mockResolvedValue({
+      api_key: 'gk_live_abc',
+      client_id: 'cli_123',
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    render(
+      h(OAuthButton, {
+        onAuthorize: vi.fn(),
+        onTestConnection: vi.fn().mockResolvedValue({ isMemberError: false, message: '' }),
+      }),
+      container
+    );
+
+    await act(async () => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('授权成功');
+
+    render(null, container);
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -487,6 +487,25 @@ describe('SettingsComponent auth credentials', () => {
     }));
   });
 
+  it('clears pending connection-status timeout when settings unmounts', async () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+    const { container } = renderSettings(makeSettings({
+      authMode: 'openapi',
+      openApiToken: 'gk-openapi-token',
+      openApiClientId: 'cli-openapi',
+    }));
+
+    await act(async () => {
+      getTestConnectionButton(container).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    render(null, container);
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
   it('runs the Web Token test-connection chain with Web credentials', async () => {
     const { container, updateSetting } = renderSettings(makeSettings({
       authMode: 'web',


### PR DESCRIPTION
## Summary
- clear pending settings warning and connection-status timers when the settings component unmounts or a new connection test starts
- clear pending OAuth copy/success feedback timers when the OAuth button unmounts
- add focused lifecycle cleanup coverage for settings and OAuth feedback flows

## Risk
- Low-risk settings UI lifecycle cleanup only
- Does not change sync semantics, vault writes, GetNote ID/timestamp handling, versions, or release artifacts

## Testing
- npm test -- tests/oauth-button.spec.ts tests/settings.spec.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build
