### PR TITLE
fix: clean markdown from note card previews

### DIFF
--- a/src/ui/card-preview.ts
+++ b/src/ui/card-preview.ts
@@ -1,0 +1,22 @@
+function stripMarkdownSyntax(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/^\s{0,3}>\s?/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/^\s*\d+[.)]\s+/gm, '')
+    .replace(/^\s*\|?[-:|\s]{3,}\|?\s*$/gm, ' ')
+    .replace(/\|/g, ' ')
+    .replace(/[*_~]{1,3}/g, '')
+    .replace(/<[^>]+>/g, ' ');
+}
+
+export function compactCardPreviewText(value: string | undefined, maxLength = 150): string {
+  const compacted = stripMarkdownSyntax(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return compacted.slice(0, maxLength);
+}

--- a/src/ui/note-picker-modal.tsx
+++ b/src/ui/note-picker-modal.tsx
@@ -7,6 +7,7 @@ import { formatNoteTypeLabel } from '../utils/note-type';
 import { NoteTypeSelect } from './note-type-select';
 import { TagSelect } from './tag-select';
 import { applyTagFilter, mergeTagNames } from '../utils/tag-aggregator';
+import { compactCardPreviewText } from './card-preview';
 
 interface NotePickerModalProps {
   onConfirm: (selectedNoteIds: string[], enabledNoteTypes?: string[], syncTags?: string[]) => void;
@@ -49,14 +50,10 @@ function matchesSearchQuery(note: GetNoteNote, searchQuery: string): boolean {
   return queryTokens.every(token => haystacks.some(value => value.toLowerCase().includes(token)));
 }
 
-function compactCardText(value: string | undefined): string {
-  return (value ?? '').replace(/\n+/g, ' ').trim();
-}
-
 function NoteRow({ note, checked, onChange, onTagClick }: { note: GetNoteNote; checked: boolean; onChange: (id: string, v: boolean) => void; onTagClick?: (tagName: string) => void }) {
   const title = generateDisplayTitle(note);
   const displayTitle = title || t('picker.noTitle');
-  const previewText = compactCardText(note.content).slice(0, 150);
+  const previewText = compactCardPreviewText(note.content);
   const toggleSelection = () => onChange(note.note_id, !checked);
   return (
     <div

--- a/src/ui/search-view.tsx
+++ b/src/ui/search-view.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import type { RecallSearchResult } from '../types';
 import { t } from '../i18n';
 import { formatNoteTypeLabel } from '../utils/note-type';
+import { compactCardPreviewText } from './card-preview';
 
 export interface SearchPanelProps {
   initialQuery?: string;
@@ -14,10 +15,6 @@ export interface SearchPanelProps {
 }
 
 type SyncState = 'idle' | 'syncing' | 'done' | 'failed';
-
-function compactText(value: string | undefined): string {
-  return (value ?? '').replace(/\s+/g, ' ').trim();
-}
 
 function formatSearchTime(result: RecallSearchResult): string {
   return result.updated_at || result.created_at || '';
@@ -141,7 +138,7 @@ export function SearchPanel({
           {results.map(result => {
             const localFile = resolveLocalFile(result.note_id);
             const state = syncState[result.note_id] ?? 'idle';
-            const preview = compactText(result.content);
+            const preview = compactCardPreviewText(result.content);
             return (
               <div className="getnote-note-card getnote-search-note-card" key={result.note_id}>
                 <div className="getnote-note-card-body">

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -5,6 +5,7 @@ import { fetchSubscribedTopics, fetchTopicContentPreviewPage } from '../api';
 import { t } from '../i18n';
 import { TagSelect } from './tag-select';
 import { mergeTagNames } from '../utils/tag-aggregator';
+import { compactCardPreviewText } from './card-preview';
 
 interface TopicData {
   topic: SubscribedTopic;
@@ -52,17 +53,13 @@ function formatRelativeTime(iso: string): string {
   }
 }
 
-function compactCardText(value: string | undefined): string {
-  return (value ?? '').replace(/\n+/g, ' ').trim();
-}
-
 function cardPreviewText(summary: string | undefined, content: string | undefined): { summaryText: string; previewText: string } {
-  const normalizedSummary = compactCardText(summary);
-  const normalizedContent = compactCardText(content);
+  const normalizedSummary = compactCardPreviewText(summary, 80);
+  const normalizedContent = compactCardPreviewText(content);
   const previewSource = normalizedContent || normalizedSummary;
   return {
-    summaryText: normalizedSummary && normalizedSummary !== previewSource ? normalizedSummary.slice(0, 80) : '',
-    previewText: previewSource.slice(0, 150),
+    summaryText: normalizedSummary && normalizedSummary !== previewSource ? normalizedSummary : '',
+    previewText: previewSource,
   };
 }
 

--- a/tests/note-picker.spec.ts
+++ b/tests/note-picker.spec.ts
@@ -527,6 +527,38 @@ describe('NotePickerModal card layout (#138)', () => {
     expect(time!.textContent).toBeTruthy();
   });
 
+  it('shows a readable plain-text preview instead of raw markdown syntax', async () => {
+    const notes: GetNoteNote[] = [
+      makeNote({
+        note_id: 'markdown-preview',
+        title: 'Markdown 预览',
+        content: [
+          '### 📑 智能总结',
+          '#### 录音信息',
+          '- **录音时间**：2026-07-10 10:57:38 ~ 2026-07-10 11:53:09',
+          '| 字段 | 内容 |',
+          '| --- | --- |',
+          '| 主题 | 数据湖会议 |',
+          '> 重点：不要把 Markdown 标记露在卡片里',
+        ].join('\n'),
+      }),
+    ];
+
+    const container = await renderPickerWithNotes(notes, {
+      token: 'web-token',
+      clientId: '',
+      authMode: 'web',
+    });
+
+    const preview = container.querySelector('.getnote-note-card-preview');
+    expect(preview?.textContent).toContain('智能总结 录音信息');
+    expect(preview?.textContent).toContain('录音时间：2026-07-10');
+    expect(preview?.textContent).toContain('主题 数据湖会议');
+    expect(preview?.textContent).not.toContain('###');
+    expect(preview?.textContent).not.toContain('**');
+    expect(preview?.textContent).not.toContain('| --- |');
+  });
+
   it('renders the card list as a single-column vertical layout (one card per row)', async () => {
     const notes: GetNoteNote[] = [
       makeNote({ note_id: 'row-1', title: '卡片 1' }),


### PR DESCRIPTION
## Summary
- clean markdown syntax from note picker, topic picker, and search card previews
- share preview compacting logic across card surfaces
- add regression coverage for markdown-heavy note previews

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build