### PR TITLE
test: type media sync fixtures

### DIFF
--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1747,7 +1747,7 @@ describe('SyncEngine — audio note sync', () => {
     });
 
     try {
-      const engine = new SyncEngine(mockApp as any, makeSettings({ maxDays: 0 }));
+      const engine = new SyncEngine(mockApp, makeSettings({ maxDays: 0 }));
       const result = await engine.sync();
 
       // 验证 asset 目录被创建/写入
@@ -1833,7 +1833,7 @@ describe('SyncEngine — audio note sync', () => {
     });
 
     try {
-      const engine = new SyncEngine(mockApp as any, makeSettings({ maxDays: 0 }));
+      const engine = new SyncEngine(mockApp, makeSettings({ maxDays: 0 }));
       const result = await engine.sync();
 
       expect(result.created).toBe(1);
@@ -1903,7 +1903,7 @@ describe('SyncEngine — audio note sync', () => {
     );
 
     try {
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const result = await engine.syncNoteIds(['image_existing']);
 
       expect(result.skipped).toBe(1);


### PR DESCRIPTION
## What changed

Removes three redundant `as any` casts from the typed media-sync test fixtures in `tests/sync-engine.spec.ts`.

## Why

This is the next small, test-only cleanup batch for #196. The fixtures are already typed as `MockApp`, which extends the Obsidian `App` contract used by `SyncEngine`.

## Impact

No production code, sync semantics, vault data behavior, UI, IDs/timestamps, or release artifacts change. The test lint-debt baseline drops from 62 to 59 errors.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` (595 passed, 2 skipped)
- `npm run build`
- `npx eslint tests --max-warnings=0` (59 remaining errors; down from 62)