### PR TITLE
fix: include subscribed bloggers in knowledge-base sync

### DIFF
--- a/docs/superpowers/plans/2026-07-17-issue-192-subscribed-bloggers.md
+++ b/docs/superpowers/plans/2026-07-17-issue-192-subscribed-bloggers.md
@@ -1,0 +1,8 @@
+# Issue #192 implementation plan
+
+1. Add focused failing tests for knowledge-base blogger enumeration, normal time/type filtering, explicit bypass modes, per-note continuation, and safe checkpoint behavior.
+2. Replace the knowledge-base sync's duplicated date check with the existing shared filter pipeline while preserving explicit full/single-item bypasses.
+3. Isolate note fetch/write failures and prevent failed notes from being skipped by an advanced checkpoint.
+4. Run targeted sync/API tests, then `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
+5. Review the diff for ID/timestamp and sync-semantics regressions, push the branch, open a PR targeting `main`, and monitor required checks.
+

--- a/docs/superpowers/plans/2026-07-17-issue-192-subscribed-bloggers.md
+++ b/docs/superpowers/plans/2026-07-17-issue-192-subscribed-bloggers.md
@@ -5,4 +5,3 @@
 3. Isolate note fetch/write failures and prevent failed notes from being skipped by an advanced checkpoint.
 4. Run targeted sync/API tests, then `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
 5. Review the diff for ID/timestamp and sync-semantics regressions, push the branch, open a PR targeting `main`, and monitor required checks.
-

--- a/docs/superpowers/specs/2026-07-17-issue-192-subscribed-bloggers-design.md
+++ b/docs/superpowers/specs/2026-07-17-issue-192-subscribed-bloggers-design.md
@@ -25,4 +25,3 @@ Failures are isolated per note. A run with note-level failures must not advance 
 - Full and explicit single-item runs preserve existing semantics.
 - One note failure does not stop later notes and remains retryable.
 - No UI, copy, path, ID, timestamp, or version change.
-

--- a/docs/superpowers/specs/2026-07-17-issue-192-subscribed-bloggers-design.md
+++ b/docs/superpowers/specs/2026-07-17-issue-192-subscribed-bloggers-design.md
@@ -1,0 +1,28 @@
+# Issue #192: Knowledge-base sync includes subscribed bloggers
+
+## Goal
+
+When a knowledge base is selected for scheduled or manual knowledge-base sync, include notes from every Douyin/TikTok blogger subscribed by that knowledge base. Keep the existing UI and existing note identity/path conventions.
+
+## Product behavior
+
+- Selecting a knowledge base implicitly selects all of its subscribed bloggers; no new setting is added.
+- Normal knowledge-base sync applies the same configured start-date and note-type filters as normal sync.
+- Explicit full sync and explicitly selected single-article sync keep their current filter-bypass behavior.
+- A failure fetching or writing one note is recorded while remaining notes continue.
+- Blogger note IDs remain string-preserving and use the existing `blogger_` namespace.
+
+## Implementation shape
+
+Reuse the existing knowledge-base content enumeration, which already returns blogger posts. Route normal knowledge-base candidates through the shared recent-note and note-type filters instead of maintaining a partial date-only copy. Keep explicit full/single-item modes outside that filtering path.
+
+Failures are isolated per note. A run with note-level failures must not advance its durable checkpoint past failed work in a way that prevents retrying those notes on the next run.
+
+## Acceptance boundary
+
+- Both API modes include all subscribed-blogger posts returned for the selected knowledge base.
+- Normal runs honor start date, maximum-days limit, and enabled note types.
+- Full and explicit single-item runs preserve existing semantics.
+- One note failure does not stop later notes and remains retryable.
+- No UI, copy, path, ID, timestamp, or version change.
+

