### PR TITLE
test: type audio sync fixtures

### DIFF
--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1921,7 +1921,7 @@ describe('SyncEngine — audio note sync', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
     const mockApp = makeMockApp();
-    const engine = new SyncEngine(mockApp as any, makeSettings());
+    const engine = new SyncEngine(mockApp, makeSettings());
 
     // @ts-expect-error accessing private method for security regression coverage
     const result = await engine['downloadAudioAsset'](audioNote, {
@@ -1954,7 +1954,7 @@ describe('SyncEngine — audio note sync', () => {
     } as Response);
 
     const mockApp = makeMockApp();
-    const engine = new SyncEngine(mockApp as any, makeSettings());
+    const engine = new SyncEngine(mockApp, makeSettings());
 
     try {
       // @ts-expect-error accessing private method for security regression coverage
@@ -2020,7 +2020,7 @@ describe('SyncEngine — audio note sync', () => {
     });
 
     try {
-      const engine = new SyncEngine(mockApp as any, makeSettings({ maxDays: 0 }));
+      const engine = new SyncEngine(mockApp, makeSettings({ maxDays: 0 }));
       const result = await engine.sync();
 
       expect(result.failed).toBe(0);


### PR DESCRIPTION
## Summary
- remove three redundant `as any` casts from audio-sync fixtures
- retain the existing typed `MockApp` helper
- reduce test lint debt from 59 to 56

## Validation
- `npx eslint tests/sync-engine.spec.ts --max-warnings=0` (remaining baseline: 56 errors)
- `npm test -- tests/sync-engine.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`