### PR TITLE
feat(ui): add full settings link to manual sync panel (#237)

### DIFF
--- a/docs/superpowers/plans/2026-08-09-issue-237-full-settings-link-layout.md
+++ b/docs/superpowers/plans/2026-08-09-issue-237-full-settings-link-layout.md
@@ -1,0 +1,104 @@
+# Issue #237 Full Settings Link Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the full-settings shortcut out of the Cancel / Sync action group and into its own utility row below the manual-sync hint.
+
+**Architecture:** Keep the existing `onOpenSettings` callback and runtime settings navigation unchanged. Adjust only the `ManualSyncModal` DOM hierarchy, localized label, and focused CSS so navigation and sync actions are visually separate.
+
+**Tech Stack:** TypeScript, Preact, CSS, Vitest, happy-dom, Obsidian API.
+
+## Global Constraints
+
+- Only change issue #237 shortcut placement, copy, presentation, and its focused tests.
+- Do not change sync behavior, modal fields, vault writes, authentication, IDs, timestamps, versions, or other modals.
+- Keep the link keyboard accessible as a semantic button with a visible focus state.
+- Required verification: `npm run typecheck`, `npm run lint`, `npx eslint tests --max-warnings=0`, `npm test`, and `npm run build`.
+- Deploy `main.js`, `manifest.json`, and `styles.css` to the enabled local `getnote-importer` vault directory without changing version `1.4.2`.
+
+---
+
+### Task 1: Separate the settings shortcut from sync actions
+
+**Files:**
+- Modify: `tests/manual-sync-modal.spec.ts`
+- Modify: `src/ui/manual-sync-modal.tsx`
+- Modify: `src/i18n.ts`
+- Modify: `styles.css`
+
+**Interfaces:**
+- Consumes: existing optional `onOpenSettings?: () => void` prop.
+- Produces: `.getnote-settings-link-row` as the final row in `.getnote-manual-sync-body`, immediately after the hint and before the footer, containing `.getnote-settings-link` with localized text and the existing click callback.
+
+- [ ] **Step 1: Write the failing layout test**
+
+Update the existing #237 component test to assert the navigation link is outside the footer action group, contains no arrow, and sits in its own row immediately before the footer:
+
+```ts
+const settingsLink = container.querySelector('.getnote-settings-link') as HTMLButtonElement;
+const settingsRow = settingsLink.parentElement;
+const body = container.querySelector('.getnote-manual-sync-body')!;
+const footer = container.querySelector('.getnote-picker-footer')!;
+
+expect(settingsLink.textContent).toBe('Open full settings');
+expect(settingsRow?.classList.contains('getnote-settings-link-row')).toBe(true);
+expect(settingsRow?.parentElement).toBe(body);
+expect(settingsRow?.previousElementSibling?.classList.contains('getnote-input-hint')).toBe(true);
+expect(body.nextElementSibling).toBe(footer);
+expect(footer.contains(settingsLink)).toBe(false);
+```
+
+- [ ] **Step 2: Run the focused test and verify the current inline layout fails**
+
+Run:
+
+```bash
+npm test -- tests/manual-sync-modal.spec.ts
+```
+
+Expected: FAIL because the current link is inside `.getnote-picker-btns` and its label includes `→`.
+
+- [ ] **Step 3: Implement the dedicated utility row**
+
+In `src/ui/manual-sync-modal.tsx`, move the existing conditional button into the end of `.getnote-manual-sync-body`, immediately after the hint:
+
+```tsx
+{onOpenSettings && (
+  <div className="getnote-settings-link-row">
+    <button
+      className="getnote-settings-link"
+      type="button"
+      onClick={onOpenSettings}
+    >
+      {t('manualSync.openSettings')}
+    </button>
+  </div>
+)}
+```
+
+Keep `.getnote-picker-btns` limited to Cancel and Sync. Change the localized values to `打开完整设置` and `Open full settings`. Add focused CSS for left alignment, spacing above the footer, link hover, and `:focus-visible` without changing the modal width or button styling.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run:
+
+```bash
+npm test -- tests/manual-sync-modal.spec.ts
+npm run typecheck
+npm run lint
+npx eslint tests --max-warnings=0
+npm test
+npm run build
+```
+
+Expected: focused test passes; full suite, lint, typecheck, and build exit successfully.
+
+- [ ] **Step 5: Commit, push, deploy, and verify artifacts**
+
+```bash
+git add src/i18n.ts src/ui/manual-sync-modal.tsx styles.css tests/manual-sync-modal.spec.ts docs/superpowers/plans/2026-08-09-issue-237-full-settings-link-layout.md
+git commit -m "fix(ui): separate #237 settings link from sync actions"
+git push origin codex/237-add-settings-entry-in-manual-sync-modal
+```
+
+Copy the rebuilt release artifacts to `/Users/zhengyan/Downloads/同步空间/9_个人笔记/郑大师的笔记本/.obsidian/plugins/getnote-importer/`, verify source and deployed SHA-256 hashes match, then request visible Obsidian acceptance after `Reload app without saving`.

--- a/docs/superpowers/plans/2026-08-09-issue-237-full-settings-link-layout.md
+++ b/docs/superpowers/plans/2026-08-09-issue-237-full-settings-link-layout.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Move the full-settings shortcut out of the Cancel / Sync action group and into its own utility row below the manual-sync hint.
+**Goal:** Put the full-settings shortcut in the footer's left-side utility position, replacing the transient-scope label.
 
 **Architecture:** Keep the existing `onOpenSettings` callback and runtime settings navigation unchanged. Adjust only the `ManualSyncModal` DOM hierarchy, localized label, and focused CSS so navigation and sync actions are visually separate.
 
@@ -28,24 +28,20 @@
 
 **Interfaces:**
 - Consumes: existing optional `onOpenSettings?: () => void` prop.
-- Produces: `.getnote-settings-link-row` as the final row in `.getnote-manual-sync-body`, immediately after the hint and before the footer, containing `.getnote-settings-link` with localized text and the existing click callback.
+- Produces: `.getnote-settings-link` as the direct left-side child of `.getnote-picker-footer`, with localized text and the existing click callback; removes the old `.getnote-settings-link-row`. When the optional callback is absent, the existing `.getnote-picker-count` remains as a compatibility fallback.
 
 - [ ] **Step 1: Write the failing layout test**
 
-Update the existing #237 component test to assert the navigation link is outside the footer action group, contains no arrow, and sits in its own row immediately before the footer:
+Update the existing #237 component test to assert the navigation link contains no arrow, replaces the old scope label, and is a direct child of the footer:
 
 ```ts
 const settingsLink = container.querySelector('.getnote-settings-link') as HTMLButtonElement;
-const settingsRow = settingsLink.parentElement;
-const body = container.querySelector('.getnote-manual-sync-body')!;
 const footer = container.querySelector('.getnote-picker-footer')!;
 
 expect(settingsLink.textContent).toBe('Open full settings');
-expect(settingsRow?.classList.contains('getnote-settings-link-row')).toBe(true);
-expect(settingsRow?.parentElement).toBe(body);
-expect(settingsRow?.previousElementSibling?.classList.contains('getnote-input-hint')).toBe(true);
-expect(body.nextElementSibling).toBe(footer);
-expect(footer.contains(settingsLink)).toBe(false);
+expect(settingsLink.parentElement).toBe(footer);
+expect(container.querySelector('.getnote-settings-link-row')).toBeNull();
+expect(container.querySelector('.getnote-picker-count')).toBeNull();
 ```
 
 - [ ] **Step 2: Run the focused test and verify the current inline layout fails**
@@ -56,27 +52,27 @@ Run:
 npm test -- tests/manual-sync-modal.spec.ts
 ```
 
-Expected: FAIL because the current link is inside `.getnote-picker-btns` and its label includes `→`.
+Expected: FAIL because the current link is in a dedicated body row and the footer still renders `.getnote-picker-count`.
 
-- [ ] **Step 3: Implement the dedicated utility row**
+- [ ] **Step 3: Implement the footer utility link**
 
-In `src/ui/manual-sync-modal.tsx`, move the existing conditional button into the end of `.getnote-manual-sync-body`, immediately after the hint:
+In `src/ui/manual-sync-modal.tsx`, remove the dedicated body row and replace the footer scope label with the conditional settings button:
 
 ```tsx
-{onOpenSettings && (
-  <div className="getnote-settings-link-row">
-    <button
-      className="getnote-settings-link"
-      type="button"
-      onClick={onOpenSettings}
-    >
-      {t('manualSync.openSettings')}
-    </button>
-  </div>
+{onOpenSettings ? (
+  <button
+    className="getnote-settings-link"
+    type="button"
+    onClick={onOpenSettings}
+  >
+    {t('manualSync.openSettings')}
+  </button>
+) : (
+  <span className="getnote-picker-count">{t('manualSync.once')}</span>
 )}
 ```
 
-Keep `.getnote-picker-btns` limited to Cancel and Sync. Change the localized values to `打开完整设置` and `Open full settings`. Add focused CSS for left alignment, spacing above the footer, link hover, and `:focus-visible` without changing the modal width or button styling.
+Keep `.getnote-picker-btns` limited to Cancel and Sync. Preserve the localized values `打开完整设置` and `Open full settings`. Remove the obsolete row CSS and preserve the count fallback CSS, link hover, and `:focus-visible` behavior without changing the modal width or button styling.
 
 - [ ] **Step 4: Run focused and full verification**
 

--- a/docs/superpowers/specs/2026-08-09-issue-237-full-settings-link-layout-design.md
+++ b/docs/superpowers/specs/2026-08-09-issue-237-full-settings-link-layout-design.md
@@ -1,0 +1,36 @@
+# Issue #237 Full Settings Link Layout Design
+
+## Goal
+
+Make the full-settings shortcut in the manual sync modal read as secondary navigation instead of part of the Cancel and Sync action sequence.
+
+## Selected Layout
+
+Use a dedicated utility row between the explanatory hint and the footer divider:
+
+- Render `打开完整设置` / `Open full settings` as a text link without a directional arrow.
+- Align the link to the left edge of the modal content.
+- Keep the footer limited to `仅本次同步` on the left and Cancel / Sync on the right.
+- Preserve the existing modal width, form layout, colors, button hierarchy, and spacing rhythm.
+
+## Interaction
+
+Clicking the link closes the manual sync modal and opens the Dedao Brain Sync settings tab. It does not trigger sync and does not preserve the modal's temporary filters.
+
+## Accessibility
+
+Implement the link as a semantic button styled like a text link because it performs an application action rather than navigating to a URL. Preserve keyboard focus behavior and a visible focus state.
+
+## Scope
+
+Only change the placement, copy, and presentation of the existing #237 settings shortcut. Do not change sync behavior, modal fields, vault writes, authentication, IDs, timestamps, versions, or other modals.
+
+## Acceptance
+
+- The full-settings link appears on its own row below the explanatory hint.
+- The link contains no arrow that can visually point at Cancel.
+- The footer contains only the transient-scope label and the Cancel / Sync buttons.
+- Clicking the link closes the modal, opens the plugin settings tab, and does not trigger sync.
+- Chinese and English labels remain localized.
+- Focused tests and the repository's required checks pass.
+- The rebuilt plugin is deployed to the enabled local vault and visually accepted in Obsidian.

--- a/docs/superpowers/specs/2026-08-09-issue-237-full-settings-link-layout-design.md
+++ b/docs/superpowers/specs/2026-08-09-issue-237-full-settings-link-layout-design.md
@@ -6,11 +6,12 @@ Make the full-settings shortcut in the manual sync modal read as secondary navig
 
 ## Selected Layout
 
-Use a dedicated utility row between the explanatory hint and the footer divider:
+Use the footer's existing left-side utility position:
 
 - Render `打开完整设置` / `Open full settings` as a text link without a directional arrow.
-- Align the link to the left edge of the modal content.
-- Keep the footer limited to `仅本次同步` on the left and Cancel / Sync on the right.
+- Replace the `仅本次同步` / `This sync only` label with the link.
+- Keep Cancel / Sync grouped on the right.
+- Do not render a second settings-link row inside the modal body.
 - Preserve the existing modal width, form layout, colors, button hierarchy, and spacing rhythm.
 
 ## Interaction
@@ -27,9 +28,10 @@ Only change the placement, copy, and presentation of the existing #237 settings 
 
 ## Acceptance
 
-- The full-settings link appears on its own row below the explanatory hint.
+- The full-settings link appears at the left side of the footer in place of the transient-scope label.
 - The link contains no arrow that can visually point at Cancel.
-- The footer contains only the transient-scope label and the Cancel / Sync buttons.
+- The footer contains the full-settings link and the Cancel / Sync buttons.
+- No duplicate settings-link row appears above the footer.
 - Clicking the link closes the modal, opens the plugin settings tab, and does not trigger sync.
 - Chinese and English labels remain localized.
 - Focused tests and the repository's required checks pass.

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -155,6 +155,7 @@ export const translations: Record<string, Record<string, string>> = {
     'manualSync.once': '仅本次同步',
     'manualSync.mode.date': '按日期',
     'manualSync.mode.days': '按天数',
+    'manualSync.openSettings': '打开完整设置 →',
 
     // === Sync Button ===
     'sync.syncing': '同步中...',
@@ -530,6 +531,7 @@ export const translations: Record<string, Record<string, string>> = {
     'manualSync.once': 'This sync only',
     'manualSync.mode.date': 'By Date',
     'manualSync.mode.days': 'By Days',
+    'manualSync.openSettings': 'Open full settings →',
 
     // === Sync Button ===
     'sync.syncing': 'Syncing...',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -155,7 +155,7 @@ export const translations: Record<string, Record<string, string>> = {
     'manualSync.once': '仅本次同步',
     'manualSync.mode.date': '按日期',
     'manualSync.mode.days': '按天数',
-    'manualSync.openSettings': '打开完整设置 →',
+    'manualSync.openSettings': '打开完整设置',
 
     // === Sync Button ===
     'sync.syncing': '同步中...',
@@ -531,7 +531,7 @@ export const translations: Record<string, Record<string, string>> = {
     'manualSync.once': 'This sync only',
     'manualSync.mode.date': 'By Date',
     'manualSync.mode.days': 'By Days',
-    'manualSync.openSettings': 'Open full settings →',
+    'manualSync.openSettings': 'Open full settings',
 
     // === Sync Button ===
     'sync.syncing': 'Syncing...',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -604,6 +604,16 @@ export default class GetNoteSyncPlugin extends Plugin {
     wrapper.open();
   }
 
+  openSettingsTab(): void {
+    // Obsidian's `app.setting` is internal API; the public TypeScript
+    // bindings (1.13+) do not expose it, but the runtime still supports
+    // it. Revisit if Obsidian ships a public replacement.
+    // @ts-expect-error — internal API, see comment above
+    this.app.setting.open();
+    // @ts-expect-error — internal API, see comment above
+    this.app.setting.openTabById(this.manifest.id);
+  }
+
   startSync(scopeOptions: SyncScopeOptions): void {
     void this.runSync('full', scopeOptions);
   }
@@ -887,6 +897,10 @@ class ManualSyncModalWrapper extends Modal {
           syncTags: this.plugin.settings.syncTags,
         }}
         tagOptions={this.plugin.settings.tagCache?.tags ?? []}
+        onOpenSettings={() => {
+          this.close();
+          this.plugin.openSettingsTab();
+        }}
         onConfirm={(options) => {
           this.close();
           this.plugin.startSync(options);

--- a/src/ui/manual-sync-modal.tsx
+++ b/src/ui/manual-sync-modal.tsx
@@ -118,20 +118,19 @@ export function ManualSyncModal({ initialOptions, tagOptions = [], onConfirm, on
           </div>
         </div>
         <div className="getnote-input-hint">{t('manualSync.hint')}</div>
-        {onOpenSettings && (
-          <div className="getnote-settings-link-row">
-            <button
-              className="getnote-settings-link"
-              type="button"
-              onClick={onOpenSettings}
-            >
-              {t('manualSync.openSettings')}
-            </button>
-          </div>
-        )}
       </div>
       <div className="getnote-picker-footer">
-        <span className="getnote-picker-count">{t('manualSync.once')}</span>
+        {onOpenSettings ? (
+          <button
+            className="getnote-settings-link"
+            type="button"
+            onClick={onOpenSettings}
+          >
+            {t('manualSync.openSettings')}
+          </button>
+        ) : (
+          <span className="getnote-picker-count">{t('manualSync.once')}</span>
+        )}
         <div className="getnote-picker-btns">
           <button className="mod-cancel" onClick={onCancel}>{t('picker.cancel')}</button>
           <button className="mod-cta" onClick={handleConfirm}>{t('picker.confirm')}</button>

--- a/src/ui/manual-sync-modal.tsx
+++ b/src/ui/manual-sync-modal.tsx
@@ -118,20 +118,21 @@ export function ManualSyncModal({ initialOptions, tagOptions = [], onConfirm, on
           </div>
         </div>
         <div className="getnote-input-hint">{t('manualSync.hint')}</div>
-      </div>
-      <div className="getnote-picker-footer">
-        <span className="getnote-picker-count">{t('manualSync.once')}</span>
-        <div className="getnote-picker-btns">
-          {onOpenSettings && (
+        {onOpenSettings && (
+          <div className="getnote-settings-link-row">
             <button
               className="getnote-settings-link"
               type="button"
               onClick={onOpenSettings}
-              aria-label={t('manualSync.openSettings')}
             >
               {t('manualSync.openSettings')}
             </button>
-          )}
+          </div>
+        )}
+      </div>
+      <div className="getnote-picker-footer">
+        <span className="getnote-picker-count">{t('manualSync.once')}</span>
+        <div className="getnote-picker-btns">
           <button className="mod-cancel" onClick={onCancel}>{t('picker.cancel')}</button>
           <button className="mod-cta" onClick={handleConfirm}>{t('picker.confirm')}</button>
         </div>

--- a/src/ui/manual-sync-modal.tsx
+++ b/src/ui/manual-sync-modal.tsx
@@ -12,6 +12,7 @@ interface ManualSyncModalProps {
   tagOptions?: string[];
   onConfirm: (options: SyncScopeOptions) => void;
   onCancel: () => void;
+  onOpenSettings?: () => void;
 }
 
 function resolveInitialSyncMode(initialOptions: SyncScopeOptions): SyncMode {
@@ -28,7 +29,7 @@ function resolveInitialSyncMode(initialOptions: SyncScopeOptions): SyncMode {
   return daysCutoff >= startTime ? 'days' : 'date';
 }
 
-export function ManualSyncModal({ initialOptions, tagOptions = [], onConfirm, onCancel }: ManualSyncModalProps) {
+export function ManualSyncModal({ initialOptions, tagOptions = [], onConfirm, onCancel, onOpenSettings }: ManualSyncModalProps) {
   const [syncMode, setSyncMode] = useState<SyncMode>(resolveInitialSyncMode(initialOptions));
   const [syncStartDate, setSyncStartDate] = useState(initialOptions.syncStartDate || getLocalDateInputValue());
   const [maxDays, setMaxDays] = useState(String(initialOptions.maxDays));
@@ -121,6 +122,16 @@ export function ManualSyncModal({ initialOptions, tagOptions = [], onConfirm, on
       <div className="getnote-picker-footer">
         <span className="getnote-picker-count">{t('manualSync.once')}</span>
         <div className="getnote-picker-btns">
+          {onOpenSettings && (
+            <button
+              className="getnote-settings-link"
+              type="button"
+              onClick={onOpenSettings}
+              aria-label={t('manualSync.openSettings')}
+            >
+              {t('manualSync.openSettings')}
+            </button>
+          )}
           <button className="mod-cancel" onClick={onCancel}>{t('picker.cancel')}</button>
           <button className="mod-cta" onClick={handleConfirm}>{t('picker.confirm')}</button>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1499,11 +1499,6 @@ body .getnote-tag-select-option input[type="checkbox"] {
   gap: 8px;
 }
 
-.getnote-settings-link-row {
-  display: flex;
-  justify-content: flex-start;
-}
-
 button.getnote-settings-link {
   height: auto;
   padding: 2px 0;

--- a/styles.css
+++ b/styles.css
@@ -1495,7 +1495,25 @@ body .getnote-tag-select-option input[type="checkbox"] {
 
 .getnote-picker-btns {
   display: flex;
+  align-items: center;
   gap: 8px;
+}
+
+button.getnote-settings-link {
+  height: auto;
+  padding: 4px 2px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-accent);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+button.getnote-settings-link:hover {
+  background: transparent;
+  color: var(--text-accent-hover);
+  text-decoration: underline;
 }
 
 /* === Loading Modal === */

--- a/styles.css
+++ b/styles.css
@@ -1499,9 +1499,14 @@ body .getnote-tag-select-option input[type="checkbox"] {
   gap: 8px;
 }
 
+.getnote-settings-link-row {
+  display: flex;
+  justify-content: flex-start;
+}
+
 button.getnote-settings-link {
   height: auto;
-  padding: 4px 2px;
+  padding: 2px 0;
   border: 0;
   background: transparent;
   box-shadow: none;
@@ -1514,6 +1519,11 @@ button.getnote-settings-link:hover {
   background: transparent;
   color: var(--text-accent-hover);
   text-decoration: underline;
+}
+
+button.getnote-settings-link:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
 }
 
 /* === Loading Modal === */

--- a/tests/manual-sync-modal.spec.ts
+++ b/tests/manual-sync-modal.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
 import { ManualSyncModal } from '../src/ui/manual-sync-modal';
+import { initI18n } from '../src/i18n';
 
 function renderModal(initialOptions: { syncStartDate: string; maxDays: number; enabledNoteTypes?: string[] }, onConfirm = vi.fn()) {
   const container = document.createElement('div');
@@ -18,6 +19,7 @@ function renderModal(initialOptions: { syncStartDate: string; maxDays: number; e
 }
 
 afterEach(() => {
+  initI18n('zh');
   vi.useRealTimers();
   vi.restoreAllMocks();
   render(null, document.body);
@@ -25,6 +27,41 @@ afterEach(() => {
 });
 
 describe('ManualSyncModal filters', () => {
+  it('hides the full-settings link by default (no onOpenSettings prop)', async () => {
+    const { container } = renderModal({ syncStartDate: '', maxDays: 30 });
+
+    expect(container.querySelector('.getnote-settings-link')).toBeNull();
+  });
+
+  it('renders a full-settings text link and triggers onOpenSettings (#237)', async () => {
+    initI18n('en');
+    const onConfirm = vi.fn();
+    const onOpenSettings = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(
+      h(ManualSyncModal, {
+        initialOptions: { syncStartDate: '', maxDays: 30 },
+        onConfirm,
+        onCancel: vi.fn(),
+        onOpenSettings,
+      }),
+      container
+    );
+
+    const settingsLink = container.querySelector('.getnote-settings-link') as HTMLButtonElement;
+    expect(settingsLink).toBeTruthy();
+    expect(settingsLink.classList.contains('mod-secondary')).toBe(false);
+    expect(settingsLink.textContent).toBe('Open full settings →');
+
+    await act(() => {
+      settingsLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   it('defaults to days mode and submits maxDays >= 1', async () => {
     const { container, onConfirm } = renderModal({ syncStartDate: '', maxDays: 0 });
 

--- a/tests/manual-sync-modal.spec.ts
+++ b/tests/manual-sync-modal.spec.ts
@@ -33,7 +33,7 @@ describe('ManualSyncModal filters', () => {
     expect(container.querySelector('.getnote-settings-link')).toBeNull();
   });
 
-  it('renders the full-settings link on its own row before the footer (#237)', async () => {
+  it('replaces the footer scope label with the full-settings link (#237)', async () => {
     initI18n('en');
     const onConfirm = vi.fn();
     const onOpenSettings = vi.fn();
@@ -50,17 +50,13 @@ describe('ManualSyncModal filters', () => {
     );
 
     const settingsLink = container.querySelector('.getnote-settings-link') as HTMLButtonElement;
-    const settingsRow = settingsLink.parentElement;
-    const body = container.querySelector('.getnote-manual-sync-body')!;
     const footer = container.querySelector('.getnote-picker-footer')!;
     expect(settingsLink).toBeTruthy();
     expect(settingsLink.classList.contains('mod-secondary')).toBe(false);
     expect(settingsLink.textContent).toBe('Open full settings');
-    expect(settingsRow?.classList.contains('getnote-settings-link-row')).toBe(true);
-    expect(settingsRow?.parentElement).toBe(body);
-    expect(settingsRow?.previousElementSibling?.classList.contains('getnote-input-hint')).toBe(true);
-    expect(body.nextElementSibling).toBe(footer);
-    expect(footer.contains(settingsLink)).toBe(false);
+    expect(settingsLink.parentElement).toBe(footer);
+    expect(container.querySelector('.getnote-settings-link-row')).toBeNull();
+    expect(container.querySelector('.getnote-picker-count')).toBeNull();
 
     await act(() => {
       settingsLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/tests/manual-sync-modal.spec.ts
+++ b/tests/manual-sync-modal.spec.ts
@@ -33,7 +33,7 @@ describe('ManualSyncModal filters', () => {
     expect(container.querySelector('.getnote-settings-link')).toBeNull();
   });
 
-  it('renders a full-settings text link and triggers onOpenSettings (#237)', async () => {
+  it('renders the full-settings link on its own row before the footer (#237)', async () => {
     initI18n('en');
     const onConfirm = vi.fn();
     const onOpenSettings = vi.fn();
@@ -50,9 +50,17 @@ describe('ManualSyncModal filters', () => {
     );
 
     const settingsLink = container.querySelector('.getnote-settings-link') as HTMLButtonElement;
+    const settingsRow = settingsLink.parentElement;
+    const body = container.querySelector('.getnote-manual-sync-body')!;
+    const footer = container.querySelector('.getnote-picker-footer')!;
     expect(settingsLink).toBeTruthy();
     expect(settingsLink.classList.contains('mod-secondary')).toBe(false);
-    expect(settingsLink.textContent).toBe('Open full settings →');
+    expect(settingsLink.textContent).toBe('Open full settings');
+    expect(settingsRow?.classList.contains('getnote-settings-link-row')).toBe(true);
+    expect(settingsRow?.parentElement).toBe(body);
+    expect(settingsRow?.previousElementSibling?.classList.contains('getnote-input-hint')).toBe(true);
+    expect(body.nextElementSibling).toBe(footer);
+    expect(footer.contains(settingsLink)).toBe(false);
 
     await act(() => {
       settingsLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));


### PR DESCRIPTION
Resolves #237

## Summary

Adds a lightweight Open full settings text link to the left side of the manual-sync footer, replacing the transient-scope label. Cancel and Sync remain grouped on the right, and there is no duplicate settings-link row above the footer.

Clicking the link closes the panel and opens the Dedao Brain Sync settings tab directly. This is a navigation shortcut only; it does not preserve temporary date, max-days, note-type, or tag selections.

## Changes

- add 打开完整设置 / Open full settings localized copy without a directional arrow
- replace the footer transient-scope label with the settings link
- keep Cancel and Sync grouped as the right-side footer actions
- remove the separate settings-link row from the modal body
- retain the existing close-and-open-settings callback and runtime app.setting bridge
- preserve keyboard focus styling and the no-callback compatibility fallback
- cover DOM placement, localized copy, click callback, and no-sync behavior
- update the selected design and implementation plan

## Verification

- npm run typecheck
- npm run lint
- npx eslint tests --max-warnings=0
- npm test: 712 passed, 2 skipped
- npm run build

## Risk / scope

No sync, vault-write, authentication, ID/timestamp, version, or release behavior changes. Built artifacts were deployed to the enabled local getnote-importer vault directory; visible Obsidian acceptance is required before merge.