--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -4,6 +4,8 @@ import { isRecord, normalizeBearerToken, parseJsonObjectOrEmpty, parseJsonPreser
 
 export const GETNOTE_LIST_LIMIT = 20;
 
+class QuotaExceededError extends Error {}
+
 // Module-level quota tracker. Updated before throwing quota-day/month errors so
 // the calling layer can persist it via Settings.lastQuotaState.
 let lastQuota: ApiQuotaState = { exhausted: false };
@@ -127,7 +129,7 @@ async function handleRateLimit<T>(
   const reason = errObj.reason as string | undefined;
   if (reason === 'quota_day' || reason === 'quota_month') {
     lastQuota = { exhausted: true, reason, checkedAt: Date.now() };
-    throw new Error(t('error.quotaExceeded'));
+    throw new QuotaExceededError(t('error.quotaExceeded'));
   }
   if (retries > 0) {
     await waitForRetryDelay(signal);
@@ -599,6 +601,7 @@ async function fetchBloggerContentDetail(
     };
   } catch (error) {
     if (signal?.aborted) throw error;
+    if (error instanceof QuotaExceededError) throw error;
     return {
       content,
       error: error instanceof Error ? error.message : String(error),

--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -4,7 +4,7 @@ import { isRecord, normalizeBearerToken, parseJsonObjectOrEmpty, parseJsonPreser
 
 export const GETNOTE_LIST_LIMIT = 20;
 
-class QuotaExceededError extends Error {}
+class FatalOpenApiError extends Error {}
 
 // Module-level quota tracker. Updated before throwing quota-day/month errors so
 // the calling layer can persist it via Settings.lastQuotaState.
@@ -28,7 +28,7 @@ function normalizeListData(value: unknown): { notes: GetNoteNote[]; hasMore: boo
   const data = isRecord(value.data) ? value.data : value;
   // Handle not_member error: server returns { success: true, data: { msg: "rejected" } }
   if (data.msg === 'rejected') {
-    throw new Error(t('error.openApiNotMember'));
+    throw new FatalOpenApiError(t('error.openApiNotMember'));
   }
   const notes = Array.isArray(data.notes) ? data.notes as GetNoteNote[] : [];
   const hasMore = Boolean(data.has_more ?? data.hasMore);
@@ -129,7 +129,7 @@ async function handleRateLimit<T>(
   const reason = errObj.reason as string | undefined;
   if (reason === 'quota_day' || reason === 'quota_month') {
     lastQuota = { exhausted: true, reason, checkedAt: Date.now() };
-    throw new QuotaExceededError(t('error.quotaExceeded'));
+    throw new FatalOpenApiError(t('error.quotaExceeded'));
   }
   if (retries > 0) {
     await waitForRetryDelay(signal);
@@ -143,7 +143,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   const res = await fetch(url, { ...options, signal });
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-  if (res.status === 401) throw new Error(t('error.invalidCredentials'));
+  if (res.status === 401) throw new FatalOpenApiError(t('error.invalidCredentials'));
   if (res.status === 429) return handleRateLimit<T>(url, options, res, retries, signal);
   if (res.status < 200 || res.status >= 300) {
     const text = await res.text();
@@ -151,7 +151,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
     if (res.status === 403 && json.success === false) {
       const errObj = (json.error ?? json) as Record<string, unknown>;
       const code = errObj?.code as number | undefined;
-      if (code === 10201) throw new Error(t('error.openApiNotMember'));
+      if (code === 10201) throw new FatalOpenApiError(t('error.openApiNotMember'));
     }
     throw new Error(t('error.apiServerError', { status: res.status }));
   }
@@ -161,7 +161,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
   if (json.success === false) {
     const errObj = (json.error ?? json) as Record<string, unknown>;
     const code = errObj?.code as number | undefined;
-    if (code === 10201) throw new Error(t('error.openApiNotMember'));
+    if (code === 10201) throw new FatalOpenApiError(t('error.openApiNotMember'));
     if (code === 10202 && retries > 0) {
       await waitForRetryDelay(signal);
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
@@ -601,7 +601,7 @@ async function fetchBloggerContentDetail(
     };
   } catch (error) {
     if (signal?.aborted) throw error;
-    if (error instanceof QuotaExceededError) throw error;
+    if (error instanceof FatalOpenApiError) throw error;
     return {
       content,
       error: error instanceof Error ? error.message : String(error),

--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -571,7 +571,13 @@ async function fetchBloggerContents(topicId: string, blogger: Blogger, token: st
   return contents;
 }
 
-async function fetchBloggerContentDetail(topicId: string, content: BloggerContent, token: string, clientId: string, signal?: AbortSignal): Promise<BloggerContent> {
+async function fetchBloggerContentDetail(
+  topicId: string,
+  content: BloggerContent,
+  token: string,
+  clientId: string,
+  signal?: AbortSignal
+): Promise<{ content: BloggerContent; error?: string }> {
   const params = new URLSearchParams({ topic_id: topicId, post_id: content.post_id_alias });
   const url = `https://openapi.biji.com/open/api/v1/resource/knowledge/blogger/content/detail?${params.toString()}`;
   try {
@@ -582,10 +588,15 @@ async function fetchBloggerContentDetail(topicId: string, content: BloggerConten
       signal
     );
     const detail = normalizeContent(normalizeData(data));
-    return detail ? { ...content, ...detail, post_id_alias: content.post_id_alias } : content;
+    return {
+      content: detail ? { ...content, ...detail, post_id_alias: content.post_id_alias } : content,
+    };
   } catch (error) {
     if (signal?.aborted) throw error;
-    return content;
+    return {
+      content,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -617,8 +628,10 @@ export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions):
       if (bloggerIdSet && !bloggerIdSet.has(blogger.follow_id)) continue;
       const contents = await fetchBloggerContents(topic.topic_id, blogger, token, clientId, signal, remainingNoteIds);
       for (const content of contents) {
-        const detail = await fetchBloggerContentDetail(topic.topic_id, content, token, clientId, signal);
-        notes.push(bloggerContentToNote(detail, topic, blogger));
+        const detailResult = await fetchBloggerContentDetail(topic.topic_id, content, token, clientId, signal);
+        const note = bloggerContentToNote(detailResult.content, topic, blogger);
+        if (detailResult.error) note.fetch_error = detailResult.error;
+        notes.push(note);
       }
       if (remainingNoteIds?.size === 0) return notes;
     }

--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -588,8 +588,14 @@ async function fetchBloggerContentDetail(
       signal
     );
     const detail = normalizeContent(normalizeData(data));
+    if (!detail) {
+      return {
+        content,
+        error: 'Invalid blogger content detail payload',
+      };
+    }
     return {
-      content: detail ? { ...content, ...detail, post_id_alias: content.post_id_alias } : content,
+      content: { ...content, ...detail, post_id_alias: content.post_id_alias },
     };
   } catch (error) {
     if (signal?.aborted) throw error;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -370,8 +370,8 @@ export default class GetNoteSyncPlugin extends Plugin {
     }
 
     // lastSyncEndTimestamp only belongs to auto sync
-    // 更新断点只要：有笔记成功同步且有 lastNoteTimestamp（即使有部分失败）
-    if (type === 'auto' && status === 'success') {
+    // Ordinary partial failures may still advance; retryable knowledge-base failures keep the old checkpoint.
+    if (type === 'auto' && status === 'success' && !result.checkpointBlocked) {
       this.settings.lastSyncEndTimestamp = result.lastNoteTimestamp ?? new Date(finishedAt).toISOString();
     }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1073,6 +1073,15 @@ export class SyncEngine {
         result.failed++;
         result.checkpointBlocked = true;
         this.recordItem(result, note, { status: 'failed', error: note.fetch_error });
+        this.onProgress?.({
+          processed: result.total,
+          total: filteredNotes.length,
+          created: result.created,
+          updated: result.updated,
+          skipped: result.skipped,
+          failed: result.failed,
+          percent: filteredNotes.length ? Math.round((result.total / filteredNotes.length) * 100) : 100,
+        });
         continue;
       }
       const knowledgeBaseName = note.topic_id ? knowledgeBaseNames[note.topic_id] : undefined;
@@ -1092,6 +1101,19 @@ export class SyncEngine {
         ? note
         : await this.enrichAudioNote(note, signal, categoryOverride);
       const appendNotes = await this.fetchAppendNotes(noteToWrite, signal, result, categoryOverride);
+      if (result.failed > failuresBeforeNote) {
+        result.checkpointBlocked = true;
+        this.onProgress?.({
+          processed: result.total,
+          total: filteredNotes.length,
+          created: result.created,
+          updated: result.updated,
+          skipped: result.skipped,
+          failed: result.failed,
+          percent: filteredNotes.length ? Math.round((result.total / filteredNotes.length) * 100) : 100,
+        });
+        continue;
+      }
       const parentBaseName = this.buildBaseName(noteToWrite);
       const parentFileName = this.getFileName(noteToWrite);
       const childFileNames = appendNotes.map(child => this.getFileName(child, parentBaseName));
@@ -1357,6 +1379,15 @@ export class SyncEngine {
           result.failed++;
           result.checkpointBlocked = true;
           this.recordItem(result, note, { status: 'failed', error: note.fetch_error });
+          this.onProgress?.({
+            processed: result.total,
+            total: filteredNotes.length,
+            created: result.created,
+            updated: result.updated,
+            skipped: result.skipped,
+            failed: result.failed,
+            percent: filteredNotes.length ? Math.round((result.total / filteredNotes.length) * 100) : 100,
+          });
           continue;
         }
         const parentMatchesTags = this.filterNotesByTags([note], syncOptions.syncTags).length > 0;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1055,15 +1055,9 @@ export class SyncEngine {
       bloggerIds,
     });
 
-    const cutoffTime = this.scopeOptions.syncStartDate
-      ? parseSyncBoundaryTime(this.scopeOptions.syncStartDate)
-      : null;
-
-    const filteredNotes = knowledgeNotes.filter(note => {
-      if (cutoffTime === null) return true;
-      const updated = parseNoteUpdatedTime(note);
-      return updated !== null && updated >= cutoffTime;
-    });
+    const filteredNotes = this.filterNotesByType(
+      this.filterNotesByDateRange(this.filterRecentNotes(knowledgeNotes))
+    );
 
     const uidIndex = this.buildUidIndex();
     const seenNoteIds = new Set<string>();
@@ -1072,6 +1066,7 @@ export class SyncEngine {
     for (const note of filteredNotes) {
       if (this.cancelled) throw new SyncCancelledError();
       if (seenNoteIds.has(note.note_id)) continue;
+      const failuresBeforeNote = result.failed;
       seenNoteIds.add(note.note_id);
       result.total++;
       const knowledgeBaseName = note.topic_id ? knowledgeBaseNames[note.topic_id] : undefined;
@@ -1130,6 +1125,10 @@ export class SyncEngine {
         );
         this.applyWriteResult(result, appendWriteResult);
         this.recordItem(result, appendNote, appendWriteResult);
+      }
+
+      if (result.failed > failuresBeforeNote) {
+        result.checkpointBlocked = true;
       }
 
       this.onProgress?.({

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1069,6 +1069,12 @@ export class SyncEngine {
       const failuresBeforeNote = result.failed;
       seenNoteIds.add(note.note_id);
       result.total++;
+      if (note.fetch_error) {
+        result.failed++;
+        result.checkpointBlocked = true;
+        this.recordItem(result, note, { status: 'failed', error: note.fetch_error });
+        continue;
+      }
       const knowledgeBaseName = note.topic_id ? knowledgeBaseNames[note.topic_id] : undefined;
       const categoryOverride = knowledgeBaseName ? this.getKnowledgeBaseDir(knowledgeBaseName) : undefined;
 
@@ -1080,34 +1086,28 @@ export class SyncEngine {
       if (preCheck.exists) {
         result.skipped++;
         this.recordItem(result, note, { status: 'skipped' });
-        this.onProgress?.({
-          processed: result.total,
-          total: result.total,
-          created: result.created,
-          updated: result.updated,
-          skipped: result.skipped,
-          failed: result.failed,
-          percent: 0,
-        });
-        continue;
       }
 
-      const noteToWrite = await this.enrichAudioNote(note, signal, categoryOverride);
+      const noteToWrite = preCheck.exists
+        ? note
+        : await this.enrichAudioNote(note, signal, categoryOverride);
       const appendNotes = await this.fetchAppendNotes(noteToWrite, signal, result, categoryOverride);
       const parentBaseName = this.buildBaseName(noteToWrite);
       const parentFileName = this.getFileName(noteToWrite);
       const childFileNames = appendNotes.map(child => this.getFileName(child, parentBaseName));
 
-      const writeResult = await this.writeNote(
-        noteToWrite,
-        uidIndex,
-        undefined,
-        undefined,
-        childFileNames,
-        categoryOverride
-      );
-      this.applyWriteResult(result, writeResult);
-      this.recordItem(result, noteToWrite, writeResult);
+      if (!preCheck.exists) {
+        const writeResult = await this.writeNote(
+          noteToWrite,
+          uidIndex,
+          undefined,
+          undefined,
+          childFileNames,
+          categoryOverride
+        );
+        this.applyWriteResult(result, writeResult);
+        this.recordItem(result, noteToWrite, writeResult);
+      }
       const updatedTime = parseNoteUpdatedTime(noteToWrite);
       const currentLastTime = result.lastNoteTimestamp ? parseSyncBoundaryTime(result.lastNoteTimestamp) : null;
       if (updatedTime !== null && (currentLastTime === null || updatedTime > currentLastTime)) {
@@ -1351,6 +1351,14 @@ export class SyncEngine {
       for (const note of filteredNotes) {
         if (this.cancelled || modal?.isCancelled()) throw new SyncCancelledError();
         if (seenNoteIds.has(note.note_id)) continue;
+        if (note.fetch_error) {
+          seenNoteIds.add(note.note_id);
+          result.total++;
+          result.failed++;
+          result.checkpointBlocked = true;
+          this.recordItem(result, note, { status: 'failed', error: note.fetch_error });
+          continue;
+        }
         const parentMatchesTags = this.filterNotesByTags([note], syncOptions.syncTags).length > 0;
         const knowledgeBaseName = syncOptions.knowledgeBaseNames?.[note.note_id] ?? syncOptions.knowledgeBaseName;
         const categoryOverride = knowledgeBaseName ? this.getKnowledgeBaseDir(knowledgeBaseName) : undefined;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -830,7 +830,7 @@ export class SyncEngine {
     return appendNotes;
   }
 
-  private filterNotesByDateRange(notes: GetNoteNote[]): GetNoteNote[] {
+  private filterNotesByDateRange(notes: GetNoteNote[], includeBoundary = false): GetNoteNote[] {
     const { syncStartDate } = this.scopeOptions;
     if (!syncStartDate) return notes;
 
@@ -839,7 +839,7 @@ export class SyncEngine {
 
     return notes.filter(note => {
       const updated = parseNoteUpdatedTime(note);
-      return updated !== null && updated > startTime;
+      return updated !== null && (includeBoundary ? updated >= startTime : updated > startTime);
     });
   }
 
@@ -1056,31 +1056,33 @@ export class SyncEngine {
     });
 
     const filteredNotes = this.filterNotesByType(
-      this.filterNotesByDateRange(this.filterRecentNotes(knowledgeNotes))
+      this.filterNotesByDateRange(this.filterRecentNotes(knowledgeNotes), true)
     );
 
     const uidIndex = this.buildUidIndex();
     const seenNoteIds = new Set<string>();
     const knowledgeBaseNames = this.scopeOptions.knowledgeBaseNames ?? {};
+    let knowledgeProcessed = 0;
 
     for (const note of filteredNotes) {
       if (this.cancelled) throw new SyncCancelledError();
       if (seenNoteIds.has(note.note_id)) continue;
       const failuresBeforeNote = result.failed;
       seenNoteIds.add(note.note_id);
+      knowledgeProcessed++;
       result.total++;
       if (note.fetch_error) {
         result.failed++;
         result.checkpointBlocked = true;
         this.recordItem(result, note, { status: 'failed', error: note.fetch_error });
         this.onProgress?.({
-          processed: result.total,
+          processed: knowledgeProcessed,
           total: filteredNotes.length,
           created: result.created,
           updated: result.updated,
           skipped: result.skipped,
           failed: result.failed,
-          percent: filteredNotes.length ? Math.round((result.total / filteredNotes.length) * 100) : 100,
+          percent: filteredNotes.length ? Math.round((knowledgeProcessed / filteredNotes.length) * 100) : 100,
         });
         continue;
       }
@@ -1104,13 +1106,13 @@ export class SyncEngine {
       if (result.failed > failuresBeforeNote) {
         result.checkpointBlocked = true;
         this.onProgress?.({
-          processed: result.total,
+          processed: knowledgeProcessed,
           total: filteredNotes.length,
           created: result.created,
           updated: result.updated,
           skipped: result.skipped,
           failed: result.failed,
-          percent: filteredNotes.length ? Math.round((result.total / filteredNotes.length) * 100) : 100,
+          percent: filteredNotes.length ? Math.round((knowledgeProcessed / filteredNotes.length) * 100) : 100,
         });
         continue;
       }
@@ -1154,13 +1156,13 @@ export class SyncEngine {
       }
 
       this.onProgress?.({
-        processed: result.total,
-        total: result.total,
+        processed: knowledgeProcessed,
+        total: filteredNotes.length,
         created: result.created,
         updated: result.updated,
         skipped: result.skipped,
         failed: result.failed,
-        percent: 0,
+        percent: filteredNotes.length ? Math.round((knowledgeProcessed / filteredNotes.length) * 100) : 100,
       });
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,7 @@ export interface SyncResult {
   total: number;
   items?: SyncResultItem[];
   lastNoteTimestamp?: string;  // updated_at of the last processed note
+  checkpointBlocked?: boolean; // note-level failure requires retry from the existing durable checkpoint
   /**
    * Tag names observed on processed notes during the sync. Used to
    * incrementally update the local tag cache without an extra network call.

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface GetNoteNote {
   assetPaths?: string[];      // 内部使用：所有附件文件的完整路径（图片、音频等）
   prime_id?: string;          // Web API detail identifier
   topic_id?: string;          // Knowledge-base topic identifier
+  fetch_error?: string;       // Internal: per-note knowledge detail failure
 }
 
 export interface LinkOriginal {

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1025,6 +1025,72 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
     }
   });
 
+  it('records an OpenAPI blogger detail payload that cannot be normalized as fetch_error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('/resource/knowledge/subscribe/list')) {
+        return mockFetchResponse({
+          data: { topics: [{ topic_id: 'topic_1', name: '长期专题' }], has_more: false },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/bloggers')) {
+        return mockFetchResponse({
+          data: { bloggers: [{ follow_id: 'blogger_1', name: '主理人' }], has_more: false },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/contents')) {
+        return mockFetchResponse({
+          data: {
+            contents: [{
+              post_id_alias: 'malformed_detail',
+              title: '详情格式异常文章',
+              summary: '不可写入的预览摘要',
+              created_at: '2026-01-01T10:00:00+08:00',
+              updated_at: '2026-01-01T10:00:00+08:00',
+            }],
+            has_more: false,
+          },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/content/detail')) {
+        return mockFetchResponse({ data: {} }) as Response;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app, makeSettings({
+        authMode: 'openapi',
+        openApiToken: 'openapi-token',
+        openApiClientId: 'openapi-client',
+      }));
+
+      const result = await engine.syncSubscribedKnowledge(undefined, {
+        syncAll: true,
+        topicIds: ['topic_1'],
+        knowledgeBaseName: '长期专题',
+      });
+
+      expect(result.created).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(result.checkpointBlocked).toBe(true);
+      expect(result.items).toEqual([
+        expect.objectContaining({
+          noteId: 'blogger_malformed_detail',
+          status: 'failed',
+          error: expect.any(String),
+        }),
+      ]);
+      expect(app.vault.create).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('不可写入的预览摘要')
+      );
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
   it('syncs exactly the selected Web API knowledge-base note and skips unrelated topics', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-04T12:00:00+08:00'));
@@ -3426,6 +3492,109 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
 
   beforeEach(() => {
     fetchSubscribedSpy.mockReset();
+  });
+
+  it('知识库失败进度使用知识库阶段自己的分子', async () => {
+    fetchSubscribedSpy.mockResolvedValue([
+      makeNote({
+        note_id: 'blogger_failed',
+        note_type: 'blogger_post',
+        source: 'blogger',
+        topic_id: 'kb-1',
+        fetch_error: 'temporary detail failure',
+      }),
+    ]);
+    vi.doMock('../src/api', async () => {
+      const actual = await vi.importActual<typeof import('../src/api')>('../src/api');
+      return {
+        ...actual,
+        fetchSubscribedKnowledgeNotes: fetchSubscribedSpy,
+      };
+    });
+    vi.resetModules();
+    const { SyncEngine: EngineReloaded } = await import('../src/sync');
+
+    try {
+      const progressSpy = vi.fn();
+      const engine = new EngineReloaded(makeMockApp(), makeSettings(), progressSpy, {
+        maxDays: 0,
+        syncKnowledgeBases: ['kb-1'],
+      });
+      const result = {
+        created: 10,
+        updated: 0,
+        skipped: 0,
+        failed: 0,
+        total: 10,
+        items: [],
+      };
+
+      await engine['runCrossKnowledgeBaseSync'](result, new AbortController().signal);
+
+      expect(progressSpy).toHaveBeenCalledWith(expect.objectContaining({
+        processed: 1,
+        total: 1,
+        percent: 100,
+      }));
+    } finally {
+      vi.doUnmock('../src/api');
+      vi.resetModules();
+    }
+  });
+
+  it('保留更新时间恰好等于自动同步断点的知识库笔记', async () => {
+    const checkpoint = '2026-07-17T10:00:00+08:00';
+    fetchSubscribedSpy.mockResolvedValue([
+      makeNote({
+        note_id: 'blogger_checkpoint_equal',
+        title: '断点同秒文章',
+        note_type: 'blogger_post',
+        source: 'blogger',
+        topic_id: 'kb-1',
+        created_at: checkpoint,
+        updated_at: checkpoint,
+      }),
+    ]);
+    vi.doMock('../src/api', async () => {
+      const actual = await vi.importActual<typeof import('../src/api')>('../src/api');
+      return {
+        ...actual,
+        fetchSubscribedKnowledgeNotes: fetchSubscribedSpy,
+      };
+    });
+    vi.resetModules();
+    const { SyncEngine: EngineReloaded } = await import('../src/sync');
+
+    try {
+      const app = makeMockApp();
+      const engine = new EngineReloaded(app, makeSettings(), undefined, {
+        maxDays: 0,
+        syncStartDate: checkpoint,
+        syncKnowledgeBases: ['kb-1'],
+        knowledgeBaseNames: { 'kb-1': '测试知识库' },
+      });
+      const result = {
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        failed: 0,
+        total: 0,
+        items: [],
+      };
+
+      await engine['runCrossKnowledgeBaseSync'](result, new AbortController().signal);
+
+      expect(result.created).toBe(1);
+      expect(result.items).toEqual([
+        expect.objectContaining({
+          noteId: 'blogger_checkpoint_equal',
+          status: 'created',
+        }),
+      ]);
+    } finally {
+      vi.doUnmock('../src/api');
+      vi.resetModules();
+    }
   });
 
   it('普通跨库同步复用 maxDays 和笔记类型过滤', async () => {

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -3383,6 +3383,145 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
     fetchSubscribedSpy.mockReset();
   });
 
+  it('普通跨库同步复用 maxDays 和笔记类型过滤', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-17T12:00:00+08:00'));
+    fetchSubscribedSpy.mockResolvedValue([
+      makeNote({
+        id: 'recent-blogger',
+        note_id: 'blogger_recent',
+        title: '近期博主文章',
+        note_type: 'blogger_post',
+        source: 'blogger',
+        topic_id: 'kb-1',
+        created_at: '2026-07-16T10:00:00+08:00',
+        updated_at: '2026-07-16T10:00:00+08:00',
+      }),
+      makeNote({
+        id: 'old-blogger',
+        note_id: 'blogger_old',
+        title: '过期博主文章',
+        note_type: 'blogger_post',
+        source: 'blogger',
+        topic_id: 'kb-1',
+        created_at: '2026-06-01T10:00:00+08:00',
+        updated_at: '2026-06-01T10:00:00+08:00',
+      }),
+      makeNote({
+        id: 'recent-plain',
+        note_id: 'recent_plain',
+        title: '近期普通笔记',
+        note_type: 'plain_text',
+        source: 'knowledge',
+        topic_id: 'kb-1',
+        created_at: '2026-07-16T10:00:00+08:00',
+        updated_at: '2026-07-16T10:00:00+08:00',
+      }),
+    ]);
+    vi.doMock('../src/api', async () => {
+      const actual = await vi.importActual<typeof import('../src/api')>('../src/api');
+      return {
+        ...actual,
+        fetchSubscribedKnowledgeNotes: fetchSubscribedSpy,
+      };
+    });
+    vi.resetModules();
+    const { SyncEngine: EngineReloaded } = await import('../src/sync');
+
+    try {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({
+        success: true,
+        data: { notes: [], has_more: false, next_cursor: '0' },
+      }) as Response);
+      const app = makeMockApp();
+      const engine = new EngineReloaded(app, makeSettings({ maxDays: 7 }), undefined, {
+        maxDays: 7,
+        enabledNoteTypes: ['blogger_post'],
+        syncKnowledgeBases: ['kb-1'],
+        knowledgeBaseNames: { 'kb-1': '测试知识库' },
+      });
+
+      const result = await engine.sync();
+
+      expect(result.items).toEqual([
+        expect.objectContaining({
+          noteId: 'blogger_recent',
+          noteType: 'blogger_post',
+          status: 'created',
+        }),
+      ]);
+      expect(app.vault.create).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.doUnmock('../src/api');
+      vi.resetModules();
+      vi.useRealTimers();
+    }
+  });
+
+  it('跨库单笔写入失败后继续后续笔记并阻止自动断点前移', async () => {
+    fetchSubscribedSpy.mockResolvedValue([
+      makeNote({
+        id: 'failed-blogger',
+        note_id: 'blogger_failed',
+        title: '写入失败文章',
+        note_type: 'blogger_post',
+        source: 'blogger',
+        topic_id: 'kb-1',
+        updated_at: '2026-07-17T11:00:00+08:00',
+      }),
+      makeNote({
+        id: 'successful-blogger',
+        note_id: 'blogger_successful',
+        title: '后续成功文章',
+        note_type: 'blogger_post',
+        source: 'blogger',
+        topic_id: 'kb-1',
+        updated_at: '2026-07-17T10:00:00+08:00',
+      }),
+    ]);
+    vi.doMock('../src/api', async () => {
+      const actual = await vi.importActual<typeof import('../src/api')>('../src/api');
+      return {
+        ...actual,
+        fetchSubscribedKnowledgeNotes: fetchSubscribedSpy,
+      };
+    });
+    vi.resetModules();
+    const { SyncEngine: EngineReloaded } = await import('../src/sync');
+
+    try {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({
+        success: true,
+        data: { notes: [], has_more: false, next_cursor: '0' },
+      }) as Response);
+      const app = makeMockApp();
+      vi.mocked(app.vault.create).mockRejectedValueOnce(new Error('disk full'));
+      const engine = new EngineReloaded(app, makeSettings({
+        maxDays: 0,
+        lastSyncEndTimestamp: '2026-07-16T10:00:00+08:00',
+      }), undefined, {
+        maxDays: 0,
+        syncKnowledgeBases: ['kb-1'],
+        knowledgeBaseNames: { 'kb-1': '测试知识库' },
+      });
+
+      const result = await engine.sync();
+
+      expect(result.items).toEqual([
+        expect.objectContaining({ noteId: 'blogger_failed', status: 'failed', error: 'disk full' }),
+        expect.objectContaining({ noteId: 'blogger_successful', status: 'created' }),
+      ]);
+      expect(result.created).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.checkpointBlocked).toBe(true);
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.doUnmock('../src/api');
+      vi.resetModules();
+    }
+  });
+
   it('syncKnowledgeBases=[] 时不调用 fetchSubscribedKnowledgeNotes（关闭跨库同步）', async () => {
     fetchSubscribedSpy.mockResolvedValue([]);
     vi.doMock('../src/api', async () => {

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1025,6 +1025,72 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
     }
   });
 
+  it('propagates OpenAPI quota exhaustion from a blogger detail request', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('/resource/knowledge/subscribe/list')) {
+        return mockFetchResponse({
+          data: { topics: [{ topic_id: 'topic_1', name: '长期专题' }], has_more: false },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/bloggers')) {
+        return mockFetchResponse({
+          data: { bloggers: [{ follow_id: 'blogger_1', name: '主理人' }], has_more: false },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/contents')) {
+        return mockFetchResponse({
+          data: {
+            contents: [{
+              post_id_alias: 'quota_exhausted',
+              title: '配额耗尽文章',
+              summary: '不可降级写入的预览摘要',
+              created_at: '2026-01-01T10:00:00+08:00',
+              updated_at: '2026-01-01T10:00:00+08:00',
+            }],
+            has_more: false,
+          },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/content/detail')) {
+        return {
+          status: 429,
+          text: async () => JSON.stringify({
+            error: { reason: 'quota_day', message: 'quota exhausted' },
+          }),
+        } as Response;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app, makeSettings({
+        authMode: 'openapi',
+        openApiToken: 'openapi-token',
+        openApiClientId: 'openapi-client',
+      }));
+
+      const outcomePromise = engine.syncSubscribedKnowledge(undefined, {
+        syncAll: true,
+        topicIds: ['topic_1'],
+        knowledgeBaseName: '长期专题',
+      }).then(
+        value => ({ value }),
+        error => ({ error }),
+      );
+      await vi.runAllTimersAsync();
+      const outcome = await outcomePromise;
+
+      expect(outcome).toEqual({ error: expect.any(Error) });
+      expect(app.vault.create).not.toHaveBeenCalled();
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('records an OpenAPI blogger detail payload that cannot be normalized as fetch_error', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const requestUrl = String(url);

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1091,6 +1091,81 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
     }
   });
 
+  it.each([
+    {
+      name: 'authentication',
+      detailResponse: () => ({
+        status: 401,
+        text: async () => '',
+      } as Response),
+    },
+    {
+      name: 'membership',
+      detailResponse: () => ({
+        status: 403,
+        text: async () => JSON.stringify({
+          success: false,
+          error: { code: 10201, message: 'membership required' },
+        }),
+      } as Response),
+    },
+  ])('propagates OpenAPI $name failure from a blogger detail request', async ({ detailResponse }) => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('/resource/knowledge/subscribe/list')) {
+        return mockFetchResponse({
+          data: { topics: [{ topic_id: 'topic_1', name: '长期专题' }], has_more: false },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/bloggers')) {
+        return mockFetchResponse({
+          data: { bloggers: [{ follow_id: 'blogger_1', name: '主理人' }], has_more: false },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/contents')) {
+        return mockFetchResponse({
+          data: {
+            contents: [{
+              post_id_alias: 'fatal_detail_failure',
+              title: '全局错误文章',
+              summary: '不可降级写入的预览摘要',
+              created_at: '2026-01-01T10:00:00+08:00',
+              updated_at: '2026-01-01T10:00:00+08:00',
+            }],
+            has_more: false,
+          },
+        }) as Response;
+      }
+      if (requestUrl.includes('/resource/knowledge/blogger/content/detail')) {
+        return detailResponse();
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    try {
+      const app = makeMockApp();
+      const engine = new SyncEngine(app, makeSettings({
+        authMode: 'openapi',
+        openApiToken: 'openapi-token',
+        openApiClientId: 'openapi-client',
+      }));
+
+      const outcome = await engine.syncSubscribedKnowledge(undefined, {
+        syncAll: true,
+        topicIds: ['topic_1'],
+        knowledgeBaseName: '长期专题',
+      }).then(
+        value => ({ value }),
+        error => ({ error }),
+      );
+
+      expect(outcome).toEqual({ error: expect.any(Error) });
+      expect(app.vault.create).not.toHaveBeenCalled();
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
   it('records an OpenAPI blogger detail payload that cannot be normalized as fetch_error', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const requestUrl = String(url);

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -920,7 +920,7 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
     }
   });
 
-  it('falls back to the OpenAPI content preview when the detail request times out', async () => {
+  it('records an OpenAPI blogger detail failure and continues with the next article', async () => {
     vi.useFakeTimers();
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const requestUrl = String(url);
@@ -937,19 +937,39 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
       if (requestUrl.includes('/resource/knowledge/blogger/contents')) {
         return mockFetchResponse({
           data: {
-            contents: [{
-              post_id_alias: 'old_post',
-              title: '旧文章',
-              summary: '详情接口不可用时仍应同步的摘要',
-              created_at: '2026-01-01T10:00:00+08:00',
-              updated_at: '2026-01-01T10:00:00+08:00',
-            }],
+            contents: [
+              {
+                post_id_alias: 'failed_post',
+                title: '详情失败文章',
+                summary: '不可静默写入的预览摘要',
+                created_at: '2026-01-01T10:00:00+08:00',
+                updated_at: '2026-01-01T10:00:00+08:00',
+              },
+              {
+                post_id_alias: 'successful_post',
+                title: '后续文章',
+                summary: '后续文章摘要',
+                created_at: '2026-01-02T10:00:00+08:00',
+                updated_at: '2026-01-02T10:00:00+08:00',
+              },
+            ],
             has_more: false,
           },
         }) as Response;
       }
       if (requestUrl.includes('/resource/knowledge/blogger/content/detail')) {
-        return new Promise<Response>(() => {});
+        if (requestUrl.includes('post_id=failed_post')) {
+          return new Promise<Response>(() => {});
+        }
+        return mockFetchResponse({
+          data: {
+            post_id: 'successful_post',
+            title: '后续文章',
+            content: '后续文章详情',
+            created_at: '2026-01-02T10:00:00+08:00',
+            updated_at: '2026-01-02T10:00:00+08:00',
+          },
+        }) as Response;
       }
       throw new Error(`Unexpected request: ${requestUrl}`);
     });
@@ -963,16 +983,35 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
       }));
 
       const resultPromise = engine.syncSubscribedKnowledge(undefined, {
-        selectedNoteIds: ['blogger_old_post'],
+        syncAll: true,
+        topicIds: ['topic_1'],
+        knowledgeBaseName: '长期专题',
       });
       await vi.runAllTimersAsync();
       const result = await resultPromise;
 
-      expect(result.total).toBe(1);
+      expect(result.total).toBe(2);
       expect(result.created).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.items).toEqual([
+        expect.objectContaining({
+          noteId: 'blogger_failed_post',
+          status: 'failed',
+          error: expect.any(String),
+        }),
+        expect.objectContaining({
+          noteId: 'blogger_successful_post',
+          status: 'created',
+        }),
+      ]);
+      expect(result.checkpointBlocked).toBe(true);
       expect(app.vault.create).toHaveBeenCalledWith(
         expect.any(String),
-        expect.stringContaining('详情接口不可用时仍应同步的摘要')
+        expect.stringContaining('后续文章详情')
+      );
+      expect(app.vault.create).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('不可静默写入的预览摘要')
       );
     } finally {
       vi.mocked(globalThis.fetch).mockRestore();
@@ -3515,6 +3554,91 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
       expect(result.created).toBe(1);
       expect(result.failed).toBe(1);
       expect(result.checkpointBlocked).toBe(true);
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+      vi.doUnmock('../src/api');
+      vi.resetModules();
+    }
+  });
+
+  it('下轮同步在父笔记已存在时重试失败的 append 子笔记并恢复断点', async () => {
+    const parentNote = makeNote({
+      id: 'parent',
+      note_id: 'knowledge_parent',
+      title: '父笔记',
+      note_type: 'plain_text',
+      source: 'knowledge',
+      topic_id: 'kb-1',
+      children_count: 1,
+      children_ids: ['knowledge_child'],
+      updated_at: '2026-07-17T11:00:00+08:00',
+    });
+    const fetchDetailSpy = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary child fetch failure'))
+      .mockResolvedValue({
+        id: 'child',
+        note_id: 'knowledge_child',
+        title: '子笔记',
+        content: '子笔记正文',
+        note_type: 'plain_text',
+        source: 'knowledge',
+        tags: [],
+        created_at: '2026-07-17T10:00:00+08:00',
+        updated_at: '2026-07-17T10:00:00+08:00',
+        parent_id: 'knowledge_parent',
+        is_child_note: true,
+      });
+    fetchSubscribedSpy.mockResolvedValue([parentNote]);
+    vi.doMock('../src/api', async () => {
+      const actual = await vi.importActual<typeof import('../src/api')>('../src/api');
+      return {
+        ...actual,
+        fetchSubscribedKnowledgeNotes: fetchSubscribedSpy,
+        fetchNoteDetail: fetchDetailSpy,
+      };
+    });
+    vi.resetModules();
+    const { SyncEngine: EngineReloaded } = await import('../src/sync');
+
+    try {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({
+        success: true,
+        data: { notes: [], has_more: false, next_cursor: '0' },
+      }) as Response);
+      const app = makeMockApp();
+      const settings = makeSettings({ maxDays: 0 });
+      const scope = {
+        maxDays: 0,
+        syncKnowledgeBases: ['kb-1'],
+        knowledgeBaseNames: { 'kb-1': '测试知识库' },
+      };
+
+      const firstResult = await new EngineReloaded(app, settings, undefined, scope).sync();
+
+      expect(firstResult.items).toEqual([
+        expect.objectContaining({
+          noteId: 'knowledge_child',
+          status: 'failed',
+          error: 'temporary child fetch failure',
+        }),
+        expect.objectContaining({ noteId: 'knowledge_parent', status: 'created' }),
+      ]);
+      expect(firstResult.checkpointBlocked).toBe(true);
+      app.vault._addFile(
+        '得到大脑/知识库/测试知识库/纯文本/父笔记.md',
+        '---\nuid: "knowledge_parent"\nmodified: "2026-07-17 11:00:00"\n---\n父笔记正文',
+        { uid: 'knowledge_parent', modified: '2026-07-17 11:00:00' }
+      );
+
+      const secondResult = await new EngineReloaded(app, settings, undefined, scope).sync();
+
+      expect(secondResult.items).toEqual([
+        expect.objectContaining({ noteId: 'knowledge_parent', status: 'skipped' }),
+        expect.objectContaining({ noteId: 'knowledge_child', status: 'created' }),
+      ]);
+      expect(secondResult.checkpointBlocked).not.toBe(true);
+      expect(secondResult.lastNoteTimestamp).toBe('2026-07-17T11:00:00+08:00');
+      expect(fetchDetailSpy).toHaveBeenCalledTimes(2);
     } finally {
       vi.mocked(globalThis.fetch).mockRestore();
       vi.doUnmock('../src/api');

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -976,11 +976,12 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
 
     try {
       const app = makeMockApp();
+      const progressSpy = vi.fn();
       const engine = new SyncEngine(app, makeSettings({
         authMode: 'openapi',
         openApiToken: 'openapi-token',
         openApiClientId: 'openapi-client',
-      }));
+      }), progressSpy);
 
       const resultPromise = engine.syncSubscribedKnowledge(undefined, {
         syncAll: true,
@@ -1005,6 +1006,11 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
         }),
       ]);
       expect(result.checkpointBlocked).toBe(true);
+      expect(progressSpy).toHaveBeenCalledWith(expect.objectContaining({
+        processed: 1,
+        total: 2,
+        failed: 1,
+      }));
       expect(app.vault.create).toHaveBeenCalledWith(
         expect.any(String),
         expect.stringContaining('后续文章详情')
@@ -3561,7 +3567,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
     }
   });
 
-  it('下轮同步在父笔记已存在时重试失败的 append 子笔记并恢复断点', async () => {
+  it('append 获取不完整时不写父子文件并在下轮原子重试完整关系', async () => {
     const parentNote = makeNote({
       id: 'parent',
       note_id: 'knowledge_parent',
@@ -3569,25 +3575,35 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
       note_type: 'plain_text',
       source: 'knowledge',
       topic_id: 'kb-1',
-      children_count: 1,
-      children_ids: ['knowledge_child'],
+      children_count: 2,
+      children_ids: ['knowledge_child_1', 'knowledge_child_2'],
       updated_at: '2026-07-17T11:00:00+08:00',
     });
+    const firstChild = {
+      id: 'child-1',
+      note_id: 'knowledge_child_1',
+      title: '子笔记一',
+      content: '子笔记一正文',
+      note_type: 'plain_text',
+      source: 'knowledge',
+      tags: [],
+      created_at: '2026-07-17T10:00:00+08:00',
+      updated_at: '2026-07-17T10:00:00+08:00',
+      parent_id: 'knowledge_parent',
+      is_child_note: true,
+    };
+    const secondChild = {
+      ...firstChild,
+      id: 'child-2',
+      note_id: 'knowledge_child_2',
+      title: '子笔记二',
+      content: '子笔记二正文',
+    };
     const fetchDetailSpy = vi.fn()
+      .mockResolvedValueOnce(firstChild)
       .mockRejectedValueOnce(new Error('temporary child fetch failure'))
-      .mockResolvedValue({
-        id: 'child',
-        note_id: 'knowledge_child',
-        title: '子笔记',
-        content: '子笔记正文',
-        note_type: 'plain_text',
-        source: 'knowledge',
-        tags: [],
-        created_at: '2026-07-17T10:00:00+08:00',
-        updated_at: '2026-07-17T10:00:00+08:00',
-        parent_id: 'knowledge_parent',
-        is_child_note: true,
-      });
+      .mockResolvedValueOnce(firstChild)
+      .mockResolvedValueOnce(secondChild);
     fetchSubscribedSpy.mockResolvedValue([parentNote]);
     vi.doMock('../src/api', async () => {
       const actual = await vi.importActual<typeof import('../src/api')>('../src/api');
@@ -3612,33 +3628,43 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
         syncKnowledgeBases: ['kb-1'],
         knowledgeBaseNames: { 'kb-1': '测试知识库' },
       };
+      const firstProgressSpy = vi.fn();
 
-      const firstResult = await new EngineReloaded(app, settings, undefined, scope).sync();
+      const firstResult = await new EngineReloaded(app, settings, firstProgressSpy, scope).sync();
 
       expect(firstResult.items).toEqual([
         expect.objectContaining({
-          noteId: 'knowledge_child',
+          noteId: 'knowledge_child_2',
           status: 'failed',
           error: 'temporary child fetch failure',
         }),
-        expect.objectContaining({ noteId: 'knowledge_parent', status: 'created' }),
       ]);
       expect(firstResult.checkpointBlocked).toBe(true);
-      app.vault._addFile(
-        '得到大脑/知识库/测试知识库/纯文本/父笔记.md',
-        '---\nuid: "knowledge_parent"\nmodified: "2026-07-17 11:00:00"\n---\n父笔记正文',
-        { uid: 'knowledge_parent', modified: '2026-07-17 11:00:00' }
-      );
+      expect(firstProgressSpy).toHaveBeenCalledWith(expect.objectContaining({
+        processed: 1,
+        total: 1,
+        failed: 1,
+      }));
+      expect(app.vault.create).not.toHaveBeenCalled();
 
       const secondResult = await new EngineReloaded(app, settings, undefined, scope).sync();
 
       expect(secondResult.items).toEqual([
-        expect.objectContaining({ noteId: 'knowledge_parent', status: 'skipped' }),
-        expect.objectContaining({ noteId: 'knowledge_child', status: 'created' }),
+        expect.objectContaining({ noteId: 'knowledge_parent', status: 'created' }),
+        expect.objectContaining({ noteId: 'knowledge_child_1', status: 'created' }),
+        expect.objectContaining({ noteId: 'knowledge_child_2', status: 'created' }),
       ]);
       expect(secondResult.checkpointBlocked).not.toBe(true);
       expect(secondResult.lastNoteTimestamp).toBe('2026-07-17T11:00:00+08:00');
-      expect(fetchDetailSpy).toHaveBeenCalledTimes(2);
+      expect(fetchDetailSpy).toHaveBeenCalledTimes(4);
+      expect(app.vault.create).toHaveBeenCalledWith(
+        expect.stringContaining('/父笔记.md'),
+        expect.stringContaining('[[父笔记__子笔记一]]')
+      );
+      expect(app.vault.create).toHaveBeenCalledWith(
+        expect.stringContaining('/父笔记.md'),
+        expect.stringContaining('[[父笔记__子笔记二]]')
+      );
     } finally {
       vi.mocked(globalThis.fetch).mockRestore();
       vi.doUnmock('../src/api');

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -300,6 +300,28 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     expect(plugin.settings.lastSyncEndTimestamp).toBe('2026-05-10T12:00:00+08:00');
   });
 
+  it('keeps the existing auto-sync checkpoint when a retryable knowledge note failed', async () => {
+    vi.spyOn(SyncEngine.prototype, 'sync').mockResolvedValue({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 1,
+      total: 2,
+      items: [],
+      lastNoteTimestamp: '2026-05-10T12:00:00+08:00',
+      checkpointBlocked: true,
+    });
+    const plugin = makePlugin();
+    plugin.settings.lastSyncEndTimestamp = '2026-05-09T10:00:00+08:00';
+
+    await plugin['runSync']('auto', {
+      maxDays: 0,
+      syncStartDate: plugin.settings.lastSyncEndTimestamp,
+    });
+
+    expect(plugin.settings.lastSyncEndTimestamp).toBe('2026-05-09T10:00:00+08:00');
+  });
+
   it('selected sync records the note type filter from the picker scope', async () => {
     vi.spyOn(SyncEngine.prototype, 'syncNoteIds').mockResolvedValue({
       created: 0,


### PR DESCRIPTION
## Summary

- apply normal time-window and note-type filters to subscribed-blogger knowledge-base sync
- continue after per-note OpenAPI detail or vault write failures while preserving the durable checkpoint for retry
- retry parent and append-note groups atomically so parent links stay complete

## Why

Knowledge-base sync already enumerated subscribed blogger posts, but its normal path bypassed max-days and note-type filters. Partial detail/append failures could also be hidden or permanently crossed by the automatic checkpoint.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` (599 passed, 2 skipped)
- `npm run build`
- independent code review: 0 Critical / 0 Important

Closes #192