### PR TITLE
[codex] test: type local file fixtures

### DIFF
--- a/tests/search-view.spec.ts
+++ b/tests/search-view.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
-import { TFile } from 'obsidian';
+import { TFile, type App } from 'obsidian';
 import { SearchPanel, findSyncedNoteFile } from '../src/ui/search-view';
 import type { RecallSearchResult } from '../src/types';
 
@@ -192,7 +192,7 @@ describe('findSyncedNoteFile', () => {
   it('returns the local Markdown file whose frontmatter uid matches the note id', () => {
     const matching = new TFile('得到大脑/链接笔记/命中.md');
     const other = new TFile('得到大脑/纯文本/其他.md');
-    const app = {
+    const app: Pick<App, 'vault' | 'metadataCache'> = {
       vault: {
         getMarkdownFiles: () => [other, matching, new TFile('其他/命中.md')],
       },
@@ -203,6 +203,6 @@ describe('findSyncedNoteFile', () => {
       },
     };
 
-    expect(findSyncedNoteFile(app as any, '得到大脑', '1909193892067130512')).toBe(matching);
+    expect(findSyncedNoteFile(app, '得到大脑', '1909193892067130512')).toBe(matching);
   });
 });

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { App, Modal } from 'obsidian';
+import { App, Modal, TFile } from 'obsidian';
 import GetNoteSyncPlugin from '../src/main';
 import { ReverseSyncEngine } from '../src/reverse-sync';
 import { SyncCancelledError, SyncEngine } from '../src/sync';
@@ -389,9 +389,9 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     });
     const plugin = makePlugin();
     plugin.settings.reverseSync = { enabled: false };
-    const selectedFiles = [{ path: 'Inbox/upload-me.md' }];
+    const selectedFiles = [new TFile('Inbox/upload-me.md')];
 
-    plugin.uploadSelectedLocalNotes(selectedFiles as any);
+    plugin.uploadSelectedLocalNotes(selectedFiles);
 
     await vi.waitFor(() => {
       expect(syncFiles).toHaveBeenCalledWith(selectedFiles);
@@ -437,7 +437,7 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     });
     const plugin = makePlugin();
 
-    plugin.uploadSelectedLocalNotes([{ path: 'Inbox/fail.md' }] as any);
+    plugin.uploadSelectedLocalNotes([new TFile('Inbox/fail.md')]);
 
     await vi.waitFor(() => {
       expect(plugin.syncHistory.at(-1)).toEqual(expect.objectContaining({


### PR DESCRIPTION
## Summary
- type the `findSyncedNoteFile` mock app with `Pick<App, "vault" | "metadataCache">`
- replace local upload `as any` fixtures with mock `TFile` instances
- reduce the `npx eslint tests --max-warnings=0` baseline from 170 errors to 167

## Verification
- `npx eslint tests/search-view.spec.ts tests/sync.spec.ts --max-warnings=0`
- `npx eslint tests --max-warnings=0` fails as expected on remaining sync-engine/reverse-sync-engine lint debt only
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Refs #196