### PR TITLE
fix: support floating selects in Obsidian popout windows

### DIFF
--- a/docs/superpowers/plans/2026-07-26-issue-204-popout-selects.md
+++ b/docs/superpowers/plans/2026-07-26-issue-204-popout-selects.md
@@ -1,0 +1,7 @@
+# Issue #204 popout implementation plan
+
+1. Add failing second-window tests for open/select, outside click, resize/scroll repositioning, same-window one-open coordination, and main-window isolation.
+2. Resolve the owning document/window from the rendered root and register all listeners/events in that realm.
+3. Run focused tests and the full repository gate.
+4. Deploy to local Obsidian and verify Tag, note-type, and knowledge-base selects in the main window and an actual popout.
+5. Push a focused PR to `main` and monitor CI.

--- a/docs/superpowers/specs/2026-07-26-issue-204-popout-selects-design.md
+++ b/docs/superpowers/specs/2026-07-26-issue-204-popout-selects-design.md
@@ -1,0 +1,5 @@
+# Issue #204: Floating selects in Obsidian popouts
+
+Floating Tag, note-type, and knowledge-base selects must behave identically in the main window and an actual Obsidian popout. Every listener and coordination event belongs to the trigger element's `ownerDocument` and `defaultView`, with `activeDocument` only as a fallback.
+
+Opening, positioning, scroll/resize repositioning, outside-click closing, and one-open-select coordination remain unchanged within each window. Events in the main window must not be required to operate or close a select in a popout. This change adds no new keyboard or accessibility behavior.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -55,7 +55,12 @@ export function notifyLegacyPluginDataMigrated(migrated: boolean): void {
 }
 
 function closeFloatingSelects(): void {
-  window.dispatchEvent(new Event(CLOSE_FLOATING_SELECTS_EVENT));
+  const hostDocument = typeof activeDocument === 'undefined' ? document : activeDocument;
+  const hostWindow = hostDocument.defaultView
+    ?? (typeof activeWindow === 'undefined' ? window : activeWindow);
+  const closeEvent = hostDocument.createEvent('Event');
+  closeEvent.initEvent(CLOSE_FLOATING_SELECTS_EVENT, false, false);
+  hostWindow.dispatchEvent(closeEvent);
 }
 
 async function findExistingLegacyDataPath(adapter: PluginDataMigrationAdapter): Promise<string | null> {

--- a/src/ui/use-floating-select-menu.ts
+++ b/src/ui/use-floating-select-menu.ts
@@ -2,6 +2,17 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 
 const CLOSE_FLOATING_SELECTS_EVENT = 'getnote-close-floating-selects';
 
+function resolveHostRealm(root: HTMLDivElement | null): {
+  hostDocument: Document;
+  hostWindow: Window;
+} {
+  const fallbackDocument = typeof activeDocument === 'undefined' ? document : activeDocument;
+  const hostDocument = root?.ownerDocument ?? fallbackDocument;
+  const fallbackWindow = typeof activeWindow === 'undefined' ? window : activeWindow;
+  const hostWindow = hostDocument.defaultView ?? fallbackDocument.defaultView ?? fallbackWindow;
+  return { hostDocument, hostWindow };
+}
+
 export function useFloatingSelectMenu<TTrigger extends HTMLElement>() {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -10,8 +21,9 @@ export function useFloatingSelectMenu<TTrigger extends HTMLElement>() {
 
   useEffect(() => {
     const close = () => setOpen(false);
-    window.addEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
-    return () => window.removeEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+    const { hostWindow } = resolveHostRealm(rootRef.current);
+    hostWindow.addEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+    return () => hostWindow.removeEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
   }, []);
 
   useEffect(() => {
@@ -29,20 +41,25 @@ export function useFloatingSelectMenu<TTrigger extends HTMLElement>() {
       if (rootRef.current?.contains(event.target as Node)) return;
       setOpen(false);
     };
-    const hostDocument = rootRef.current?.ownerDocument ?? document;
+    const { hostDocument, hostWindow } = resolveHostRealm(rootRef.current);
     positionMenu();
     hostDocument.addEventListener('mousedown', handlePointerDown);
-    window.addEventListener('resize', positionMenu);
-    window.addEventListener('scroll', positionMenu, true);
+    hostWindow.addEventListener('resize', positionMenu);
+    hostWindow.addEventListener('scroll', positionMenu, true);
     return () => {
       hostDocument.removeEventListener('mousedown', handlePointerDown);
-      window.removeEventListener('resize', positionMenu);
-      window.removeEventListener('scroll', positionMenu, true);
+      hostWindow.removeEventListener('resize', positionMenu);
+      hostWindow.removeEventListener('scroll', positionMenu, true);
     };
   }, [open]);
 
   const toggleOpen = () => {
-    if (!open) window.dispatchEvent(new Event(CLOSE_FLOATING_SELECTS_EVENT));
+    if (!open) {
+      const { hostDocument, hostWindow } = resolveHostRealm(rootRef.current);
+      const closeEvent = hostDocument.createEvent('Event');
+      closeEvent.initEvent(CLOSE_FLOATING_SELECTS_EVENT, false, false);
+      hostWindow.dispatchEvent(closeEvent);
+    }
     setOpen(!open);
   };
 

--- a/src/ui/use-floating-select-menu.ts
+++ b/src/ui/use-floating-select-menu.ts
@@ -29,12 +29,13 @@ export function useFloatingSelectMenu<TTrigger extends HTMLElement>() {
       if (rootRef.current?.contains(event.target as Node)) return;
       setOpen(false);
     };
+    const hostDocument = rootRef.current?.ownerDocument ?? document;
     positionMenu();
-    document.addEventListener('mousedown', handlePointerDown);
+    hostDocument.addEventListener('mousedown', handlePointerDown);
     window.addEventListener('resize', positionMenu);
     window.addEventListener('scroll', positionMenu, true);
     return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
+      hostDocument.removeEventListener('mousedown', handlePointerDown);
       window.removeEventListener('resize', positionMenu);
       window.removeEventListener('scroll', positionMenu, true);
     };

--- a/src/ui/use-floating-select-menu.ts
+++ b/src/ui/use-floating-select-menu.ts
@@ -21,9 +21,17 @@ export function useFloatingSelectMenu<TTrigger extends HTMLElement>() {
 
   useEffect(() => {
     const close = () => setOpen(false);
-    const { hostWindow } = resolveHostRealm(rootRef.current);
+    let { hostWindow } = resolveHostRealm(rootRef.current);
     hostWindow.addEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
-    return () => hostWindow.removeEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+    const stopListeningForMigration = rootRef.current?.onWindowMigrated?.((nextWindow) => {
+      hostWindow.removeEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+      hostWindow = nextWindow;
+      hostWindow.addEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+    });
+    return () => {
+      stopListeningForMigration?.();
+      hostWindow.removeEventListener(CLOSE_FLOATING_SELECTS_EVENT, close);
+    };
   }, []);
 
   useEffect(() => {
@@ -41,15 +49,29 @@ export function useFloatingSelectMenu<TTrigger extends HTMLElement>() {
       if (rootRef.current?.contains(event.target as Node)) return;
       setOpen(false);
     };
-    const { hostDocument, hostWindow } = resolveHostRealm(rootRef.current);
-    positionMenu();
-    hostDocument.addEventListener('mousedown', handlePointerDown);
-    hostWindow.addEventListener('resize', positionMenu);
-    hostWindow.addEventListener('scroll', positionMenu, true);
-    return () => {
+    let { hostDocument, hostWindow } = resolveHostRealm(rootRef.current);
+    const addHostListeners = () => {
+      hostDocument.addEventListener('mousedown', handlePointerDown);
+      hostWindow.addEventListener('resize', positionMenu);
+      hostWindow.addEventListener('scroll', positionMenu, true);
+    };
+    const removeHostListeners = () => {
       hostDocument.removeEventListener('mousedown', handlePointerDown);
       hostWindow.removeEventListener('resize', positionMenu);
       hostWindow.removeEventListener('scroll', positionMenu, true);
+    };
+    positionMenu();
+    addHostListeners();
+    const stopListeningForMigration = rootRef.current?.onWindowMigrated?.((nextWindow) => {
+      removeHostListeners();
+      hostDocument = rootRef.current?.ownerDocument ?? nextWindow.document;
+      hostWindow = nextWindow;
+      positionMenu();
+      addHostListeners();
+    });
+    return () => {
+      stopListeningForMigration?.();
+      removeHostListeners();
     };
   }, [open]);
 

--- a/tests/floating-select-menu.spec.ts
+++ b/tests/floating-select-menu.spec.ts
@@ -54,4 +54,23 @@ describe('floating select menu behavior', () => {
 
     expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
   });
+
+  it('closes an open floating select on outside mouse down in its owning document', async () => {
+    const popoutDocument = document.implementation.createHTMLDocument('popout');
+    const container = popoutDocument.createElement('div');
+    popoutDocument.body.appendChild(container);
+    render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+
+    await act(() => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeTruthy();
+
+    await act(() => {
+      popoutDocument.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
+    render(null, container);
+  });
 });

--- a/tests/floating-select-menu.spec.ts
+++ b/tests/floating-select-menu.spec.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Window } from 'happy-dom';
 import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NoteTypeSelect } from '../src/ui/note-type-select';
 
 afterEach(() => {
@@ -9,8 +10,20 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
+function createPopout() {
+  const popoutWindow = new Window({ url: 'https://getnote.test/popout' });
+  const container = popoutWindow.document.createElement('div');
+  popoutWindow.document.body.appendChild(container);
+  return { popoutWindow, container };
+}
+
+function openSelect(popoutWindow: Window, container: HTMLElement, index = 0) {
+  const trigger = container.querySelectorAll<HTMLButtonElement>('.getnote-note-type-select-trigger')[index];
+  trigger.dispatchEvent(new popoutWindow.MouseEvent('click', { bubbles: true }));
+}
+
 describe('floating select menu behavior', () => {
-  it('keeps the existing global close coordination between floating selects', async () => {
+  it('keeps one floating select open in the main window', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(
@@ -38,7 +51,7 @@ describe('floating select menu behavior', () => {
     expect(triggers[1].querySelector('.is-open')).toBeTruthy();
   });
 
-  it('closes an open floating select on outside mouse down', async () => {
+  it('closes an open floating select on outside mouse down in the main window', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
@@ -55,22 +68,133 @@ describe('floating select menu behavior', () => {
     expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
   });
 
-  it('closes an open floating select on outside mouse down in its owning document', async () => {
-    const popoutDocument = document.implementation.createHTMLDocument('popout');
-    const container = popoutDocument.createElement('div');
-    popoutDocument.body.appendChild(container);
-    render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+  it('opens and selects an option in a popout window realm', async () => {
+    const { popoutWindow, container } = createPopout();
+    const onChange = vi.fn();
+    render(h(NoteTypeSelect, { onChange }), container);
+
+    await act(() => openSelect(popoutWindow, container));
+    const plainText = container.querySelector<HTMLInputElement>(
+      '.getnote-note-type-select-option:nth-child(2) input'
+    );
+    expect(plainText).toBeTruthy();
 
     await act(() => {
-      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      plainText!.checked = false;
+      plainText!.dispatchEvent(new popoutWindow.Event('change', { bubbles: true }));
     });
+
+    expect(onChange).toHaveBeenCalledWith(expect.not.arrayContaining(['plain_text']));
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('closes an open floating select on outside mouse down in its popout document', async () => {
+    const { popoutWindow, container } = createPopout();
+    render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+
+    await act(() => openSelect(popoutWindow, container));
     expect(container.querySelector('.getnote-note-type-select-menu')).toBeTruthy();
 
     await act(() => {
-      popoutDocument.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      popoutWindow.document.body.dispatchEvent(new popoutWindow.MouseEvent('mousedown', { bubbles: true }));
     });
 
     expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
     render(null, container);
+    popoutWindow.close();
+  });
+
+  it('repositions a popout menu on its own resize and capture scroll events', async () => {
+    const { popoutWindow, container } = createPopout();
+    render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+    const trigger = container.querySelector<HTMLButtonElement>('.getnote-note-type-select-trigger')!;
+    let rect = { bottom: 20, left: 10, width: 120 };
+    vi.spyOn(trigger, 'getBoundingClientRect').mockImplementation(
+      () => ({ ...rect }) as DOMRect
+    );
+
+    await act(() => openSelect(popoutWindow, container));
+    const menu = container.querySelector<HTMLElement>('.getnote-note-type-select-menu')!;
+    expect(menu.style.top).toBe('24px');
+    expect(menu.style.left).toBe('10px');
+    expect(menu.style.width).toBe('120px');
+
+    rect = { bottom: 40, left: 30, width: 160 };
+    await act(() => {
+      popoutWindow.dispatchEvent(new popoutWindow.Event('resize'));
+    });
+    expect(menu.style.top).toBe('44px');
+    expect(menu.style.left).toBe('30px');
+    expect(menu.style.width).toBe('160px');
+
+    rect = { bottom: 60, left: 50, width: 180 };
+    const scrollTarget = popoutWindow.document.createElement('div');
+    container.appendChild(scrollTarget);
+    await act(() => {
+      scrollTarget.dispatchEvent(new popoutWindow.Event('scroll'));
+    });
+    expect(menu.style.top).toBe('64px');
+    expect(menu.style.left).toBe('50px');
+    expect(menu.style.width).toBe('180px');
+
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('keeps one floating select open within a popout window', async () => {
+    const { popoutWindow, container } = createPopout();
+    render(
+      h('div', {}, [
+        h(NoteTypeSelect, { onChange: vi.fn() }),
+        h(NoteTypeSelect, { onChange: vi.fn() }),
+      ]),
+      container
+    );
+
+    await act(() => openSelect(popoutWindow, container, 0));
+    await act(() => openSelect(popoutWindow, container, 1));
+
+    const triggers = container.querySelectorAll('.getnote-note-type-select-trigger');
+    expect(container.querySelectorAll('.getnote-note-type-select-menu')).toHaveLength(1);
+    expect(triggers[0].querySelector('.is-open')).toBeNull();
+    expect(triggers[1].querySelector('.is-open')).toBeTruthy();
+
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('ignores main-window coordination, resize, scroll, and outside events for a popout menu', async () => {
+    const { popoutWindow, container } = createPopout();
+    render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+    const popoutTrigger = container.querySelector<HTMLButtonElement>('.getnote-note-type-select-trigger')!;
+    let rect = { bottom: 20, left: 10, width: 120 };
+    vi.spyOn(popoutTrigger, 'getBoundingClientRect').mockImplementation(
+      () => ({ ...rect }) as DOMRect
+    );
+
+    await act(() => openSelect(popoutWindow, container));
+    const popoutMenu = container.querySelector<HTMLElement>('.getnote-note-type-select-menu')!;
+    expect(popoutMenu.style.top).toBe('24px');
+
+    const mainContainer = document.createElement('div');
+    document.body.appendChild(mainContainer);
+    render(h(NoteTypeSelect, { onChange: vi.fn() }), mainContainer);
+    rect = { bottom: 80, left: 70, width: 200 };
+    await act(() => {
+      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event('scroll'));
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      mainContainer.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBe(popoutMenu);
+    expect(popoutMenu.style.top).toBe('24px');
+    expect(popoutMenu.style.left).toBe('10px');
+    expect(popoutMenu.style.width).toBe('120px');
+
+    render(null, mainContainer);
+    render(null, container);
+    popoutWindow.close();
   });
 });

--- a/tests/floating-select-menu.spec.ts
+++ b/tests/floating-select-menu.spec.ts
@@ -8,6 +8,8 @@ import { DEFAULT_SETTINGS } from '../src/types';
 import { NoteTypeSelect } from '../src/ui/note-type-select';
 
 const originalSetText = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'setText');
+const originalOnWindowMigrated = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'onWindowMigrated');
+const windowMigrationListeners = new WeakMap<HTMLElement, Set<(win: globalThis.Window) => void>>();
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -18,6 +20,11 @@ afterEach(() => {
     Object.defineProperty(HTMLElement.prototype, 'setText', originalSetText);
   } else {
     delete (HTMLElement.prototype as Partial<HTMLElement>).setText;
+  }
+  if (originalOnWindowMigrated) {
+    Object.defineProperty(HTMLElement.prototype, 'onWindowMigrated', originalOnWindowMigrated);
+  } else {
+    delete (HTMLElement.prototype as Partial<HTMLElement>).onWindowMigrated;
   }
 });
 
@@ -31,6 +38,29 @@ function createPopout() {
 function openSelect(popoutWindow: Window, container: HTMLElement, index = 0) {
   const trigger = container.querySelectorAll<HTMLButtonElement>('.getnote-note-type-select-trigger')[index];
   trigger.dispatchEvent(new popoutWindow.MouseEvent('click', { bubbles: true }));
+}
+
+function installWindowMigrationHook() {
+  Object.defineProperty(HTMLElement.prototype, 'onWindowMigrated', {
+    configurable: true,
+    value(this: HTMLElement, listener: (win: globalThis.Window) => void) {
+      const listeners = windowMigrationListeners.get(this) ?? new Set();
+      listeners.add(listener);
+      windowMigrationListeners.set(this, listeners);
+      return () => listeners.delete(listener);
+    },
+  });
+}
+
+function migrateToPopout(popoutWindow: Window, container: HTMLElement) {
+  const selectRoots = Array.from(container.querySelectorAll<HTMLElement>('.getnote-note-type-select'));
+  popoutWindow.document.adoptNode(container);
+  popoutWindow.document.body.appendChild(container);
+  for (const root of selectRoots) {
+    for (const listener of windowMigrationListeners.get(root) ?? []) {
+      listener(popoutWindow as unknown as globalThis.Window);
+    }
+  }
 }
 
 describe('floating select menu behavior', () => {
@@ -235,6 +265,123 @@ describe('floating select menu behavior', () => {
     });
     await act(() => {
       plugin.openManualSyncModal();
+    });
+
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('keeps one menu open after Obsidian migrates mounted selects into a popout', async () => {
+    installWindowMigrationHook();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(() => {
+      render(
+        h('div', {}, [
+          h(NoteTypeSelect, { onChange: vi.fn() }),
+          h(NoteTypeSelect, { onChange: vi.fn() }),
+        ]),
+        container
+      );
+    });
+    const popoutWindow = new Window({ url: 'https://getnote.test/migrated-popout' });
+    migrateToPopout(popoutWindow, container);
+
+    await act(() => openSelect(popoutWindow, container, 0));
+    await act(() => openSelect(popoutWindow, container, 1));
+
+    const triggers = container.querySelectorAll('.getnote-note-type-select-trigger');
+    expect(container.querySelectorAll('.getnote-note-type-select-menu')).toHaveLength(1);
+    expect(triggers[0].querySelector('.is-open')).toBeNull();
+    expect(triggers[1].querySelector('.is-open')).toBeTruthy();
+
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('closes a migrated popout menu before opening a command-driven modal', async () => {
+    installWindowMigrationHook();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(() => {
+      render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+    });
+    const popoutWindow = new Window({ url: 'https://getnote.test/migrated-command-popout' });
+    migrateToPopout(popoutWindow, container);
+    Object.assign(globalThis, {
+      activeDocument: popoutWindow.document,
+      activeWindow: popoutWindow,
+    });
+
+    await act(() => openSelect(popoutWindow, container));
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeTruthy();
+
+    const plugin = new GetNoteSyncPlugin(new App());
+    plugin.settings = { ...DEFAULT_SETTINGS };
+    Object.defineProperty(HTMLElement.prototype, 'setText', {
+      configurable: true,
+      value(text: string) {
+        this.textContent = text;
+      },
+    });
+    vi.spyOn(Modal.prototype, 'open').mockImplementation(() => {});
+    await act(() => {
+      plugin.openManualSyncModal();
+    });
+
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('repositions an open menu after its mounted tree migrates to a popout', async () => {
+    installWindowMigrationHook();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(() => {
+      render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+    });
+    const trigger = container.querySelector<HTMLButtonElement>('.getnote-note-type-select-trigger')!;
+    let rect = { bottom: 20, left: 10, width: 120 };
+    vi.spyOn(trigger, 'getBoundingClientRect').mockImplementation(
+      () => ({ ...rect }) as DOMRect
+    );
+    await act(() => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const menu = container.querySelector<HTMLElement>('.getnote-note-type-select-menu')!;
+    expect(menu.style.top).toBe('24px');
+
+    const popoutWindow = new Window({ url: 'https://getnote.test/migrated-open-popout' });
+    migrateToPopout(popoutWindow, container);
+    rect = { bottom: 40, left: 30, width: 160 };
+    await act(() => {
+      popoutWindow.dispatchEvent(new popoutWindow.Event('resize'));
+    });
+
+    expect(menu.style.top).toBe('44px');
+    expect(menu.style.left).toBe('30px');
+    expect(menu.style.width).toBe('160px');
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('closes an open menu from its new document after mounted-tree migration', async () => {
+    installWindowMigrationHook();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(() => {
+      render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+    });
+    await act(() => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const popoutWindow = new Window({ url: 'https://getnote.test/migrated-open-outside' });
+    migrateToPopout(popoutWindow, container);
+
+    await act(() => {
+      popoutWindow.document.body.dispatchEvent(new popoutWindow.MouseEvent('mousedown', { bubbles: true }));
     });
 
     expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();

--- a/tests/floating-select-menu.spec.ts
+++ b/tests/floating-select-menu.spec.ts
@@ -1,13 +1,24 @@
 import { Window } from 'happy-dom';
+import { App, Modal } from 'obsidian';
 import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import GetNoteSyncPlugin from '../src/main';
+import { DEFAULT_SETTINGS } from '../src/types';
 import { NoteTypeSelect } from '../src/ui/note-type-select';
+
+const originalSetText = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'setText');
 
 afterEach(() => {
   vi.restoreAllMocks();
   render(null, document.body);
   document.body.innerHTML = '';
+  Object.assign(globalThis, { activeDocument: document, activeWindow: window });
+  if (originalSetText) {
+    Object.defineProperty(HTMLElement.prototype, 'setText', originalSetText);
+  } else {
+    delete (HTMLElement.prototype as Partial<HTMLElement>).setText;
+  }
 });
 
 function createPopout() {
@@ -194,6 +205,39 @@ describe('floating select menu behavior', () => {
     expect(popoutMenu.style.width).toBe('120px');
 
     render(null, mainContainer);
+    render(null, container);
+    popoutWindow.close();
+  });
+
+  it('closes a popout floating select only when its window owns the command-driven modal', async () => {
+    const { popoutWindow, container } = createPopout();
+    render(h(NoteTypeSelect, { onChange: vi.fn() }), container);
+    await act(() => openSelect(popoutWindow, container));
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeTruthy();
+
+    const plugin = new GetNoteSyncPlugin(new App());
+    plugin.settings = { ...DEFAULT_SETTINGS };
+    Object.defineProperty(HTMLElement.prototype, 'setText', {
+      configurable: true,
+      value(text: string) {
+        this.textContent = text;
+      },
+    });
+    vi.spyOn(Modal.prototype, 'open').mockImplementation(() => {});
+    await act(() => {
+      plugin.openManualSyncModal();
+    });
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeTruthy();
+
+    Object.assign(globalThis, {
+      activeDocument: popoutWindow.document,
+      activeWindow: popoutWindow,
+    });
+    await act(() => {
+      plugin.openManualSyncModal();
+    });
+
+    expect(container.querySelector('.getnote-note-type-select-menu')).toBeNull();
     render(null, container);
     popoutWindow.close();
   });


### PR DESCRIPTION
## Summary

- bind floating-select close coordination, outside clicks, resize, and capture-scroll listeners to the trigger element owner document and window
- construct coordination events in the same window realm
- preserve same-window one-open behavior while isolating main and popout windows
- add true second-Window tests for open/select, outside close, positioning, scroll/resize, coordination, and cross-window isolation

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` (600 passed, 2 skipped)
- `npm run build`
- focused happy-dom popout tests: 7 passed
- independent review: 0 blocking / 0 Important
- build deployed to local Obsidian test vault; artifact hash matched

## Manual UI gate

The Mac locked before the actual Obsidian popout interaction pass. Before merge, verify Tag, note-type, and knowledge-base selects in a real popout: open below trigger, reposition on scroll/resize, close outside, and keep one menu open per window. This PR must not merge until that check is recorded.

Refs #204 (item 1)