### PR TITLE
test: type sync-engine SyncEngine constructor calls

### DIFF
--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -2186,7 +2186,7 @@ describe('SyncEngine — selective sync cancellation', () => {
   describe('SyncEngine — preCheckNote', () => {
     it('不存在 uidIndex 时返回 { exists: false }', () => {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({ note_id: 'note_missing' });
       // @ts-expect-error private helper is tested directly
       const result = engine['preCheckNote'](note, new Map());
@@ -2201,7 +2201,7 @@ describe('SyncEngine — selective sync cancellation', () => {
         { uid: 'note_changed', modified: '2026-04-27 10:00:00' }
       );
       app.vault._addFolder('得到大脑/纯文本');
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'note_changed',
         updated_at: '2026-04-28T10:00:00+08:00',
@@ -2221,7 +2221,7 @@ describe('SyncEngine — selective sync cancellation', () => {
         { uid: 'note_unchanged', modified: '2026-04-28 10:00:00' }
       );
       app.vault._addFolder('得到大脑/纯文本');
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'note_unchanged',
         note_type: 'plain_text',
@@ -2244,7 +2244,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       app.vault._addFolder('得到大脑/录音笔记/asset');
       app.vault._addFile('得到大脑/录音笔记/asset/测试笔记_audio.mp3', '');
       app.vault._addFile('得到大脑/录音笔记/asset/测试笔记_transcript.md', '');
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'audio_ready',
         title: '测试笔记',
@@ -2267,7 +2267,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       app.vault._addFolder('得到大脑/录音笔记');
       app.vault._addFolder('得到大脑/录音笔记/asset');
       app.vault._addFile('得到大脑/录音笔记/asset/测试笔记_transcript.md', '');
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'audio_missing_mp3',
         title: '测试笔记',
@@ -2290,7 +2290,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       app.vault._addFolder('得到大脑/录音笔记');
       app.vault._addFolder('得到大脑/录音笔记/asset');
       app.vault._addFile('得到大脑/录音笔记/asset/测试笔记_audio.mp3', '');
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'audio_missing_transcript',
         title: '测试笔记',
@@ -2311,7 +2311,7 @@ describe('SyncEngine — selective sync cancellation', () => {
         { uid: 'note_link', modified: '2026-04-28 10:00:00' }
       );
       app.vault._addFolder('得到大脑/纯文本');
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'note_link',
         note_type: 'plain_text',
@@ -2333,7 +2333,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       app.vault._addFolder('得到大脑/图片笔记');
       app.vault._addFolder('得到大脑/图片笔记/asset');
       app.vault._addFile('得到大脑/图片笔记/asset/测试笔记_image.jpg', '');
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'image_ready',
         title: '测试笔记',
@@ -2351,7 +2351,7 @@ describe('SyncEngine — selective sync cancellation', () => {
 
     it('图片笔记：图片笔记目录下的非音频笔记也会下载多张图片附件', async () => {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'image_multi',
         title: '测试笔记',
@@ -2380,7 +2380,7 @@ describe('SyncEngine — selective sync cancellation', () => {
 
     it('同一笔记的同名通用附件会下载到不同文件', async () => {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'duplicate_generic_names',
         title: '测试笔记',
@@ -2408,7 +2408,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       const basePath = await mkdtemp(join(tmpdir(), 'dedao-generic-asset-'));
       const app = makeMockApp();
       app.vault.adapter = { getBasePath: () => basePath };
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'local_fast_path',
         title: '测试笔记',
@@ -2436,7 +2436,7 @@ describe('SyncEngine — selective sync cancellation', () => {
 
     it('通用附件文件名会忽略 URL fragment', async () => {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings());
+      const engine = new SyncEngine(app, makeSettings());
       const note = makeNote({
         note_id: 'fragment_generic_name',
         title: '测试笔记',
@@ -2460,7 +2460,7 @@ describe('SyncEngine — selective sync cancellation', () => {
 
     it('Web API 模式会处理列表响应中已有的通用附件', async () => {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings({
+      const engine = new SyncEngine(app, makeSettings({
         authMode: 'web',
         webApiToken: 'web-token',
       }));
@@ -2487,7 +2487,7 @@ describe('SyncEngine — selective sync cancellation', () => {
 
     it('禁用音频导入时不会保留会渲染成断链的音频字段', async () => {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings({
+      const engine = new SyncEngine(app, makeSettings({
         attachmentImport: { image: true, audio: false, video: true, document: true },
       }));
       const note = makeNote({
@@ -2543,7 +2543,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       );
 
       try {
-        const engine = new SyncEngine(app as any, makeSettings());
+        const engine = new SyncEngine(app, makeSettings());
         const result = await engine.syncNoteIds(['pre_skip']);
 
         expect(result.total).toBe(1);
@@ -2585,7 +2585,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       );
 
       try {
-        const engine = new SyncEngine(app as any, makeSettings());
+        const engine = new SyncEngine(app, makeSettings());
         const result = await engine.syncNoteIds(['pre_proceed']);
 
         expect(result.total).toBe(1);
@@ -2637,7 +2637,7 @@ describe('SyncEngine — selective sync cancellation', () => {
       );
 
       try {
-        const engine = new SyncEngine(app as any, makeSettings());
+        const engine = new SyncEngine(app, makeSettings());
         const result = await engine.syncNoteIds(['existing', 'new_one']);
 
         expect(result.total).toBe(2);
@@ -2669,7 +2669,7 @@ describe('SyncEngine — selective sync cancellation', () => {
     );
 
     const mockApp = makeMockApp();
-    const engine = new SyncEngine(mockApp as any, makeSettings(), (info) => {
+    const engine = new SyncEngine(mockApp, makeSettings(), (info) => {
       if (info.processed === 1) {
         engine.cancel();
       }
@@ -2700,7 +2700,7 @@ describe('SyncEngine auth credential chains', () => {
       mockFetchResponse({ data: { notes: [], has_more: false, next_cursor: '' } }) as Response
     );
 
-    const engine = new SyncEngine(makeMockApp() as any, makeSettings({
+    const engine = new SyncEngine(makeMockApp(), makeSettings({
       authMode: 'openapi',
       apiToken: 'active-web-token',
       clientId: 'legacy-client',
@@ -2726,7 +2726,7 @@ describe('SyncEngine auth credential chains', () => {
       mockFetchResponse({ h: {}, c: { list: [], has_more: false } }) as Response
     );
 
-    const engine = new SyncEngine(makeMockApp() as any, makeSettings({
+    const engine = new SyncEngine(makeMockApp(), makeSettings({
       authMode: 'web',
       apiToken: 'active-openapi-token',
       clientId: 'openapi-client',
@@ -2755,7 +2755,7 @@ describe('SyncEngine auth credential chains', () => {
       }) as Response
     );
 
-    const engine = new SyncEngine(makeMockApp() as any, makeSettings({
+    const engine = new SyncEngine(makeMockApp(), makeSettings({
       authMode: 'openapi',
       apiToken: 'active-web-token',
       clientId: 'legacy-client',
@@ -2784,7 +2784,7 @@ describe('SyncEngine auth credential chains', () => {
       }) as Response
     );
 
-    const engine = new SyncEngine(makeMockApp() as any, makeSettings({
+    const engine = new SyncEngine(makeMockApp(), makeSettings({
       authMode: 'web',
       apiToken: 'active-openapi-token',
       clientId: 'openapi-client',
@@ -2815,7 +2815,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-core-openapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'openapi',
       openApiToken: 'test-openapi-token',
       openApiClientId: 'test-client',
@@ -2846,7 +2846,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-core-openapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'openapi',
       openApiToken: 'test-openapi-token',
       openApiClientId: 'test-client',
@@ -2873,7 +2873,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-core-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -2903,7 +2903,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-core-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -2929,7 +2929,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('selective-sync-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -2952,7 +2952,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('selective-sync-openapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'openapi',
       openApiToken: 'test-openapi-token',
       openApiClientId: 'test-client',
@@ -2978,7 +2978,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('selective-sync-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -3003,7 +3003,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-parent-and-children-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -3036,7 +3036,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-parent-and-children-openapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'openapi',
       openApiToken: 'test-openapi-token',
       openApiClientId: 'test-client',
@@ -3070,7 +3070,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-stale-children-openapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'openapi',
       openApiToken: 'test-openapi-token',
       openApiClientId: 'test-client',
@@ -3099,7 +3099,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-stale-children-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -3132,7 +3132,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-parent-and-children-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -3166,7 +3166,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-failed-child-openapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'openapi',
       openApiToken: 'test-openapi-token',
       openApiClientId: 'test-client',
@@ -3187,7 +3187,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-failed-child-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -3210,7 +3210,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('sync-parent-primeid-webapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'web',
       webApiToken: 'test-web-token',
       maxDays: 0,
@@ -3233,7 +3233,7 @@ describe('SyncEngine — fixture-based sync integration', () => {
     loadScenario('selective-sync-openapi');
 
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings({
+    const engine = new SyncEngine(app, makeSettings({
       authMode: 'openapi',
       openApiToken: 'test-openapi-token',
       openApiClientId: 'test-client',
@@ -3271,7 +3271,7 @@ describe('SyncEngine — tag whitelist filter', () => {
 
     try {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }), undefined, { syncTags: [] });
+      const engine = new SyncEngine(app, makeSettings({ maxDays: 0 }), undefined, { syncTags: [] });
       const result = await engine.sync();
       expect(result.total).toBe(2);
     } finally {
@@ -3296,7 +3296,7 @@ describe('SyncEngine — tag whitelist filter', () => {
 
     try {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }), undefined, { syncTags: ['work'] });
+      const engine = new SyncEngine(app, makeSettings({ maxDays: 0 }), undefined, { syncTags: ['work'] });
       const result = await engine.sync();
       expect(result.total).toBe(1);
       expect(result.items?.map(i => i.noteId)).toEqual(['a']);
@@ -3320,7 +3320,7 @@ describe('SyncEngine — tag whitelist filter', () => {
 
     try {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }), undefined, { syncTags: ['work'] });
+      const engine = new SyncEngine(app, makeSettings({ maxDays: 0 }), undefined, { syncTags: ['work'] });
       const result = await engine.sync();
       expect(result.total).toBe(1);
     } finally {
@@ -3343,7 +3343,7 @@ describe('SyncEngine — tag whitelist filter', () => {
 
     try {
       const app = makeMockApp();
-      const engine = new SyncEngine(app as any, makeSettings({ maxDays: 0 }), undefined, { syncTags: ['nope'] });
+      const engine = new SyncEngine(app, makeSettings({ maxDays: 0 }), undefined, { syncTags: ['nope'] });
       const result = await engine.sync();
       expect(result.total).toBe(0);
     } finally {
@@ -3353,7 +3353,7 @@ describe('SyncEngine — tag whitelist filter', () => {
 
   it('filterNotesByTags private method returns all notes when whitelist is undefined', () => {
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings());
+    const engine = new SyncEngine(app, makeSettings());
     const notes = [
       makeNote({ note_id: 'a', tags: [{ name: 'work' }] }),
       makeNote({ note_id: 'b', tags: [] }),
@@ -3364,7 +3364,7 @@ describe('SyncEngine — tag whitelist filter', () => {
 
   it('filterNotesByTags private method returns matching notes for non-empty whitelist', () => {
     const app = makeMockApp();
-    const engine = new SyncEngine(app as any, makeSettings());
+    const engine = new SyncEngine(app, makeSettings());
     const notes = [
       makeNote({ note_id: 'a', tags: [{ name: 'work' }, { name: 'project' }] }),
       makeNote({ note_id: 'b', tags: [{ name: 'daily' }] }),
@@ -3407,9 +3407,9 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({
         success: true,
         data: { notes: [], has_more: false, next_cursor: '0' },
-      }) as any);
+      }) as Response);
 
-      const engine = new EngineReloaded(app as any, settings, undefined, {
+      const engine = new EngineReloaded(app, settings, undefined, {
         maxDays: 0,
         syncStartDate: '2026-04-27',
       });
@@ -3469,7 +3469,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({
         success: true,
         data: { notes: [], has_more: false, next_cursor: '0' },
-      }) as any);
+      }) as Response);
 
       const settings = makeSettings({
         scheduledSync: {
@@ -3479,7 +3479,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
         },
       });
 
-      const engine = new EngineReloaded(app as any, settings, undefined, {
+      const engine = new EngineReloaded(app, settings, undefined, {
         maxDays: 0,
         syncStartDate: '2026-04-27',
         syncKnowledgeBases: ['kb-1'],
@@ -3535,7 +3535,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({
         success: true,
         data: { notes: [], has_more: false, next_cursor: '0' },
-      }) as any);
+      }) as Response);
 
       const settings = makeSettings({
         scheduledSync: {
@@ -3545,7 +3545,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
         },
       });
 
-      const engine = new EngineReloaded(app as any, settings, undefined, {
+      const engine = new EngineReloaded(app, settings, undefined, {
         maxDays: 0,
         syncStartDate: '2026-04-27',
         syncKnowledgeBases: ['kb-3'],
@@ -3604,7 +3604,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
       );
       app.vault._addFile('得到大脑/知识库/跨库专题/asset/跨库音频笔记_transcript.md', '');
 
-      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: Request | string | URL) => {
         const urlStr = typeof url === 'string' ? url : url?.url ?? '';
         if (urlStr.includes('/resource/note/list')) {
           return mockFetchResponse({
@@ -3649,11 +3649,11 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
         },
       });
 
-      const engine = new EngineReloaded(app as any, settings, undefined, {
+      const engine = new EngineReloaded(app, settings, undefined, {
         maxDays: 0,
         syncStartDate: '2026-04-27',
         syncKnowledgeBases: ['kb-audio'],
-        knowledgeBaseNames: { kb_audio: '跨库专题', kb_audio_missing: '跨库专题' } as any,
+        knowledgeBaseNames: { kb_audio: '跨库专题', kb_audio_missing: '跨库专题' } as Record<string, string>,
       });
 
       const result = await engine.sync();


### PR DESCRIPTION
## Summary

Removes the remaining 53 `@typescript-eslint/no-explicit-any` violations from
`tests/sync-engine.spec.ts` so `npx eslint tests --max-warnings=0` drops from
53 errors to 0. No production code or test behavior changes.

## What changed

- Drop the `app as any` casts at 47 `new SyncEngine(...)` and 4
  `new EngineReloaded(...)` constructor sites; `MockApp = App & {...}` already
  extends the `App` interface, so direct assignment compiles.
- Drop the equivalent `makeMockApp() as any` (4x) and `mockApp as any` (1x)
  casts.
- Replace the 3 `}) as any)` mockResolvedValue mock fetch responses with
  `}) as Response)` to match the existing pattern.
- Replace `(url: any)` mock fetch parameter with
  `(url: Request | string | URL)`.
- Replace `} as any,` on the knowledgeBaseNames setting with
  `} as Record<string, string>` to match the SyncScopeOptions type.

## Risk

Pure test-only typing cleanup. No production code, sync semantics, vault writes,
GetNote ID/timestamp precision, authentication/quota behavior, user-facing UI,
release flow, or any package/manifest version is changed.

## Validation

- `npm run typecheck` — pass.
- `npm run lint` (src/) — pass.
- `npx eslint tests --max-warnings=0` — 0 errors (was 53).
- `npm test` — 595 passed, 2 skipped.
- `npm run build` — pass (main.js, manifest.json, styles.css).
- sync-engine.spec.ts: 99 tests still pass.

## Related

- #196 (test lint coverage debt)
- #233 / PR #233: previous batch that closed link-original fixtures.