### PR TITLE
refactor: consolidate local date input formatting

### DIFF
--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -12,6 +12,7 @@ import { App, AbstractInputSuggest } from 'obsidian';
 import { fetchNotes } from '../api';
 import { t } from '../i18n';
 import { ExternalLink } from './external-link';
+import { getLocalDateInputValue } from '../ui/date-input';
 
 type SuggestionProvider = (query: string) => string[];
 
@@ -83,13 +84,6 @@ interface SettingsComponentProps {
   lastSyncTime?: number;
   syncHistory?: SyncHistoryEntry[];
   initialKnowledgeBaseCache?: { entries: Array<{ topicId: string; name: string; source?: 'subscribed' | 'created' }>; cacheUpdatedAt?: number };
-}
-
-function getLocalDateInputValue(date = new Date()): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
 }
 
 export function SettingsComponent({

--- a/src/ui/date-input.test.ts
+++ b/src/ui/date-input.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { getLocalDateInputValue } from './date-input';
+
+describe('getLocalDateInputValue', () => {
+  it('formats the calendar date using local date parts', () => {
+    expect(getLocalDateInputValue(new Date(2026, 0, 2, 0, 30))).toBe('2026-01-02');
+    expect(getLocalDateInputValue(new Date(2026, 11, 31, 23, 30))).toBe('2026-12-31');
+  });
+});

--- a/src/ui/date-input.ts
+++ b/src/ui/date-input.ts
@@ -1,0 +1,6 @@
+export function getLocalDateInputValue(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/src/ui/manual-sync-modal.tsx
+++ b/src/ui/manual-sync-modal.tsx
@@ -3,6 +3,7 @@ import type { SyncScopeOptions } from '../types';
 import { t } from '../i18n';
 import { NoteTypeSelect } from './note-type-select';
 import { TagSelect } from './tag-select';
+import { getLocalDateInputValue } from './date-input';
 
 type SyncMode = 'date' | 'days';
 
@@ -25,13 +26,6 @@ function resolveInitialSyncMode(initialOptions: SyncScopeOptions): SyncMode {
 
   const daysCutoff = Date.now() - initialOptions.maxDays * 24 * 60 * 60 * 1000;
   return daysCutoff >= startTime ? 'days' : 'date';
-}
-
-function getLocalDateInputValue(date = new Date()): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
 }
 
 export function ManualSyncModal({ initialOptions, tagOptions = [], onConfirm, onCancel }: ManualSyncModalProps) {


### PR DESCRIPTION
## Summary
- extract the duplicated local `YYYY-MM-DD` formatter into `src/ui/date-input.ts`
- reuse it from the settings page and manual sync modal without changing local-date semantics
- add direct month/year boundary coverage for the shared helper

Closes #210

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test` (595 passed, 2 skipped)
- `npm run build`

## Local Obsidian deployment
- deployed `main.js`, `manifest.json`, and `styles.css` to the configured test vault; source and deployed hashes match
- the plugin settings page was visible in the real Obsidian window. Automated opening of the manual-sync modal was not reliable, so the PR remains draft pending a quick manual check of the manual-sync date field after plugin reload.