### PR TITLE
fix: address Community Dashboard static/lint/style warnings (#204 items 3-7)

### DIFF
--- a/src/api-clients/webapi-client.ts
+++ b/src/api-clients/webapi-client.ts
@@ -27,7 +27,7 @@ function parseWebApiListResponse(value: unknown): { notes: GetNoteNote[]; hasMor
   // Map Web API fields to GetNoteNote
   const notes: GetNoteNote[] = list.map((raw): GetNoteNote => {
     const n: Record<string, unknown> = isRecord(raw) ? raw : {};
-    const stringField = (key: string): string => (typeof n[key] === 'string' ? (n[key] as string) : '');
+    const stringField = (key: string): string => (typeof n[key] === 'string' ? n[key] : '');
     const childCountRaw = n.children_count;
     const subNoteCountRaw = n.sub_note_count;
     return {

--- a/src/note-parser.ts
+++ b/src/note-parser.ts
@@ -182,7 +182,7 @@ function buildAssetBlock(assetPaths: string[]): string {
     const safePaths = groups.images
       .map(p => {
         if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(p)) return null;
-        if (/[<>{}|\`\x00-\x1f]/.test(p)) return null;
+        if (/[<>{}|`]/.test(p) || Array.from(p).some(char => char.charCodeAt(0) <= 0x1f)) return null;
         return relativeAssetPath(p);
       })
       .filter((p): p is string => Boolean(p))

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -147,7 +147,7 @@ export function SettingsComponent({
   const attachmentImport = settings.attachmentImport ?? {};
   const attachmentKinds = ['image', 'audio', 'video', 'document'] as const;
   const allAttachmentsOn = attachmentKinds.every(
-    k => attachmentImport[k as 'image' | 'audio' | 'video' | 'document'] !== false,
+    k => attachmentImport[k] !== false,
   );
   const handleMasterAttachmentChange = (value: boolean) => {
     updateSetting('attachmentImport', {
@@ -420,7 +420,7 @@ export function SettingsComponent({
           const tokenStr = token.replace(/^Bearer\s+/i, '');
           const payload: unknown = JSON.parse(atob(tokenStr.split('.')[1]));
           if (payload && typeof payload === 'object' && 'exp' in payload) {
-            const exp = (payload as { exp: unknown }).exp;
+            const exp = payload.exp;
             if (typeof exp === 'number') {
               const remaining = Math.round((exp - Date.now() / 1000) / 60);
               if (remaining > 0) setConnectionExpiryMin(remaining);

--- a/src/ui/search-view.tsx
+++ b/src/ui/search-view.tsx
@@ -24,7 +24,7 @@ export function findSyncedNoteFile(app: Pick<App, 'vault' | 'metadataCache'>, fo
   const prefix = `${folderName}/`;
   for (const file of app.vault.getMarkdownFiles()) {
     if (!file.path.startsWith(prefix)) continue;
-    const uid = app.metadataCache.getFileCache(file)?.frontmatter?.['uid'];
+    const uid: unknown = app.metadataCache.getFileCache(file)?.frontmatter?.['uid'];
     if (String(uid ?? '') === noteId) return file;
   }
   return null;

--- a/styles.css
+++ b/styles.css
@@ -908,14 +908,14 @@
   flex: 0 0 auto;
 }
 
-.getnote-knowledge-base-select-option input[type="checkbox"],
-.getnote-tag-select-option input[type="checkbox"] {
-  flex: 0 0 16px !important;
-  width: 16px !important;
-  min-width: 16px !important;
-  max-width: 16px !important;
-  height: 16px !important;
-  margin: 0 !important;
+body .getnote-knowledge-base-select-option input[type="checkbox"],
+body .getnote-tag-select-option input[type="checkbox"] {
+  flex: 0 0 16px;
+  width: 16px;
+  min-width: 16px;
+  max-width: 16px;
+  height: 16px;
+  margin: 0;
 }
 
 .getnote-knowledge-base-select-option span {
@@ -1938,6 +1938,6 @@
   color: var(--text-muted);
 }
 
-.getnote-ribbon-action-hidden {
-  display: none !important;
+body .getnote-ribbon-action-hidden {
+  display: none;
 }


### PR DESCRIPTION
## Summary

Triage the static-analysis and lint findings from the read-only Obsidian Community dashboard review of release 1.4.1 (commit 2a70096). Per issue #204 option A, behavior-changing items (activeDocument popout, settings display API) are deferred to separate experiment branches (#216, #217 — see `codex/204-popout-activeDocument-experiment` and `codex/204-settings-refresh-experiment`).

## Changes (5 files, 15+/-15)

- `src/api-clients/webapi-client.ts:30` — drop unnecessary type assertion
- `src/note-parser.ts:185` — escape regex control characters
- `src/settings/index.tsx:156, :429` — drop two unnecessary type assertions
- `src/ui/search-view.tsx:27` — type `uid` explicitly as `unknown` (removes unsafe assignment warning)
- `styles.css:913-918, :1942` — scope !important rules more specifically so they no longer require the flag

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (600 passed, 2 skipped)
- `npm run build` ✅

## Out of scope (deliberately deferred)

- `src/ui/use-floating-select-menu.ts` (activeDocument) — popout-window behavior risk; isolated to `codex/204-popout-activeDocument-experiment`
- `src/main.tsx` settingsTab.display() refresh — settings lifecycle risk; isolated to `codex/204-settings-refresh-experiment`
- `src/types.ts:98` 'document' literal — verified as false positive (string literal, not Document type reference)

Closes #204 (partial)