### PR TITLE
[codex] fix(ribbon): restore sync ribbon entry per issue #186

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -201,6 +201,7 @@ export default class GetNoteSyncPlugin extends Plugin {
       callback: () => void this.openSearchView(),
     });
 
+    this.addRibbonIcon('book-lock', t('ribbon.tooltip'), () => this.openManualSyncModal());
     this.addRibbonIcon('brain-circuit', t('ribbon.searchTooltip'), () => void this.openSearchView());
     this.registerEvent(this.app.workspace.on('editor-menu', (menu: Menu, editor: Editor) => {
       const selectedText = editor.getSelection().trim();

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -20,6 +20,10 @@ export class Events {
   }
 }
 
+export function debounce<T extends (...args: never[]) => unknown>(callback: T, _wait: number, _immediate?: boolean): T {
+  return callback;
+}
+
 // ---- Vault ----
 export class Vault extends Events {
   adapter = { getName: () => 'mock' };

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -459,3 +459,57 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     expect(plugin.isSyncing).toBe(false);
   });
 });
+
+describe('GetNoteSyncPlugin ribbon actions (issue #186)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('registers the sync and search ribbon icons after onload', async () => {
+    vi.useFakeTimers();
+    const plugin = new GetNoteSyncPlugin(new App());
+    Object.assign(plugin.app.vault.adapter, {
+      exists: vi.fn().mockResolvedValue(false),
+      mkdir: vi.fn(),
+      copy: vi.fn(),
+    });
+    const addRibbonIcon = vi.fn();
+    Object.assign(plugin, { addRibbonIcon });
+
+    await plugin.onload();
+
+    const syncRibbon = addRibbonIcon.mock.calls.find(([icon]) => icon === 'book-lock');
+    const searchRibbon = addRibbonIcon.mock.calls.find(([icon]) => icon === 'brain-circuit');
+
+    expect(syncRibbon).toBeDefined();
+    expect(searchRibbon).toBeDefined();
+    expect(syncRibbon![1]).toBe('同步得到大脑');
+    expect(searchRibbon![1]).toBe('搜索得到大脑');
+  });
+
+  it('sync ribbon callback opens the manual sync modal', async () => {
+    vi.useFakeTimers();
+    const plugin = new GetNoteSyncPlugin(new App());
+    Object.assign(plugin.app.vault.adapter, {
+      exists: vi.fn().mockResolvedValue(false),
+      mkdir: vi.fn(),
+      copy: vi.fn(),
+    });
+    const addRibbonIcon = vi.fn();
+    Object.assign(plugin, { addRibbonIcon });
+    const openManualSyncModal = vi.spyOn(plugin, 'openManualSyncModal').mockImplementation(() => {});
+    const openSearchView = vi.spyOn(plugin, 'openSearchView').mockImplementation(() => {});
+
+    await plugin.onload();
+
+    const syncRibbon = addRibbonIcon.mock.calls.find(([icon]) => icon === 'book-lock')!;
+    const searchRibbon = addRibbonIcon.mock.calls.find(([icon]) => icon === 'brain-circuit')!;
+
+    syncRibbon[2]();
+    searchRibbon[2]();
+
+    expect(openManualSyncModal).toHaveBeenCalledOnce();
+    expect(openSearchView).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #186.

## Scope

Per the clarification on #186:

- Restore the 1.3.1-style sync ribbon entry: `book-lock` icon, tooltip `同步得到大脑`, opens the manual sync modal.
- Keep the 1.4.0 search ribbon entry: `brain-circuit` icon, tooltip `搜索得到大脑`, opens the search modal.
- Command palette `同步笔记` and `打开得到大脑搜索` commands are unchanged.
- No changes to sync/search semantics, filters, vault writes, GetNote ID parsing, timestamps, or auth/rate-limiting behavior.

## Diff scope

This is a fresh branch based on current `main` (1.4.1) so it lands cleanly without inheriting unrelated diffs from older base commits. Only the ribbon registration in `src/main.tsx` is changed; no version files, README files, settings UI, or unrelated tests are touched. The previous PR #191 added a settings UI for toggling ribbon actions beyond the clarification scope; this PR keeps only the agreed scope.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` (579 passed, 2 skipped)
- `npm run build`
- Local Obsidian deploy: copied `main.js`, `manifest.json`, and `styles.css` to the local vault at `/Users/zhengyan/Downloads/同步空间/9_个人笔记/郑大师的笔记本/.obsidian/plugins/getnote-getnote-importer/`.

## Acceptance

- Left ribbon shows both sync (book-lock, "同步得到大脑") and search (brain-circuit, "搜索得到大脑") icons.
- Sync ribbon opens the manual sync modal.
- Search ribbon opens the search modal.
- Command palette entries are unchanged.

## Notes

- The local Obsidian `data.json` may still contain a `ribbonActions` setting left over from the previous PR #191 deployment. The new version safely ignores it (the field is dropped on `saveData`) and no crash is expected.
- Ready-for-review requested. No release bump, no version bump, no merge conflict expected.