### PR TITLE
[codex] test: remove unused test lint debt

### DIFF
--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createNote, fetchNoteChildren, fetchNotes, fetchNoteDetail, fetchNoteOriginal, fetchRecallSearch, fetchSubscribedTopics, fetchTopicContentPreviewPage } from '../src/api';
-import type { ListResponse } from '../src/types';
 
 // Extract the internal safeJsonParse for direct testing
 function safeJsonParse(text: string): unknown {

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import * as i18n from '../src/i18n';
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 describe('initI18n', () => {

--- a/tests/mocks/fixtures/loader.spec.ts
+++ b/tests/mocks/fixtures/loader.spec.ts
@@ -5,16 +5,6 @@ import { loadScenario, registerFixture, resetFixtures } from './loader';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-function mockResponse(status: number, body: unknown) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    headers: new Headers({ 'content-type': 'application/json' }),
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body)),
-  } as unknown as Response;
-}
-
 describe('fixture loader', () => {
   beforeEach(() => {
     resetFixtures();

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -827,7 +827,6 @@ describe('SettingsComponent auth credentials', () => {
     });
     await new Promise(r => setTimeout(r, 50));
 
-    const sectionName = container.querySelector('.setting-item-name');
     expect(container.textContent).toContain('附件下载配置');
 
     const toggleEls = container.querySelectorAll('.setting-item .checkbox-container');


### PR DESCRIPTION
## Summary
- remove unused imports and local test helpers from focused specs
- reduce the `npx eslint tests --max-warnings=0` baseline from 179 errors to 175
- leave broad `any` and `@ts-ignore` cleanup for later typed-helper phases

## Verification
- `npx eslint tests --max-warnings=0` fails as expected on existing broad test lint debt only; no `no-unused-vars` errors remain
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Refs #196