### PR TITLE
fix: preserve settings state during runtime updates

### DIFF
--- a/docs/superpowers/plans/2026-07-26-issue-204-stable-settings-updates.md
+++ b/docs/superpowers/plans/2026-07-26-issue-204-stable-settings-updates.md
@@ -1,0 +1,7 @@
+# Issue #204 stable settings implementation plan
+
+1. Add failing tests that mount the settings tab once, mutate DOM-local state, send repeated runtime updates, and assert node identity, input value, focus/caret, disclosures, scroll, and floating-select state are preserved while progress/quota content changes.
+2. Introduce a small mounted settings host/controller with a runtime update method; `display()` mounts and `hide()` unmounts.
+3. Replace lifecycle refresh calls with runtime updates and remove progress-driven `scrollIntoView`.
+4. Run focused tests and the full repository gate.
+5. Deploy to local Obsidian and verify settings during a real progress sequence before opening a focused PR.

--- a/docs/superpowers/specs/2026-07-26-issue-204-stable-settings-updates-design.md
+++ b/docs/superpowers/specs/2026-07-26-issue-204-stable-settings-updates-design.md
@@ -1,0 +1,7 @@
+# Issue #204: Stable settings runtime updates
+
+The settings tab mounts once per `display()` and unmounts once per `hide()`. Sync progress, quota, and other runtime changes update props/state without invoking the settings-tab lifecycle or rebuilding the settings tree.
+
+Runtime updates must preserve the settings scroll position, disclosure state, unsaved input text, focused element and caret, and open floating-select menu. Progress updates must not call `scrollIntoView`. Visible progress and quota values still update immediately.
+
+This is a lifecycle-preserving change only. It adds no new settings behavior, copy, keyboard behavior, or synchronization semantics.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -334,7 +334,7 @@ export default class GetNoteSyncPlugin extends Plugin {
       this.settings.lastQuotaState = undefined;
       resetQuotaState();
       await this.saveSettings();
-      this.refreshSettingsTab();
+      this.updateSettingsRuntimeState();
     }
   }
 
@@ -363,8 +363,8 @@ export default class GetNoteSyncPlugin extends Plugin {
     return Array.from(folders).sort();
   }
 
