### PR TITLE
test: type fixture fetch installer

### DIFF
--- a/tests/mocks/fixtures/loader.ts
+++ b/tests/mocks/fixtures/loader.ts
@@ -91,17 +91,19 @@ function makeResponse(status: number, body: unknown): Response {
   } as unknown as Response;
 }
 
+function installMockFetch(): void {
+  globalThis.fetch = mockFetch;
+}
+
 export function registerFixture(fixture: Fixture): void {
   fixtures.push(fixture);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (globalThis as any).fetch = mockFetch;
+  installMockFetch();
 }
 
 export function resetFixtures(): void {
   fixtures = [];
   requests = [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (globalThis as any).fetch = mockFetch;
+  installMockFetch();
 }
 
 export function getFixtureRequests(): Array<{ method: string; url: string }> {


### PR DESCRIPTION
## Summary
- Replace repeated `globalThis.fetch` test mock assignment with a typed `installMockFetch()` helper.
- Remove two local `no-explicit-any` eslint suppressions from the fixture loader.

## Why
This is a small test-infrastructure cleanup found during the daily architecture/debt patrol. It keeps fixture mock setup behavior unchanged while reducing local lint debt and repeated assignment logic.

## Validation
- `npm test -- tests/mocks/fixtures/loader.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
