### PR TITLE
test: type sync boundary fixtures

### DIFF
--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1247,7 +1247,7 @@ describe('SyncEngine — lastSyncEndTimestamp boundary re-check', () => {
     app.vault._addFolder('得到大脑/纯文本');
 
     const engine = new SyncEngine(
-      app as any,
+      app,
       makeSettings({ maxDays: 0 }),
       undefined,
       { syncStartDate: '2026-05-10T12:00:00+08:00', maxDays: 0 }
@@ -1281,7 +1281,7 @@ describe('SyncEngine — lastSyncEndTimestamp boundary re-check', () => {
     const app = makeMockApp();
     app.vault._addFolder('得到大脑/纯文本');
     const engine = new SyncEngine(
-      app as any,
+      app,
       makeSettings({
         maxDays: 0,
         syncHistory: [
@@ -1356,7 +1356,7 @@ describe('SyncEngine — lastSyncEndTimestamp boundary re-check', () => {
     const app = makeMockApp();
     app.vault._addFolder('得到大脑/纯文本');
     const engine = new SyncEngine(
-      app as any,
+      app,
       makeSettings({
         maxDays: 0,
         syncHistory: [
@@ -1434,7 +1434,7 @@ describe('SyncEngine — lastSyncEndTimestamp boundary re-check', () => {
     app.vault._addFolder('得到大脑/纯文本');
 
     const engine = new SyncEngine(
-      app as any,
+      app,
       makeSettings({ maxDays: 0 }),
       undefined,
       { syncStartDate: '2026-05-10T12:00:00+08:00', maxDays: 0 }


### PR DESCRIPTION
## What changed

- Removed four redundant `app as any` casts from the last-sync-boundary SyncEngine tests.
- Kept the mock app typed as `MockApp`, which already satisfies the SyncEngine constructor contract.

## Why

This advances issue #196's test-only lint-debt cleanup without changing runtime sync behavior. The focused test-lint baseline drops from 79 to 75 errors.

## Validation

- `npx eslint tests/sync-engine.spec.ts --max-warnings=0` (expected remaining debt: 75 errors)
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`