### PR TITLE
test: type build UID index fixtures

### DIFF
--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1453,7 +1453,7 @@ describe('SyncEngine — lastSyncEndTimestamp boundary re-check', () => {
 describe('SyncEngine — buildUidIndex', () => {
   it('返回空 Map 当 vault 没有 md 文件', () => {
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings());
+    const engine = new SyncEngine(app, makeSettings());
     // @ts-expect-error private helper is tested directly
     const index = engine['buildUidIndex']();
     expect(index.size).toBe(0);
@@ -1463,7 +1463,7 @@ describe('SyncEngine — buildUidIndex', () => {
     const app = makeMockApp();
     app.vault._addFile('得到大脑/纯文本/test.md', 'content', { uid: 'note_abc' });
     app.vault._addFolder('得到大脑/纯文本');
-    const engine = new SyncEngine(app as any, makeSettings());
+    const engine = new SyncEngine(app, makeSettings());
     // @ts-expect-error private helper is tested directly
     const index = engine['buildUidIndex']();
     expect(index.size).toBe(1);
@@ -1474,7 +1474,7 @@ describe('SyncEngine — buildUidIndex', () => {
     const app = makeMockApp();
     app.vault._addFile('得到大脑/纯文本/test.md', 'content', {});
     app.vault._addFolder('得到大脑/纯文本');
-    const engine = new SyncEngine(app as any, makeSettings());
+    const engine = new SyncEngine(app, makeSettings());
     // @ts-expect-error private helper is tested directly
     const index = engine['buildUidIndex']();
     expect(index.size).toBe(0);
@@ -1486,7 +1486,7 @@ describe('SyncEngine — buildUidIndex', () => {
     app.vault._addFile('其他/纯文本/other.md', 'content', { uid: 'note_002' });
     app.vault._addFolder('得到大脑/纯文本');
     app.vault._addFolder('其他/纯文本');
-    const engine = new SyncEngine(app as any, makeSettings());
+    const engine = new SyncEngine(app, makeSettings());
     // @ts-expect-error private helper is tested directly
     const index = engine['buildUidIndex']();
     expect(index.size).toBe(1);


### PR DESCRIPTION
## Summary
- replace four redundant `app as any` casts in buildUidIndex tests with the existing `MockApp` type
- preserve test behavior while reducing the test lint baseline by four errors

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npx vitest run tests/sync-engine.spec.ts

No runtime code or user-visible behavior changed.