### PR TITLE
refactor(ui): share picker relative time formatting

### DIFF
--- a/src/ui/note-picker-modal.tsx
+++ b/src/ui/note-picker-modal.tsx
@@ -8,6 +8,7 @@ import { NoteTypeSelect } from './note-type-select';
 import { TagSelect } from './tag-select';
 import { applyTagFilter, mergeTagNames } from '../utils/tag-aggregator';
 import { compactCardPreviewText } from './card-preview';
+import { formatPickerRelativeTime } from './picker-time';
 
 interface NotePickerModalProps {
   onConfirm: (selectedNoteIds: string[], enabledNoteTypes?: string[], syncTags?: string[]) => void;
@@ -18,20 +19,6 @@ interface NotePickerModalProps {
   abortSignal?: AbortSignal;
   initialSyncTags?: string[];
   tagOptions?: string[];
-}
-
-function formatRelativeTime(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) {
-    return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
-  } else if (diffDays === 1) {
-    return t('picker.yesterday');
-  } else {
-    return `${diffDays}${t('picker.daysAgo')}`;
-  }
 }
 
 function getTypeLabel(noteType: string): string {
@@ -103,7 +90,7 @@ function NoteRow({ note, checked, onChange, onTagClick }: { note: GetNoteNote; c
               ))}
             </div>
           )}
-          <span className="getnote-note-card-time">{formatRelativeTime(note.updated_at)}</span>
+          <span className="getnote-note-card-time">{formatPickerRelativeTime(note.updated_at)}</span>
         </div>
       </div>
     </div>

--- a/src/ui/picker-time.ts
+++ b/src/ui/picker-time.ts
@@ -1,0 +1,20 @@
+import { t } from '../i18n';
+
+export function formatPickerRelativeTime(iso: string): string {
+  if (!iso) return '';
+
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+  }
+
+  if (diffDays === 1) {
+    return t('picker.yesterday');
+  }
+
+  return `${diffDays}${t('picker.daysAgo')}`;
+}

--- a/src/ui/topic-picker-modal.tsx
+++ b/src/ui/topic-picker-modal.tsx
@@ -6,6 +6,7 @@ import { t } from '../i18n';
 import { TagSelect } from './tag-select';
 import { mergeTagNames } from '../utils/tag-aggregator';
 import { compactCardPreviewText } from './card-preview';
+import { formatPickerRelativeTime } from './picker-time';
 
 interface TopicData {
   topic: SubscribedTopic;
@@ -36,21 +37,6 @@ interface TopicPickerModalProps {
   abortSignal?: AbortSignal;
   initialSyncTags?: string[];
   tagOptions?: string[];
-}
-
-function formatRelativeTime(iso: string): string {
-  if (!iso) return '';
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) {
-    return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
-  } else if (diffDays === 1) {
-    return t('picker.yesterday');
-  } else {
-    return `${diffDays}${t('picker.daysAgo')}`;
-  }
 }
 
 function cardPreviewText(summary: string | undefined, content: string | undefined): { summaryText: string; previewText: string } {
@@ -107,7 +93,7 @@ function ContentRow({ item, checked, onChange, onTagClick }: { item: ContentPrev
               ))}
             </div>
           )}
-          <span className="getnote-note-card-time">{formatRelativeTime(item.updated_at)}</span>
+          <span className="getnote-note-card-time">{formatPickerRelativeTime(item.updated_at)}</span>
         </div>
       </div>
     </div>

--- a/tests/picker-time.spec.ts
+++ b/tests/picker-time.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initI18n } from '../src/i18n';
+import { formatPickerRelativeTime } from '../src/ui/picker-time';
+
+describe('formatPickerRelativeTime', () => {
+  beforeEach(() => {
+    initI18n('zh');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T12:00:00+08:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('formats same-day timestamps as local hour and minute', () => {
+    const timestamp = '2026-06-03T10:05:00+08:00';
+    const expected = new Date(timestamp).toLocaleTimeString('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    expect(formatPickerRelativeTime(timestamp)).toBe(expected);
+  });
+
+  it('formats yesterday with the picker translation', () => {
+    expect(formatPickerRelativeTime('2026-06-02T12:00:00+08:00')).toBe('昨天');
+  });
+
+  it('formats older timestamps as a day count', () => {
+    expect(formatPickerRelativeTime('2026-05-31T12:00:00+08:00')).toBe('3天前');
+  });
+
+  it('keeps empty timestamps blank for preview rows without update time', () => {
+    expect(formatPickerRelativeTime('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- extract duplicated picker relative-time formatting into `formatPickerRelativeTime`
- reuse it from note picker and topic picker rows
- add focused coverage for same-day, yesterday, older, and empty timestamps

## Validation
- `npm test -- tests/picker-time.spec.ts` failed before implementation because `src/ui/picker-time` did not exist
- `npm test -- tests/picker-time.spec.ts tests/note-picker.spec.ts tests/topic-picker-modal.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Risk
Low-risk UI refactor only. No sync semantics, vault writes, auth flow, ID parsing, timestamp parsing, release files, or version bumps changed.