-  private refreshSettingsTab(): void {
-    this.settingsTab?.refresh();
+  private updateSettingsRuntimeState(): void {
+    this.settingsTab?.updateRuntimeState();
   }
 
   startAutoSync(): void {
@@ -466,7 +466,7 @@ export default class GetNoteSyncPlugin extends Plugin {
     this.isSyncing = true;
     this.syncProgress = { message: t('sync.fetching', { page: 1 }), count: '', percent: 0 };
     this.currentSyncEngine = null;
-    this.refreshSettingsTab();
+    this.updateSettingsRuntimeState();
     showNotice(t('sync.started'));
 
     const engine = new SyncEngine(this.app, this.settings, (info) => this.setProgress(info), scopeOptions);
@@ -498,7 +498,7 @@ export default class GetNoteSyncPlugin extends Plugin {
         this.syncProgress = { message: '', count: '', percent: 0 };
         this.isSyncing = false;
         this.currentSyncEngine = null;
-        this.refreshSettingsTab();
+        this.updateSettingsRuntimeState();
         return;
       }
     } catch (err) {
@@ -543,7 +543,7 @@ export default class GetNoteSyncPlugin extends Plugin {
         if (type === 'auto') {
           this.syncProgress = { message: '', count: '', percent: 0 };
         }
-        this.refreshSettingsTab();
+        this.updateSettingsRuntimeState();
       }
     }
   }
@@ -593,7 +593,7 @@ export default class GetNoteSyncPlugin extends Plugin {
     const now = Date.now();
     if (now - this.lastProgressUpdate > 300) {
       this.lastProgressUpdate = now;
-      this.refreshSettingsTab();
+      this.updateSettingsRuntimeState();
     }
   }
 
@@ -681,7 +681,7 @@ export default class GetNoteSyncPlugin extends Plugin {
     this.isSyncing = true;
     this.syncProgress = { message: t('sync.subscribedKnowledge.fetching'), count: '', percent: 0 };
     this.currentSyncEngine = null;
-    this.refreshSettingsTab();
+    this.updateSettingsRuntimeState();
     showNotice(t('sync.subscribedKnowledge.started'));
 
     const engine = new SyncEngine(this.app, this.settings, (info) => this.setProgress(info), {
@@ -729,7 +729,7 @@ export default class GetNoteSyncPlugin extends Plugin {
       this.isSyncing = false;
       this.currentSyncEngine = null;
       this.syncProgress = { message: '', count: '', percent: 0 };
-      this.refreshSettingsTab();
+      this.updateSettingsRuntimeState();
     }
   }
 
@@ -754,7 +754,7 @@ export default class GetNoteSyncPlugin extends Plugin {
     const startedAt = Date.now();
     this.isSyncing = true;
     this.syncProgress = { message: t('reverseSync.running'), count: '', percent: 0 };
-    this.refreshSettingsTab();
+    this.updateSettingsRuntimeState();
 
     try {
       const engine = new ReverseSyncEngine(this.app, this.settings, (progress) => {
@@ -764,7 +764,7 @@ export default class GetNoteSyncPlugin extends Plugin {
           count: `${t('modal.countProgress', { processed: progress.processed })} ${progress.title}`,
           percent,
         };
-        this.refreshSettingsTab();
+        this.updateSettingsRuntimeState();
       });
       this.currentSyncEngine = engine;
       const result = files ? await engine.syncFiles(files) : await engine.syncBack();
@@ -808,7 +808,7 @@ export default class GetNoteSyncPlugin extends Plugin {
       this.isSyncing = false;
       this.currentSyncEngine = null;
       this.syncProgress = { message: '', count: '', percent: 0 };
-      this.refreshSettingsTab();
+      this.updateSettingsRuntimeState();
     }
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -364,7 +364,7 @@ export default class GetNoteSyncPlugin extends Plugin {
   }
 
   private refreshSettingsTab(): void {
-    if (this.settingsTab) this.settingsTab.display();
+    this.settingsTab?.refresh();
   }
 
   startAutoSync(): void {

--- a/src/settings-tab.tsx
+++ b/src/settings-tab.tsx
@@ -19,6 +19,10 @@ export class GetNoteSettingsTab extends PluginSettingTab {
   }
 
   display(): void {
+    this.refresh();
+  }
+
+  refresh(): void {
     ReactDOM.render(
       <SettingsComponent
         settings={this.plugin.settings}

--- a/src/settings-tab.tsx
+++ b/src/settings-tab.tsx
@@ -1,12 +1,76 @@
 import { App, debounce, PluginSettingTab } from 'obsidian';
 import ReactDOM from 'react-dom';
+import { useLayoutEffect, useState } from 'preact/hooks';
 import { SettingsComponent } from './settings/index';
 import type { Settings } from './types';
 import type GetNoteSyncPlugin from './main';
 import { confirmDatePathMigration } from './ui/date-path-confirm-modal';
+import type {
+  DatePathMigrationResult,
+  DatePathMigrationTarget,
+} from './date-path-migration';
+import type { DatePathConfirmationRequest } from './ui/date-path-confirm-modal';
+
+class SettingsRuntimeUpdates {
+  private listeners = new Set<() => void>();
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  emit(): void {
+    for (const listener of this.listeners) listener();
+  }
+}
+
+function MountedSettings({
+  app,
+  plugin,
+  updateSetting,
+  runtimeUpdates,
+  applyDatePathSettings,
+  confirmDatePathMigration: confirmDatePathMigrationProp,
+}: {
+  app: App;
+  plugin: GetNoteSyncPlugin;
+  updateSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  runtimeUpdates: SettingsRuntimeUpdates;
+  applyDatePathSettings?: (target: DatePathMigrationTarget) => Promise<DatePathMigrationResult>;
+  confirmDatePathMigration?: (request: DatePathConfirmationRequest) => Promise<boolean>;
+}) {
+  const [, setRevision] = useState(0);
+  useLayoutEffect(
+    () => runtimeUpdates.subscribe(() => setRevision(revision => revision + 1)),
+    [runtimeUpdates],
+  );
+
+  return (
+    <SettingsComponent
+      settings={plugin.settings}
+      updateSetting={updateSetting}
+      startSync={() => plugin.openManualSyncModal()}
+      isSyncing={plugin.isSyncing}
+      syncProgress={plugin.syncProgress}
+      openNotePicker={() => plugin.openNotePicker()}
+      startSubscribedKnowledgeSync={() => plugin.syncSubscribedKnowledge()}
+      openLocalUpload={() => plugin.openLocalUploadModal()}
+      startAutoSync={() => plugin.startAutoSync()}
+      stopAutoSync={() => plugin.stopAutoSync()}
+      cancelSync={() => plugin.cancelSync()}
+      app={app}
+      lastSyncTime={plugin.lastSyncResult?.timestamp}
+      syncHistory={plugin.syncHistory}
+      applyDatePathSettings={applyDatePathSettings}
+      confirmDatePathMigration={confirmDatePathMigrationProp}
+    />
+  );
+}
 
 export class GetNoteSettingsTab extends PluginSettingTab {
   private plugin: GetNoteSyncPlugin;
+  private mounted = false;
+  private readonly runtimeUpdates = new SettingsRuntimeUpdates();
 
   constructor(app: App, plugin: GetNoteSyncPlugin) {
     super(app, plugin);
@@ -19,26 +83,14 @@ export class GetNoteSettingsTab extends PluginSettingTab {
   }
 
   display(): void {
-    this.refresh();
-  }
-
-  refresh(): void {
+    if (this.mounted) return;
+    this.mounted = true;
     ReactDOM.render(
-      <SettingsComponent
-        settings={this.plugin.settings}
-        updateSetting={this.updateSetting}
-        startSync={() => this.plugin.openManualSyncModal()}
-        isSyncing={this.plugin.isSyncing}
-        syncProgress={this.plugin.syncProgress}
-        openNotePicker={() => this.plugin.openNotePicker()}
-        startSubscribedKnowledgeSync={() => this.plugin.syncSubscribedKnowledge()}
-        openLocalUpload={() => this.plugin.openLocalUploadModal()}
-        startAutoSync={() => this.plugin.startAutoSync()}
-        stopAutoSync={() => this.plugin.stopAutoSync()}
-        cancelSync={() => this.plugin.cancelSync()}
+      <MountedSettings
         app={this.app}
-        lastSyncTime={this.plugin.lastSyncResult?.timestamp}
-        syncHistory={this.plugin.syncHistory}
+        plugin={this.plugin}
+        updateSetting={this.updateSetting}
+        runtimeUpdates={this.runtimeUpdates}
         applyDatePathSettings={(target) => this.plugin.applyDatePathSettings(target)}
         confirmDatePathMigration={(request) => confirmDatePathMigration(this.app, request)}
       />,
@@ -46,8 +98,14 @@ export class GetNoteSettingsTab extends PluginSettingTab {
     );
   }
 
+  updateRuntimeState(): void {
+    if (!this.mounted) return;
+    this.runtimeUpdates.emit();
+  }
+
   hide(): void {
     ReactDOM.unmountComponentAtNode(this.containerEl);
+    this.mounted = false;
   }
 
   private debouncedSave: () => void;

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -536,12 +536,6 @@ export function SettingsComponent({
     : Boolean(apiTokenOpenapi.trim() && clientIdOpenapi.trim());
   const { scheduledSync } = settings;
   const currentSyncHistory = syncHistory.length > 0 ? syncHistory : settings.syncHistory;
-  const syncStatusRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!isSyncing) return;
-    syncStatusRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-  }, [isSyncing, syncProgress?.message, syncProgress?.count, syncProgress?.percent]);
 
   // Format last sync time
   const formatLastSync = (timestamp?: number): string => {
@@ -1148,7 +1142,7 @@ export function SettingsComponent({
 
       {/* 同步进度条 */}
       {isSyncing && (
-        <div className="getnote-settings-sync-status" ref={syncStatusRef}>
+        <div className="getnote-settings-sync-status">
           <div className="getnote-settings-sync-status-header">
             <span className="getnote-mono-text">{syncProgress?.message || t('sync.syncing')}</span>
             <button className="mod-warning getnote-settings-cancel-button" onClick={cancelSync}>

--- a/tests/settings-tab.spec.ts
+++ b/tests/settings-tab.spec.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'preact/test-utils';
+import { App } from 'obsidian';
+import GetNoteSyncPlugin from '../src/main';
+import { GetNoteSettingsTab } from '../src/settings-tab';
+import { initI18n } from '../src/i18n';
+import { DEFAULT_SETTINGS } from '../src/types';
+
+function makePlugin(): GetNoteSyncPlugin {
+  const plugin = new GetNoteSyncPlugin(new App());
+  plugin.settings = {
+    ...DEFAULT_SETTINGS,
+    scheduledSync: {
+      ...DEFAULT_SETTINGS.scheduledSync,
+      enabled: true,
+    },
+    syncHistory: [],
+  };
+  plugin.syncHistory = [];
+  return plugin;
+}
+
+function click(element: Element): void {
+  element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  initI18n('zh-CN');
+  document.body.innerHTML = '';
+});
+
+describe('GetNoteSettingsTab runtime updates', () => {
+  it('mounts once per display lifecycle and remounts after hide', async () => {
+    const plugin = makePlugin();
+    const tab = new GetNoteSettingsTab(plugin.app, plugin);
+
+    await act(() => {
+      tab.display();
+    });
+    const firstRoot = tab.containerEl.querySelector('.getnote-settings-react');
+
+    await act(() => {
+      tab.display();
+    });
+    expect(tab.containerEl.querySelector('.getnote-settings-react')).toBe(firstRoot);
+
+    await act(() => {
+      tab.hide();
+    });
+    expect(tab.containerEl.childElementCount).toBe(0);
+
+    await act(() => {
+      tab.display();
+    });
+    expect(tab.containerEl.querySelector('.getnote-settings-react')).not.toBe(firstRoot);
+  });
+
+  it('updates progress and quota without rebuilding or disturbing local UI state', async () => {
+    const plugin = makePlugin();
+    const tab = new GetNoteSettingsTab(plugin.app, plugin);
+    const runtimeTab = tab as GetNoteSettingsTab & { updateRuntimeState: () => void };
+    document.body.appendChild(tab.containerEl);
+
+    await act(() => {
+      tab.display();
+    });
+
+    tab.containerEl.scrollTop = 420;
+
+    const scheduledDisclosure = tab.containerEl.querySelector(
+      '.getnote-scheduled-master-row .getnote-inline-disclosure',
+    ) as HTMLButtonElement;
+    const attachmentDisclosure = tab.containerEl.querySelector(
+      '.getnote-attachment-master-row .getnote-inline-disclosure',
+    ) as HTMLButtonElement;
+    await act(() => {
+      click(scheduledDisclosure);
+      click(attachmentDisclosure);
+    });
+
+    const folderInput = tab.containerEl.querySelector(
+      'input[placeholder="得到大脑"]',
+    ) as HTMLInputElement;
+    await act(() => {
+      folderInput.value = '尚未保存的本地输入';
+      folderInput.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        inputType: 'insertText',
+        data: '尚未保存的本地输入',
+      }));
+    });
+    folderInput.focus();
+    folderInput.setSelectionRange(2, 6);
+
+    const noteTypeTrigger = tab.containerEl.querySelector(
+      '.getnote-note-type-select-trigger',
+    ) as HTMLButtonElement;
+    await act(() => {
+      click(noteTypeTrigger);
+    });
+
+    expect(tab.containerEl.querySelector('.getnote-note-type-select-menu')).not.toBeNull();
+    expect(typeof runtimeTab.updateRuntimeState).toBe('function');
+
+    plugin.isSyncing = true;
+    plugin.syncProgress = {
+      message: '正在同步第 1 批',
+      count: '处理中 1 条',
+      percent: 25,
+    };
+    plugin.settings.lastQuotaState = {
+      exhausted: true,
+      reason: 'quota_day',
+      checkedAt: Date.now(),
+    };
+    await act(() => {
+      runtimeTab.updateRuntimeState();
+    });
+
+    plugin.syncProgress = {
+      message: '正在同步第 2 批',
+      count: '处理中 2 条',
+      percent: 75,
+    };
+    await act(() => {
+      runtimeTab.updateRuntimeState();
+    });
+
+    expect(tab.containerEl.scrollTop).toBe(420);
+    expect(scheduledDisclosure.getAttribute('aria-expanded')).toBe('true');
+    expect(attachmentDisclosure.getAttribute('aria-expanded')).toBe('true');
+    expect(tab.containerEl.querySelector('input[placeholder="得到大脑"]')).toBe(folderInput);
+    expect(folderInput.value).toBe('尚未保存的本地输入');
+    expect(document.activeElement).toBe(folderInput);
+    expect(folderInput.selectionStart).toBe(2);
+    expect(folderInput.selectionEnd).toBe(6);
+    expect(tab.containerEl.querySelector('.getnote-note-type-select-trigger')).toBe(noteTypeTrigger);
+    expect(tab.containerEl.querySelector('.getnote-note-type-select-menu')).not.toBeNull();
+    expect(tab.containerEl.textContent).toContain('正在同步第 2 批');
+    expect(tab.containerEl.textContent).toContain('处理中 2 条');
+    expect(tab.containerEl.textContent).toContain('75%');
+    expect(tab.containerEl.querySelector('.getnote-quota-banner')).not.toBeNull();
+  });
+});

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -558,7 +558,7 @@ describe('SettingsComponent auth credentials', () => {
     expect(uploadButton!.disabled).toBe(true);
   });
 
-  it('keeps the syncing progress block visible when upload progress changes', async () => {
+  it('updates syncing progress without forcing the settings page to scroll', async () => {
     const scrollIntoView = vi.fn();
     const originalScrollIntoView = Element.prototype.scrollIntoView;
     Element.prototype.scrollIntoView = scrollIntoView;
@@ -593,7 +593,9 @@ describe('SettingsComponent auth credentials', () => {
         );
       });
 
-      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
+      expect(container.textContent).toContain('处理中 2 条...');
+      expect(container.textContent).toContain('100%');
+      expect(scrollIntoView).not.toHaveBeenCalled();
     } finally {
       Element.prototype.scrollIntoView = originalScrollIntoView;
     }

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { App, Modal, TFile } from 'obsidian';
 import GetNoteSyncPlugin from '../src/main';
 import { ReverseSyncEngine } from '../src/reverse-sync';
+import { GetNoteSettingsTab } from '../src/settings-tab';
 import { SyncCancelledError, SyncEngine } from '../src/sync';
 import { DEFAULT_SETTINGS } from '../src/types';
 
@@ -44,6 +45,71 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     plugin.syncHistory = [];
     return plugin;
   }
+
+  function watchSettingsRefresh(plugin: GetNoteSyncPlugin) {
+    const settingsTab = new GetNoteSettingsTab(plugin.app, plugin);
+    const refresh = vi.spyOn(settingsTab, 'refresh').mockImplementation(() => {});
+    plugin['settingsTab'] = settingsTab;
+    return refresh;
+  }
+
+  it('refreshes settings after clearing stale quota state', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T01:00:00+08:00'));
+    const plugin = makePlugin();
+    plugin.settings.lastQuotaState = {
+      exhausted: true,
+      reason: 'quota_day',
+      checkedAt: new Date('2026-07-21T23:00:00+08:00').getTime(),
+    };
+    const refresh = watchSettingsRefresh(plugin);
+
+    await plugin['clearStaleQuotaState']();
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes settings when manual sync starts', async () => {
+    let resolveSync!: (result: Awaited<ReturnType<SyncEngine['sync']>>) => void;
+    vi.spyOn(SyncEngine.prototype, 'sync').mockImplementation(() => new Promise(resolve => {
+      resolveSync = resolve;
+    }));
+    const plugin = makePlugin();
+    const refresh = watchSettingsRefresh(plugin);
+
+    const syncPromise = plugin['runSync']('full', { maxDays: 0, syncStartDate: '' });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    resolveSync({ created: 0, updated: 0, skipped: 0, failed: 0, total: 0, items: [] });
+    await syncPromise;
+  });
+
+  it('refreshes settings when manual sync is cancelled', async () => {
+    vi.spyOn(SyncEngine.prototype, 'sync').mockRejectedValue(new SyncCancelledError());
+    const plugin = makePlugin();
+    const refresh = watchSettingsRefresh(plugin);
+
+    await plugin['runSync']('full', { maxDays: 0, syncStartDate: '' });
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes settings when manual sync completes', async () => {
+    vi.spyOn(SyncEngine.prototype, 'sync').mockResolvedValue({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      total: 1,
+      items: [],
+    });
+    const plugin = makePlugin();
+    const refresh = watchSettingsRefresh(plugin);
+
+    await plugin['runSync']('full', { maxDays: 0, syncStartDate: '' });
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
 
   it('manual sync failure clears syncing state', async () => {
     vi.spyOn(SyncEngine.prototype, 'sync').mockRejectedValue(new Error('boom'));

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -46,11 +46,11 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     return plugin;
   }
 
-  function watchSettingsRefresh(plugin: GetNoteSyncPlugin) {
+  function watchSettingsRuntimeUpdate(plugin: GetNoteSyncPlugin) {
     const settingsTab = new GetNoteSettingsTab(plugin.app, plugin);
-    const refresh = vi.spyOn(settingsTab, 'refresh').mockImplementation(() => {});
+    const updateRuntimeState = vi.spyOn(settingsTab, 'updateRuntimeState').mockImplementation(() => {});
     plugin['settingsTab'] = settingsTab;
-    return refresh;
+    return updateRuntimeState;
   }
 
   it('refreshes settings after clearing stale quota state', async () => {
@@ -62,11 +62,11 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
       reason: 'quota_day',
       checkedAt: new Date('2026-07-21T23:00:00+08:00').getTime(),
     };
-    const refresh = watchSettingsRefresh(plugin);
+    const updateRuntimeState = watchSettingsRuntimeUpdate(plugin);
 
     await plugin['clearStaleQuotaState']();
 
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(updateRuntimeState).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes settings when manual sync starts', async () => {
@@ -75,10 +75,10 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
       resolveSync = resolve;
     }));
     const plugin = makePlugin();
-    const refresh = watchSettingsRefresh(plugin);
+    const updateRuntimeState = watchSettingsRuntimeUpdate(plugin);
 
     const syncPromise = plugin['runSync']('full', { maxDays: 0, syncStartDate: '' });
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(updateRuntimeState).toHaveBeenCalledTimes(1);
 
     resolveSync({ created: 0, updated: 0, skipped: 0, failed: 0, total: 0, items: [] });
     await syncPromise;
@@ -87,11 +87,11 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
   it('refreshes settings when manual sync is cancelled', async () => {
     vi.spyOn(SyncEngine.prototype, 'sync').mockRejectedValue(new SyncCancelledError());
     const plugin = makePlugin();
-    const refresh = watchSettingsRefresh(plugin);
+    const updateRuntimeState = watchSettingsRuntimeUpdate(plugin);
 
     await plugin['runSync']('full', { maxDays: 0, syncStartDate: '' });
 
-    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(updateRuntimeState).toHaveBeenCalledTimes(2);
   });
 
   it('refreshes settings when manual sync completes', async () => {
@@ -104,11 +104,11 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
       items: [],
     });
     const plugin = makePlugin();
-    const refresh = watchSettingsRefresh(plugin);
+    const updateRuntimeState = watchSettingsRuntimeUpdate(plugin);
 
     await plugin['runSync']('full', { maxDays: 0, syncStartDate: '' });
 
-    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(updateRuntimeState).toHaveBeenCalledTimes(2);
   });
 
   it('manual sync failure clears syncing state', async () => {


### PR DESCRIPTION
## Summary

- mount the settings component once per settings-tab display/hide lifecycle
- update sync progress, quota, history, and runtime flags through a stable mounted host instead of reusing the settings-tab display lifecycle
- remove progress-driven `scrollIntoView`
- preserve scroll, disclosure state, unsaved input, focus/caret, DOM nodes, and open floating selects during repeated runtime updates

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` (601 passed, 2 skipped)
- `npm run build`
- focused lifecycle/settings tests: 82 passed
- independent review: 0 blocking / 0 Important

## Manual UI gate

The Mac is currently locked, so the final real-Obsidian progress sequence could not be operated. Before merge, scroll the settings page mid-flow, open scheduled and attachment disclosures, focus/edit an input, open a floating select, then trigger sync start/progress/completion/error and quota reset. Confirm scroll, disclosure, input, focus/caret, and menu state stay unchanged while visible runtime values update.

Refs #204 (item 2)