### PR TITLE
test: tighten link original sync fixtures

### DIFF
--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -2073,7 +2073,7 @@ describe('SyncEngine — link original sync', () => {
     const app = makeMockApp();
 
     try {
-      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }));
+      const engine = new SyncEngine(app, makeSettings({ maxDays: 0 }));
       const result = await engine.sync();
 
       expect(result.created).toBe(1);
@@ -2118,7 +2118,7 @@ describe('SyncEngine — link original sync', () => {
     const app = makeMockApp();
 
     try {
-      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }));
+      const engine = new SyncEngine(app, makeSettings({ maxDays: 0 }));
       const result = await engine.sync();
 
       expect(result.created).toBe(1);
@@ -2170,7 +2170,7 @@ describe('SyncEngine — link original sync', () => {
     );
 
     try {
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const result = await engine.syncNoteIds(['link_001']);
 
       expect(result.skipped).toBe(1);


### PR DESCRIPTION
## Summary
- remove three redundant `as any` casts from link-original sync fixtures
- reuse the existing typed `MockApp` test helper
- no production or sync behavior changes

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test` (595 passed, 2 skipped)
- `npm run build`
- `npx eslint tests --max-warnings=0` (remaining baseline: 53 errors, down from 56)