### PR TITLE
[codex] test: type settings folder fixtures

### DIFF
--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
 import { App } from 'obsidian';
-import { abstractInputSuggestInstances, TFile } from './mocks/obsidian';
+import { abstractInputSuggestInstances, TFile, TFolder } from './mocks/obsidian';
 import { fetchNotes } from '../src/api';
 import { initI18n } from '../src/i18n';
 import { SettingsComponent } from '../src/settings';
@@ -21,6 +21,13 @@ function makeSettings(overrides: Partial<Settings> = {}): Settings {
     syncHistory: [],
     ...overrides,
   };
+}
+
+function makeFolder(path: string): TFolder {
+  const folder = new TFolder();
+  folder.path = path;
+  folder.name = path.split('/').pop() ?? path;
+  return folder;
 }
 
 function renderSettings(
@@ -213,9 +220,9 @@ describe('SettingsComponent auth credentials', () => {
   it('suggests vault folders for the target folder path', async () => {
     const app = new App();
     vi.spyOn(app.vault, 'getAllFolders').mockReturnValue([
-      { path: 'Templates' } as any,
-      { path: '得到大脑' } as any,
-      { path: 'Projects/Archive' } as any,
+      makeFolder('Templates'),
+      makeFolder('得到大脑'),
+      makeFolder('Projects/Archive'),
     ]);
 
     let rendered!: ReturnType<typeof renderSettings>;
@@ -260,8 +267,8 @@ describe('SettingsComponent auth credentials', () => {
       new TFile('得到大脑/纯文本/已有同步笔记.md'),
     ]);
     vi.spyOn(app.vault, 'getAllFolders').mockReturnValue([
-      { path: 'Templates' } as any,
-      { path: '得到大脑' } as any,
+      makeFolder('Templates'),
+      makeFolder('得到大脑'),
     ]);
 
     let rendered!: ReturnType<typeof renderSettings>;


### PR DESCRIPTION
## Summary
- add a typed `makeFolder()` helper for settings tests
- replace 5 local `as any` folder fixtures with `TFolder` instances
- reduce the `npx eslint tests --max-warnings=0` baseline from 175 errors to 170

## Verification
- `npx eslint tests/settings.spec.ts --max-warnings=0`
- `npx eslint tests --max-warnings=0` fails as expected on remaining broad test lint debt only
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Refs #196