### PR TITLE
[codex] refactor clarified issue helpers

### DIFF
--- a/src/api-clients/api-client-utils.ts
+++ b/src/api-clients/api-client-utils.ts
@@ -1,0 +1,45 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function normalizeBearerToken(token: string): string {
+  const trimmed = token.trim();
+  return /^Bearer\s+/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
+}
+
+export function parseJsonPreservingIds(text: string): unknown {
+  let safe = text.replace(
+    /"(id|note_id|prime_id|parent_id|follow_id|live_id|topic_id|post_id|post_id_alias)"\s*:\s*(\d+)/g,
+    '"$1":"$2"'
+  );
+  safe = safe.replace(/"children_ids"\s*:\s*\[([^\]]*)\]/g, (_match, body: string) => {
+    const normalized = body
+      .split(',')
+      .map(item => {
+        const trimmed = item.trim();
+        return /^\d{15,}$/.test(trimmed) ? `"${trimmed}"` : item;
+      })
+      .join(',');
+    return `"children_ids":[${normalized}]`;
+  });
+  return JSON.parse(safe);
+}
+
+export function parseJsonObjectOrEmpty(text: string): Record<string, unknown> {
+  try {
+    const value = parseJsonPreservingIds(text || '{}');
+    return isRecord(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function waitForRetryDelay(signal?: AbortSignal): Promise<void> {
+  await new Promise<void>(resolve => {
+    const timer = window.setTimeout(() => resolve(), 3000);
+    signal?.addEventListener('abort', () => {
+      window.clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}

--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -1,5 +1,6 @@
 import type { GetNoteNote, Attachment, LinkOriginal, RecallSearchResult, SubscribedTopic, ApiQuotaState } from '../types';
 import { t } from '../i18n';
+import { isRecord, normalizeBearerToken, parseJsonObjectOrEmpty, parseJsonPreservingIds, waitForRetryDelay } from './api-client-utils';
 
 export const GETNOTE_LIST_LIMIT = 20;
 
@@ -11,33 +12,6 @@ export function getLastQuotaState(): ApiQuotaState {
 }
 export function resetQuotaState(): void {
   lastQuota = { exhausted: false };
-}
-
-function safeJsonParse(text: string): unknown {
-  let safe = text.replace(
-    /"(id|note_id|parent_id|follow_id|live_id|topic_id|post_id|post_id_alias)"\s*:\s*(\d+)/g,
-    '"$1":"$2"'
-  );
-  safe = safe.replace(/"children_ids"\s*:\s*\[([^\]]*)\]/g, (_match, body: string) => {
-    const normalized = body
-      .split(',')
-      .map(item => {
-        const trimmed = item.trim();
-        return /^\d{15,}$/.test(trimmed) ? `"${trimmed}"` : item;
-      })
-      .join(',');
-    return `"children_ids":[${normalized}]`;
-  });
-  return JSON.parse(safe);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
-
-function normalizeBearerToken(token: string): string {
-  const trimmed = token.trim();
-  return /^Bearer\s+/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
 }
 
 function buildHeaders(token: string, clientId: string): Record<string, string> {
@@ -136,23 +110,8 @@ function normalizeNoteDetailData(value: unknown): Partial<GetNoteNote> | null {
   return { ...detail, attachments, audio, linkOriginal, children_ids: childrenIds };
 }
 
-async function waitForRetry(signal?: AbortSignal): Promise<void> {
-  await new Promise<void>(resolve => {
-    const timer = window.setTimeout(() => resolve(), 3000);
-    signal?.addEventListener('abort', () => {
-      window.clearTimeout(timer);
-      resolve();
-    }, { once: true });
-  });
-}
-
 function parseErrorBody(text: string): Record<string, unknown> {
-  try {
-    const value = safeJsonParse(text);
-    return isRecord(value) ? value : {};
-  } catch {
-    return {};
-  }
+  return parseJsonObjectOrEmpty(text);
 }
 
 async function handleRateLimit<T>(
@@ -171,7 +130,7 @@ async function handleRateLimit<T>(
     throw new Error(t('error.quotaExceeded'));
   }
   if (retries > 0) {
-    await waitForRetry(signal);
+    await waitForRetryDelay(signal);
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     return apiRequest(url, options, retries - 1, signal);
   }
@@ -186,7 +145,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
   if (res.status === 429) return handleRateLimit<T>(url, options, res, retries, signal);
   if (res.status < 200 || res.status >= 300) {
     const text = await res.text();
-    const json = safeJsonParse(text) as Record<string, unknown>;
+    const json = parseJsonPreservingIds(text) as Record<string, unknown>;
     if (res.status === 403 && json.success === false) {
       const errObj = (json.error ?? json) as Record<string, unknown>;
       const code = errObj?.code as number | undefined;
@@ -195,14 +154,14 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
     throw new Error(t('error.apiServerError', { status: res.status }));
   }
   const text = await res.text();
-  const json = safeJsonParse(text) as Record<string, unknown>;
+  const json = parseJsonPreservingIds(text) as Record<string, unknown>;
   // Handle HTTP 200 with business-level errors
   if (json.success === false) {
     const errObj = (json.error ?? json) as Record<string, unknown>;
     const code = errObj?.code as number | undefined;
     if (code === 10201) throw new Error(t('error.openApiNotMember'));
     if (code === 10202 && retries > 0) {
-      await waitForRetry(signal);
+      await waitForRetryDelay(signal);
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       return apiRequest(url, options, retries - 1, signal);
     }

--- a/src/api-clients/webapi-client.ts
+++ b/src/api-clients/webapi-client.ts
@@ -1,14 +1,6 @@
 import type { GetNoteNote, Attachment, LinkOriginal, SubscribedTopic } from '../types';
 import { t } from '../i18n';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
-
-function normalizeBearerToken(token: string): string {
-  const trimmed = token.trim();
-  return /^Bearer\s+/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
-}
+import { isRecord, normalizeBearerToken, parseJsonObjectOrEmpty, parseJsonPreservingIds, waitForRetryDelay } from './api-client-utils';
 
 function buildHeaders(token: string): Record<string, string> {
   return {
@@ -97,30 +89,7 @@ function normalizeLinkOriginal(value: unknown): LinkOriginal | null {
 }
 
 function tryParseJsonObject(text: string): Record<string, unknown> {
-  try {
-    const value = safeJsonParse(text || '{}');
-    return isRecord(value) ? value : {};
-  } catch {
-    return {};
-  }
-}
-
-function safeJsonParse(text: string): unknown {
-  const safe = text.replace(
-    /"(id|note_id|prime_id|parent_id|follow_id|live_id)"\s*:\s*(\d+)/g,
-    '"$1":"$2"'
-  );
-  return JSON.parse(safe);
-}
-
-async function waitForRetry(signal?: AbortSignal): Promise<void> {
-  await new Promise<void>(resolve => {
-    const timer = window.setTimeout(() => resolve(), 3000);
-    signal?.addEventListener('abort', () => {
-      window.clearTimeout(timer);
-      resolve();
-    }, { once: true });
-  });
+  return parseJsonObjectOrEmpty(text);
 }
 
 async function handleRateLimit<T>(
@@ -138,7 +107,7 @@ async function handleRateLimit<T>(
     throw new Error(t('error.quotaExceeded'));
   }
   if (retries > 0) {
-    await waitForRetry(signal);
+    await waitForRetryDelay(signal);
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     return apiRequest(url, options, retries - 1, signal);
   }
@@ -159,14 +128,14 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
   if (res.status === 429) return handleRateLimit<T>(url, options, res, retries, signal);
   if (res.status < 200 || res.status >= 300) {
     if (res.status >= 500 && retries > 0) {
-      await waitForRetry(signal);
+      await waitForRetryDelay(signal);
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       return apiRequest(url, options, retries - 1, signal);
     }
     throw new Error(t('error.apiServerError', { status: res.status }));
   }
   const text = await res.text();
-  const json = safeJsonParse(text) as Record<string, unknown>;
+  const json = parseJsonPreservingIds(text) as Record<string, unknown>;
   if (json.success === false) {
     const err = (json.error ?? json) as Record<string, unknown>;
     const errMsg = (err?.message as string) ?? (json.message as string) ?? '';

--- a/src/sync-paths.ts
+++ b/src/sync-paths.ts
@@ -1,0 +1,45 @@
+import { t } from './i18n';
+import { generateDisplayTitle, formatTimestampPrefix } from './note-parser';
+import type { GetNoteNote, Settings } from './types';
+
+export function getKnowledgeBaseDir(name: string): string {
+  const safeName = name.replace(/[\\/:*?"<>|]/g, '_').trim() || t('picker.noTitle');
+  return `知识库/${safeName}`;
+}
+
+export function buildNoteBaseName(note: GetNoteNote, settings: Pick<Settings, 'filenamePrefix'>): string {
+  const rawTitle = generateDisplayTitle(note);
+  const displayTitle = rawTitle || t('picker.noTitle');
+  const prefix = settings.filenamePrefix?.trim();
+  if (!prefix) return displayTitle;
+
+  const hasTimestampTokens = /YYYY|MM|DD|HH|mm|ss/.test(prefix);
+  if (hasTimestampTokens) {
+    const formattedPrefix = formatTimestampPrefix(prefix, note.created_at);
+    if (!formattedPrefix) {
+      return displayTitle;
+    }
+    const separator = formattedPrefix.endsWith('_') ? '' : '_';
+    return `${formattedPrefix}${separator}${displayTitle}`;
+  }
+
+  const separator = prefix.endsWith('_') ? '' : '_';
+  return `${prefix}${separator}${displayTitle}`;
+}
+
+export function getFileName(note: GetNoteNote, settings: Pick<Settings, 'filenamePrefix'>, parentBaseName?: string): string {
+  if (parentBaseName) {
+    const childTitle = generateDisplayTitle(note) || t('picker.noTitle');
+    return `${parentBaseName}__${childTitle}`;
+  }
+  return buildNoteBaseName(note, settings);
+}
+
+export function getAudioAssetBaseName(note: GetNoteNote, settings: Pick<Settings, 'filenamePrefix'>): string {
+  const safeNoteId = note.note_id.replace(/[\\/:*?"<>|]/g, '_');
+  return `${getFileName(note, settings)}_${safeNoteId}`;
+}
+
+export function getFilePath(categoryDir: string, note: GetNoteNote, settings: Pick<Settings, 'filenamePrefix'>): string {
+  return `${categoryDir}/${getFileName(note, settings)}.md`;
+}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { fetchAllNotes, fetchNoteChildren, fetchNoteDetail, fetchNoteOriginal, fetchSubscribedKnowledgeNotes } from './api';
-import { formatDateTime, formatTimestampPrefix, renderNote, renderNoteWithTemplate, generateDisplayTitle } from './note-parser';
+import { formatDateTime, renderNote, renderNoteWithTemplate, generateDisplayTitle } from './note-parser';
 import { getCategoryDir } from './types';
 import { getAuthCredentials, type GetNoteNote, type Settings, type SyncResult, type SyncResultItem, type SyncScopeOptions } from './types';
 import { applyTagFilter } from './utils/tag-aggregator';
@@ -8,6 +8,13 @@ import type { SyncModal } from './ui/sync-modal';
 import { t } from './i18n';
 import { tryWriteBinary } from './utils/vault-fs';
 import { classifyAttachmentUrl, isAttachmentTypeEnabled } from './utils/attachments';
+import {
+  buildNoteBaseName,
+  getAudioAssetBaseName,
+  getFileName,
+  getFilePath,
+  getKnowledgeBaseDir,
+} from './sync-paths';
 
 const AUDIO_NOTE_TYPES = new Set([
   'recorder_audio',
@@ -193,46 +200,23 @@ export class SyncEngine {
   }
 
   private getKnowledgeBaseDir(name: string): string {
-    const safeName = name.replace(/[\\/:*?"<>|]/g, '_').trim() || t('picker.noTitle');
-    return `知识库/${safeName}`;
+    return getKnowledgeBaseDir(name);
   }
 
   private buildBaseName(note: GetNoteNote): string {
-    const rawTitle = generateDisplayTitle(note);
-    const displayTitle = rawTitle || t('picker.noTitle');
-    const prefix = this.settings.filenamePrefix?.trim();
-    if (!prefix) return displayTitle;
-
-    const hasTimestampTokens = /YYYY|MM|DD|HH|mm|ss/.test(prefix);
-    if (hasTimestampTokens) {
-      const formattedPrefix = formatTimestampPrefix(prefix, note.created_at);
-      if (!formattedPrefix) {
-        return displayTitle;
-      }
-      const separator = formattedPrefix.endsWith('_') ? '' : '_';
-      return `${formattedPrefix}${separator}${displayTitle}`;
-    }
-
-    const separator = prefix.endsWith('_') ? '' : '_';
-    return `${prefix}${separator}${displayTitle}`;
+    return buildNoteBaseName(note, this.settings);
   }
 
   private getFileName(note: GetNoteNote, parentBaseName?: string): string {
-    // 子文档用父文档 baseName + 子文档标题，不用 note_id
-    if (parentBaseName) {
-      const childTitle = generateDisplayTitle(note) || t('picker.noTitle');
-      return `${parentBaseName}__${childTitle}`;
-    }
-    return this.buildBaseName(note);
+    return getFileName(note, this.settings, parentBaseName);
   }
 
   private getAudioAssetBaseName(note: GetNoteNote): string {
-    const safeNoteId = note.note_id.replace(/[\\/:*?"<>|]/g, '_');
-    return `${this.getFileName(note)}_${safeNoteId}`;
+    return getAudioAssetBaseName(note, this.settings);
   }
 
   private getFilePath(categoryDir: string, note: GetNoteNote): string {
-    return `${categoryDir}/${this.getFileName(note)}.md`;
+    return getFilePath(categoryDir, note, this.settings);
   }
 
   private resolveConflict(categoryDir: string, baseName: string): string {

--- a/src/ui/knowledge-base-select.tsx
+++ b/src/ui/knowledge-base-select.tsx
@@ -7,6 +7,7 @@ import {
 } from '../utils/knowledge-base-aggregator';
 import { fetchSubscribedTopics } from '../api';
 import type { AuthMode } from '../types';
+import { useFloatingSelectMenu } from './use-floating-select-menu';
 
 interface KnowledgeBaseSelectProps {
   /** Selected knowledge-base topic ids (empty = cross-KB sync disabled). */
@@ -72,15 +73,12 @@ export function KnowledgeBaseSelect({
   initialCache,
   onCacheUpdate,
 }: KnowledgeBaseSelectProps) {
-  const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [state, setState] = useState<AggregateState>(() => ({
     ...EMPTY_STATE,
     entries: initialCache?.entries ?? [],
   }));
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [menuStyle, setMenuStyle] = useState<Record<string, string>>({});
+  const { open, rootRef, triggerRef, menuStyle, toggleOpen } = useFloatingSelectMenu<HTMLButtonElement>();
   const aggregatorRef = useRef<KnowledgeBaseAggregator | null>(null);
   const initialCacheRef = useRef(initialCache);
   const authModeRef = useRef(authMode);
@@ -95,12 +93,6 @@ export function KnowledgeBaseSelect({
     if (!aggregatorRef.current) {
       aggregatorRef.current = createAggregator(authModeRef, initialCacheRef.current);
     }
-  }, []);
-
-  useEffect(() => {
-    const close = () => setOpen(false);
-    window.addEventListener('getnote-close-floating-selects', close);
-    return () => window.removeEventListener('getnote-close-floating-selects', close);
   }, []);
 
   useEffect(() => {
@@ -172,32 +164,6 @@ export function KnowledgeBaseSelect({
     };
   }, [open, hasCredentials, token, clientId, authMode, onCacheUpdate]);
 
-  useEffect(() => {
-    if (!open) return;
-    const positionMenu = () => {
-      const rect = triggerRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      setMenuStyle({
-        top: `${rect.bottom + 4}px`,
-        left: `${rect.left}px`,
-        width: `${rect.width}px`,
-      });
-    };
-    const handlePointerDown = (event: MouseEvent) => {
-      if (rootRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
-    };
-    positionMenu();
-    document.addEventListener('mousedown', handlePointerDown);
-    window.addEventListener('resize', positionMenu);
-    window.addEventListener('scroll', positionMenu, true);
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      window.removeEventListener('resize', positionMenu);
-      window.removeEventListener('scroll', positionMenu, true);
-    };
-  }, [open]);
-
   const filtered = useMemo(() => {
     const lower = query.trim().toLowerCase();
     if (!lower) return state.entries;
@@ -230,10 +196,7 @@ export function KnowledgeBaseSelect({
         ref={triggerRef}
         type="button"
         className="getnote-knowledge-base-select-trigger"
-        onClick={() => {
-          if (!open) window.dispatchEvent(new Event('getnote-close-floating-selects'));
-          setOpen(!open);
-        }}
+        onClick={toggleOpen}
       >
         <span>{triggerLabel}</span>
         <span aria-hidden="true" className={`getnote-knowledge-base-select-caret${open ? ' is-open' : ''}`} />

--- a/src/ui/note-type-select.tsx
+++ b/src/ui/note-type-select.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { t } from '../i18n';
 import { INTERNAL_AUDIO_NOTE_TYPES } from '../types';
+import { useFloatingSelectMenu } from './use-floating-select-menu';
 
 // 顶层 UI 仅 5 个 group。订阅博主（blogger_post）从 UI 选项移除但仍默认同步。
 // 9 种内部 audio 类型合并到"录音笔记"组；sync.ts 的 AUDIO_NOTE_TYPES 保持 9 种不变以解耦。
@@ -38,11 +39,8 @@ interface NoteTypeSelectProps {
 }
 
 export function NoteTypeSelect({ value, onChange }: NoteTypeSelectProps) {
-  const [open, setOpen] = useState(false);
   const [visibleValue, setVisibleValue] = useState<string[] | undefined>(value);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [menuStyle, setMenuStyle] = useState<Record<string, string>>({});
+  const { open, rootRef, triggerRef, menuStyle, toggleOpen } = useFloatingSelectMenu<HTMLButtonElement>();
   const allNoteTypes = NOTE_TYPE_OPTIONS.flatMap(option => option.noteTypes);
   const selectedTypes = visibleValue ?? allNoteTypes;
   const allSelected = visibleValue === undefined || selectedTypes.length === allNoteTypes.length;
@@ -51,38 +49,6 @@ export function NoteTypeSelect({ value, onChange }: NoteTypeSelectProps) {
   useEffect(() => {
     setVisibleValue(value);
   }, [value]);
-
-  useEffect(() => {
-    const close = () => setOpen(false);
-    window.addEventListener('getnote-close-floating-selects', close);
-    return () => window.removeEventListener('getnote-close-floating-selects', close);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-    const positionMenu = () => {
-      const rect = triggerRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      setMenuStyle({
-        top: `${rect.bottom + 4}px`,
-        left: `${rect.left}px`,
-        width: `${rect.width}px`,
-      });
-    };
-    const handlePointerDown = (event: MouseEvent) => {
-      if (rootRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
-    };
-    positionMenu();
-    document.addEventListener('mousedown', handlePointerDown);
-    window.addEventListener('resize', positionMenu);
-    window.addEventListener('scroll', positionMenu, true);
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      window.removeEventListener('resize', positionMenu);
-      window.removeEventListener('scroll', positionMenu, true);
-    };
-  }, [open]);
 
   const applyChange = (next: string[] | undefined) => {
     setVisibleValue(next);
@@ -104,10 +70,7 @@ export function NoteTypeSelect({ value, onChange }: NoteTypeSelectProps) {
         ref={triggerRef}
         type="button"
         className="getnote-note-type-select-trigger"
-        onClick={() => {
-          if (!open) window.dispatchEvent(new Event('getnote-close-floating-selects'));
-          setOpen(!open);
-        }}
+        onClick={toggleOpen}
       >
         <span>{visibleValue === undefined ? t('noteTypes.all') : summarizeTypes(visibleValue)}</span>
         <span

--- a/src/ui/tag-select.tsx
+++ b/src/ui/tag-select.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import { t } from '../i18n';
+import { useFloatingSelectMenu } from './use-floating-select-menu';
 
 interface TagSelectProps {
   /**
@@ -38,11 +39,8 @@ function matchesFilter(tag: string, query: string): boolean {
 }
 
 export function TagSelect({ value, onChange, options, placeholder, allowCreate = true, onCreateTag }: TagSelectProps) {
-  const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [menuStyle, setMenuStyle] = useState<Record<string, string>>({});
+  const { open, rootRef, triggerRef, menuStyle, toggleOpen } = useFloatingSelectMenu<HTMLButtonElement>();
 
   const selectedSet = new Set(value);
   const allSelected = value.length === 0;
@@ -85,48 +83,13 @@ export function TagSelect({ value, onChange, options, placeholder, allowCreate =
     }
   };
 
-  useEffect(() => {
-    const close = () => setOpen(false);
-    window.addEventListener('getnote-close-floating-selects', close);
-    return () => window.removeEventListener('getnote-close-floating-selects', close);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-    const positionMenu = () => {
-      const rect = triggerRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      setMenuStyle({
-        top: `${rect.bottom + 4}px`,
-        left: `${rect.left}px`,
-        width: `${rect.width}px`,
-      });
-    };
-    const handlePointerDown = (event: MouseEvent) => {
-      if (rootRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
-    };
-    positionMenu();
-    document.addEventListener('mousedown', handlePointerDown);
-    window.addEventListener('resize', positionMenu);
-    window.addEventListener('scroll', positionMenu, true);
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      window.removeEventListener('resize', positionMenu);
-      window.removeEventListener('scroll', positionMenu, true);
-    };
-  }, [open]);
-
   return (
     <div className="getnote-tag-select" ref={rootRef}>
       <button
         ref={triggerRef}
         type="button"
         className="getnote-tag-select-trigger"
-        onClick={() => {
-          if (!open) window.dispatchEvent(new Event('getnote-close-floating-selects'));
-          setOpen(!open);
-        }}
+        onClick={toggleOpen}
       >
         <span>{summarize(value)}</span>
         <span

--- a/src/ui/use-floating-select-menu.ts
+++ b/src/ui/use-floating-select-menu.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+const CLOSE_FLOATING_SELECTS_EVENT = 'getnote-close-floating-selects';
+
+export function useFloatingSelectMenu<TTrigger extends HTMLElement>() {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<TTrigger>(null);
+  const [menuStyle, setMenuStyle] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const close = () => setOpen(false);
+    window.addEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+    return () => window.removeEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const positionMenu = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setMenuStyle({
+        top: `${rect.bottom + 4}px`,
+        left: `${rect.left}px`,
+        width: `${rect.width}px`,
+      });
+    };
+    const handlePointerDown = (event: MouseEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    positionMenu();
+    document.addEventListener('mousedown', handlePointerDown);
+    window.addEventListener('resize', positionMenu);
+    window.addEventListener('scroll', positionMenu, true);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      window.removeEventListener('resize', positionMenu);
+      window.removeEventListener('scroll', positionMenu, true);
+    };
+  }, [open]);
+
+  const toggleOpen = () => {
+    if (!open) window.dispatchEvent(new Event(CLOSE_FLOATING_SELECTS_EVENT));
+    setOpen(!open);
+  };
+
+  return {
+    open,
+    setOpen,
+    rootRef,
+    triggerRef,
+    menuStyle,
+    toggleOpen,
+  };
+}

--- a/tests/api-client-utils.spec.ts
+++ b/tests/api-client-utils.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isRecord, normalizeBearerToken, parseJsonObjectOrEmpty, parseJsonPreservingIds } from '../src/api-clients/api-client-utils';
+
+describe('api client shared transport primitives', () => {
+  it('parses GetNote numeric identifiers as strings without losing precision', () => {
+    const result = parseJsonPreservingIds(
+      '{"id":9007199254740999,"note_id":123456789012345678,"prime_id":1909246675068292528,"post_id_alias":1908043831896764336,"children_ids":[1909246675068292528,42]}'
+    ) as Record<string, unknown>;
+
+    expect(result.id).toBe('9007199254740999');
+    expect(result.note_id).toBe('123456789012345678');
+    expect(result.prime_id).toBe('1909246675068292528');
+    expect(result.post_id_alias).toBe('1908043831896764336');
+    expect(result.children_ids).toEqual(['1909246675068292528', 42]);
+  });
+
+  it('returns an empty object for invalid or non-object error bodies', () => {
+    expect(parseJsonObjectOrEmpty('not json')).toEqual({});
+    expect(parseJsonObjectOrEmpty('[]')).toEqual({});
+    expect(parseJsonObjectOrEmpty('{"reason":"quota_day"}')).toEqual({ reason: 'quota_day' });
+  });
+
+  it('shares record and bearer-token normalization helpers without policy semantics', () => {
+    expect(isRecord({ ok: true })).toBe(true);
+    expect(isRecord([])).toBe(false);
+    expect(normalizeBearerToken('abc')).toBe('Bearer abc');
+    expect(normalizeBearerToken('Bearer abc')).toBe('Bearer abc');
+  });
+});

--- a/tests/floating-select-menu.spec.ts
+++ b/tests/floating-select-menu.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { NoteTypeSelect } from '../src/ui/note-type-select';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  render(null, document.body);
+  document.body.innerHTML = '';
+});
+
+describe('floating select menu behavior', () => {
+  it('keeps the existing global close coordination between floating selects', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(
+      h('div', {}, [
+        h(NoteTypeSelect, { onChange: vi.fn() }),
+        h(NoteTypeSelect, { onChange: vi.fn() }),
+      ]),
+      container
+    );
+
+    const triggers = Array.from(container.querySelectorAll('.getnote-note-type-select-trigger')) as HTMLButtonElement[];
+
+    await act(() => {
+      triggers[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelectorAll('.getnote-note-type-select-menu')).toHaveLength(1);
+
+    await act(() => {
+      triggers[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const menus = Array.from(container.querySelectorAll('.getnote-note-type-select-menu'));
+    expect(menus).toHaveLength(1);
+    expect(triggers[0].querySelector('.is-open')).toBeNull();
+    expect(triggers[1].querySelector('.is-open')).toBeTruthy();
+  });
+
+  it('closes an open floating select on outside mouse down', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+
+    await act(() => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeTruthy();
+
+    await act(() => {
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
+  });
+});

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1542,51 +1542,6 @@ describe('SyncEngine — writeNote', () => {
   });
 });
 
-describe('SyncEngine — getFileName', () => {
-  it('无前缀时返回标题', () => {
-    const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({ filenamePrefix: '' }));
-    const note = makeNote({ title: '我的笔记' });
-    // @ts-ignore
-    expect(engine['getFileName'](note)).toBe('我的笔记');
-  });
-
-  it('有前缀时返回 prefix_title', () => {
-    const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({ filenamePrefix: 'YYYY-MM-DD' }));
-    const note = makeNote({ title: '我的笔记' });
-    // @ts-ignore
-    expect(engine['getFileName'](note)).toBe('2026-04-27_我的笔记');
-  });
-
-  it('无效日期前缀返回标题（无前缀）', () => {
-    const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({ filenamePrefix: 'YYYY-MM-DD' }));
-    const note = makeNote({ title: '我的笔记', created_at: 'invalid' });
-    // @ts-ignore
-    expect(engine['getFileName'](note)).toBe('我的笔记');
-  });
-
-  it('附加笔记使用父文档名作为前缀', () => {
-    const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({ filenamePrefix: 'getnote' }));
-    const note = makeNote({
-      title: '原笔记标题',
-      note_id: '1909246675068292528',
-      parent_id: '1909193892067130512',
-      is_child_note: true,
-    });
-
-    // 子文档不带 parentBaseName 时，返回带前缀的标题（不用 note_id）
-    // @ts-ignore
-    expect(engine['getFileName'](note)).toBe('getnote_原笔记标题');
-
-    // 传入父文档 baseName 时，格式为：父文档名__子文档标题
-    // @ts-ignore
-    expect(engine['getFileName'](note, 'getnote_主笔记标题')).toBe('getnote_主笔记标题__原笔记标题');
-  });
-});
-
 describe('SyncEngine — append note sync', () => {
   it('详情关系字段覆盖列表里的 stale is_child_note', () => {
     const app = makeMockApp();

--- a/tests/sync-paths.spec.ts
+++ b/tests/sync-paths.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { buildNoteBaseName, getAudioAssetBaseName, getFileName, getFilePath, getKnowledgeBaseDir } from '../src/sync-paths';
+import type { GetNoteNote, Settings } from '../src/types';
+import { DEFAULT_SETTINGS } from '../src/types';
+
+function makeSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    ...DEFAULT_SETTINGS,
+    authMode: 'openapi',
+    openApiToken: '',
+    openApiClientId: '',
+    webApiToken: '',
+    apiToken: 'test-token',
+    clientId: 'test-client',
+    webCsrfToken: '',
+    folderName: '得到大脑',
+    templateFilePath: '',
+    maxDays: 30,
+    syncStartDate: '',
+    lastSyncEndTimestamp: '',
+    filenamePrefix: '',
+    scheduledSync: { enabled: false, intervalMinutes: 30, syncOnStart: false },
+    syncHistory: [],
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<GetNoteNote> = {}): GetNoteNote {
+  return {
+    id: 1,
+    note_id: 'note_001',
+    title: '测试笔记',
+    content: '正文内容',
+    note_type: 'plain_text',
+    source: 'app',
+    tags: [],
+    created_at: '2026-04-27T22:26:17+08:00',
+    updated_at: '2026-04-28T10:00:00+08:00',
+    ...overrides,
+  };
+}
+
+describe('sync path helpers', () => {
+  it('derives note filenames from the display title when no prefix is configured', () => {
+    expect(getFileName(makeNote({ title: '我的笔记' }), makeSettings({ filenamePrefix: '' }))).toBe('我的笔记');
+  });
+
+  it('derives note filenames with formatted timestamp prefixes', () => {
+    expect(getFileName(makeNote({ title: '我的笔记' }), makeSettings({ filenamePrefix: 'YYYY-MM-DD' }))).toBe('2026-04-27_我的笔记');
+  });
+
+  it('falls back to the display title when a timestamp prefix cannot be formatted', () => {
+    expect(getFileName(makeNote({ title: '我的笔记', created_at: 'invalid' }), makeSettings({ filenamePrefix: 'YYYY-MM-DD' }))).toBe('我的笔记');
+  });
+
+  it('derives child note filenames from the parent base name and child title', () => {
+    const settings = makeSettings({ filenamePrefix: 'getnote' });
+    const child = makeNote({
+      title: '原笔记标题',
+      note_id: '1909246675068292528',
+      parent_id: '1909193892067130512',
+      is_child_note: true,
+    });
+
+    expect(getFileName(child, settings)).toBe('getnote_原笔记标题');
+    expect(getFileName(child, settings, 'getnote_主笔记标题')).toBe('getnote_主笔记标题__原笔记标题');
+  });
+
+  it('derives vault and asset paths without changing existing naming rules', () => {
+    const note = makeNote({ note_id: 'audio:001', title: '录音/标题' });
+    const settings = makeSettings({ filenamePrefix: '' });
+
+    expect(buildNoteBaseName(note, settings)).toBe('录音标题');
+    expect(getFilePath('得到大脑/录音笔记', note, settings)).toBe('得到大脑/录音笔记/录音标题.md');
+    expect(getAudioAssetBaseName(note, settings)).toBe('录音标题_audio_001');
+  });
+
+  it('derives knowledge base directories with the legacy unsafe-character replacement', () => {
+    expect(getKnowledgeBaseDir('A/B:C*D?E"F<G>H|I')).toBe('知识库/A_B_C_D_E_F_G_H_I');
+    expect(getKnowledgeBaseDir('   ')).toBe('知识库/(无标题)');
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #178 by extracting shared OpenAPI/WebAPI transport primitives for ID-preserving JSON parsing, bearer token normalization, record guards, error-body parsing, and abort-aware retry delay while preserving per-client retry/auth/quota/error semantics.
- Closes #182 by extracting pure sync filename/path derivation helpers and migrating the touched private `SyncEngine#getFileName` coverage to public helper tests without splitting vault writes, enrichment, or attachment collaborators.
- Closes #184 by extracting shared floating-select open/close coordination, trigger positioning, outside-click close, and resize/scroll cleanup into `useFloatingSelectMenu` for tag, note-type, and knowledge-base selects.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` (35 passed, 1 skipped; 583 passed, 2 skipped)
- `npm run build`
- Local Obsidian deploy: copied `main.js`, `manifest.json`, and `styles.css` to `/Users/zhengyan/Downloads/同步空间/9_个人笔记/郑大师的笔记本/.obsidian/plugins/obsidian-getnote-importer/` and verified matching SHA-256 hashes.

## Notes

- Device-flow parsing in `src/api.ts` is intentionally deferred per #178 clarified scope.
- #186 remains skipped despite its `clarified` label because its full-sync-vs-search behavior still changes user-visible sync semantics and needs separate manual confirmation.
