### PR TITLE
test: type audio sync fixtures

### DIFF
--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1747,7 +1747,7 @@ describe('SyncEngine — audio note sync', () => {
     });
 
     try {
-      const engine = new SyncEngine(mockApp as any, makeSettings({ maxDays: 0 }));
+      const engine = new SyncEngine(mockApp, makeSettings({ maxDays: 0 }));
       const result = await engine.sync();
 
       // 验证 asset 目录被创建/写入
@@ -1833,7 +1833,7 @@ describe('SyncEngine — audio note sync', () => {
     });
 
     try {
-      const engine = new SyncEngine(mockApp as any, makeSettings({ maxDays: 0 }));
+      const engine = new SyncEngine(mockApp, makeSettings({ maxDays: 0 }));
       const result = await engine.sync();
 
       expect(result.created).toBe(1);
@@ -1903,7 +1903,7 @@ describe('SyncEngine — audio note sync', () => {
     );
 
     try {
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const result = await engine.syncNoteIds(['image_existing']);
 
       expect(result.skipped).toBe(1);


### PR DESCRIPTION
## Summary
- remove three redundant `as any` casts from audio-sync fixtures
- retain the existing typed `MockApp` helper
- reduce test lint debt from 62 to 59

## Validation
- `npx eslint tests/sync-engine.spec.ts --max-warnings=0` (remaining baseline: 59 errors)
- `npm test -- tests/sync-engine.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`