### PR TITLE
fix: address Codex Security scan findings

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -29,7 +29,7 @@ jobs:
         if: env.OPENAI_API_KEY == ''
         run: echo "OPENAI_API_KEY is not configured; skipping Codex review."
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: env.OPENAI_API_KEY != ''
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
@@ -47,7 +47,7 @@ jobs:
       - name: Run Codex review
         if: env.OPENAI_API_KEY != ''
         id: run_codex
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           sandbox: read-only
@@ -83,7 +83,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Report Codex feedback
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
           cache: 'npm'
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           name: ${{ steps.version.outputs.version }}
           files: |
@@ -84,6 +84,6 @@ jobs:
 
       - name: Attest Build Artifacts
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: "main.js,manifest.json,styles.css"

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -72,9 +72,20 @@ function isSortedByCreatedDesc(notes: GetNoteNote[]): boolean {
   return true;
 }
 
+const TRUSTED_ATTACHMENT_HOST_SUFFIXES = ['.umiwi.com'];
+
 function isSafeAttachmentUrl(url: string): boolean {
   try {
-    return new URL(url).protocol === 'https:';
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    const trustedHost = TRUSTED_ATTACHMENT_HOST_SUFFIXES.some(suffix => (
+      hostname === suffix.slice(1) || hostname.endsWith(suffix)
+    ));
+    return parsed.protocol === 'https:'
+      && !parsed.username
+      && !parsed.password
+      && (!parsed.port || parsed.port === '443')
+      && trustedHost;
   } catch {
     return false;
   }
@@ -269,7 +280,7 @@ export class SyncEngine {
       // Skip already-existing files
       if (this.app.vault.getAbstractFileByPath(targetPath)) return targetPath;
 
-      const res = await fetch(attachment.url);
+      const res = await fetch(attachment.url, { redirect: 'error' });
       if (res.status < 200 || res.status >= 300) {
         console.error(`[DedaoBrain] Audio download failed: ${res.status}`);
         return null;
@@ -307,7 +318,7 @@ export class SyncEngine {
 
       if (this.app.vault.getAbstractFileByPath(targetPath)) return targetPath;
 
-      const res = await fetch(attachment.url);
+      const res = await fetch(attachment.url, { redirect: 'error' });
       if (res.status < 200 || res.status >= 300) {
         console.error(`[DedaoBrain] Image download failed: ${res.status}`);
         return null;
@@ -345,7 +356,7 @@ export class SyncEngine {
 
       if (this.app.vault.getAbstractFileByPath(targetPath)) return targetPath;
 
-      const res = await fetch(attachment.url);
+      const res = await fetch(attachment.url, { redirect: 'error' });
       if (res.status < 200 || res.status >= 300) {
         console.error(`[DedaoBrain] Generic asset download failed (${kind}): ${res.status}`);
         return null;
@@ -372,11 +383,8 @@ export class SyncEngine {
       const targetPath = `${assetDir}/${this.getAudioAssetBaseName(note)}_transcript.md`;
       const content = `# ${generateDisplayTitle(note) || t('picker.noTitle')}\n\n${note.audio}`;
       const existing = this.app.vault.getAbstractFileByPath(targetPath);
-      if (existing instanceof TFile) {
-        await this.app.vault.modify(existing, content);
-      } else {
-        await this.app.vault.create(targetPath, content);
-      }
+      if (existing) return targetPath;
+      await this.app.vault.create(targetPath, content);
       return targetPath;
     } catch (err) {
       console.error('[DedaoBrain] Audio transcript write error:', err);
@@ -401,11 +409,8 @@ export class SyncEngine {
       const sourceLine = url ? `来源链接：${url}\n\n` : '';
       const content = `# ${title}\n\n${sourceLine}${originalContent}`;
       const existing = this.app.vault.getAbstractFileByPath(targetPath);
-      if (existing) {
-        await this.app.vault.modify(existing as TFile, content);
-      } else {
-        await this.app.vault.create(targetPath, content);
-      }
+      if (existing) return targetPath;
+      await this.app.vault.create(targetPath, content);
       return targetPath;
     } catch (err) {
       console.error('[DedaoBrain] Link original write error:', err);
@@ -444,6 +449,11 @@ export class SyncEngine {
     } catch {
       return true;
     }
+  }
+
+  private isOwnedByNote(file: TFile, noteId: string): boolean {
+    const cached = this.app.metadataCache.getFileCache(file);
+    return String(cached?.frontmatter?.['uid'] ?? '') === noteId;
   }
 
   private buildUidIndex(): Map<string, TFile> {
@@ -507,18 +517,17 @@ export class SyncEngine {
 
       const categoryDir = await this.ensureNoteCategoryDir(note, categoryOverride ?? getCategoryDir(note.note_type));
       let targetPath = `${categoryDir}/${this.getFileName(note, parentBaseName)}.md`;
-      const existingAtTarget = this.app.vault.getAbstractFileByPath(targetPath);
+      let existingAtTarget = this.app.vault.getAbstractFileByPath(targetPath);
 
-      if (existingAtTarget instanceof TFile) {
-        const cached = this.app.metadataCache.getFileCache(existingAtTarget);
-        const targetUid = cached?.frontmatter?.['uid'] as string | undefined;
-        if (targetUid && targetUid !== note.note_id) {
-          const baseName = this.getFileName(note);
-          targetPath = this.resolveConflict(categoryDir, baseName);
-        }
+      if (
+        existingAtTarget
+        && (!(existingAtTarget instanceof TFile) || !this.isOwnedByNote(existingAtTarget, note.note_id))
+      ) {
+        targetPath = this.resolveConflict(categoryDir, this.getFileName(note, parentBaseName));
+        existingAtTarget = this.app.vault.getAbstractFileByPath(targetPath);
       }
 
-      if (existingAtTarget instanceof TFile) {
+      if (existingAtTarget instanceof TFile && this.isOwnedByNote(existingAtTarget, note.note_id)) {
         const content = renderNote(note, note.assetFileName, parentFileName, childFileNames);
         // File exists at target path but wasn't in uidIndex - check content
         const contentChanged = this.isContentChanged(existingAtTarget, note) || hasImageAssetPaths(note) || Boolean(note.linkOriginalFileName);
@@ -536,14 +545,19 @@ export class SyncEngine {
           return { status: 'created', file: created instanceof TFile ? created : undefined };
         } catch (createErr) {
           // File was created by another process between check and create
-          const existing = this.app.vault.getAbstractFileByPath(targetPath);
-          if (existing instanceof TFile) {
-            const contentChanged = this.isContentChanged(existing, note);
-            await this.app.vault.modify(existing, content);
-            uidIndex.set(note.note_id, existing);
-            return { status: contentChanged ? 'updated' : 'skipped', file: existing };
+          const racedTarget = this.app.vault.getAbstractFileByPath(targetPath);
+          if (!racedTarget) throw createErr;
+          if (racedTarget instanceof TFile && this.isOwnedByNote(racedTarget, note.note_id)) {
+            const contentChanged = this.isContentChanged(racedTarget, note);
+            await this.app.vault.modify(racedTarget, content);
+            uidIndex.set(note.note_id, racedTarget);
+            return { status: contentChanged ? 'updated' : 'skipped', file: racedTarget };
           }
-          throw createErr;
+          const retryPath = this.resolveConflict(categoryDir, this.getFileName(note, parentBaseName));
+          await this.app.vault.create(retryPath, content);
+          const created = this.app.vault.getAbstractFileByPath(retryPath);
+          if (created instanceof TFile) uidIndex.set(note.note_id, created);
+          return { status: 'created', file: created instanceof TFile ? created : undefined };
         }
       }
     } catch (err) {

--- a/tests/sync-engine.spec.ts
+++ b/tests/sync-engine.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { App, TFile } from 'obsidian';
+import { TFile, type App } from 'obsidian';
 import { SyncEngine } from '../src/sync';
 import type { Settings, GetNoteNote } from '../src/types';
 import { DEFAULT_SETTINGS } from '../src/types';
@@ -121,6 +121,81 @@ function mockFetchResponse(body: unknown) {
   };
 }
 
+describe('SyncEngine — vault write ownership', () => {
+  it.each([
+    { label: 'has no uid', frontmatter: {} },
+    { label: 'belongs to another uid', frontmatter: { uid: 'another-note' } },
+  ])('preserves a colliding Markdown file that $label', async ({ frontmatter }) => {
+    const app = makeMockApp();
+    const targetPath = '得到大脑/纯文本/冲突标题.md';
+    const originalGet = app.vault.getAbstractFileByPath.bind(app.vault);
+    const existingFile = new TFile(targetPath);
+    app.vault._addFile(targetPath, '用户原始内容', frontmatter);
+    vi.spyOn(app.vault, 'getAbstractFileByPath').mockImplementation((path: string) => (
+      path === targetPath ? existingFile : originalGet(path)
+    ));
+
+    const engine = new SyncEngine(app, makeSettings());
+    // @ts-expect-error private helper is tested through its real vault boundary
+    await engine['writeNote'](
+      makeNote({ note_id: 'remote-note', title: '冲突标题', content: '远端内容' }),
+      new Map<string, TFile>(),
+    );
+
+    expect((originalGet(targetPath) as { content: string }).content).toBe('用户原始内容');
+    expect(app.vault.create).toHaveBeenCalledWith(
+      '得到大脑/纯文本/冲突标题-2.md',
+      expect.stringContaining('远端内容'),
+    );
+  });
+
+  it('does not overwrite an unrelated transcript artifact', async () => {
+    const app = makeMockApp();
+    const targetPath = '得到大脑/录音笔记/asset/录音_collision_audio_transcript.md';
+    const originalGet = app.vault.getAbstractFileByPath.bind(app.vault);
+    const existingFile = new TFile(targetPath);
+    app.vault._addFile(targetPath, '用户自己的附件笔记');
+    vi.spyOn(app.vault, 'getAbstractFileByPath').mockImplementation((path: string) => (
+      path === targetPath ? existingFile : originalGet(path)
+    ));
+
+    const engine = new SyncEngine(app, makeSettings());
+    // @ts-expect-error private helper is tested through its real vault boundary
+    await engine['writeAudioTranscriptAsset'](makeNote({
+      note_id: 'collision_audio',
+      title: '录音',
+      note_type: 'recorder_audio',
+      audio: '远端转写',
+    }));
+
+    expect((originalGet(targetPath) as { content: string }).content).toBe('用户自己的附件笔记');
+    expect(app.vault.modify).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite an unrelated link-original artifact', async () => {
+    const app = makeMockApp();
+    const targetPath = '得到大脑/链接笔记/asset/链接_collision_link_original.md';
+    const originalGet = app.vault.getAbstractFileByPath.bind(app.vault);
+    const existingFile = new TFile(targetPath);
+    app.vault._addFile(targetPath, '用户自己的链接笔记');
+    vi.spyOn(app.vault, 'getAbstractFileByPath').mockImplementation((path: string) => (
+      path === targetPath ? existingFile : originalGet(path)
+    ));
+
+    const engine = new SyncEngine(app, makeSettings());
+    // @ts-expect-error private helper is tested through its real vault boundary
+    await engine['writeLinkOriginalAsset'](makeNote({
+      note_id: 'collision_link',
+      title: '链接',
+      note_type: 'link',
+      linkOriginal: { content: '远端原文' },
+    }));
+
+    expect((originalGet(targetPath) as { content: string }).content).toBe('用户自己的链接笔记');
+    expect(app.vault.modify).not.toHaveBeenCalled();
+  });
+});
+
 describe('SyncEngine — existing UID precheck before enrichment', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -130,14 +205,14 @@ describe('SyncEngine — existing UID precheck before enrichment', () => {
     {
       label: 'image',
       noteType: 'img_text',
-      detail: { attachments: [{ type: 'image', url: 'https://cdn.example.com/image.png', title: '图片' }] },
+      detail: { attachments: [{ type: 'image', url: 'https://mediacdn.umiwi.com/image.png', title: '图片' }] },
     },
     {
       label: 'audio',
       noteType: 'recorder_audio',
       detail: {
         audio: '转写',
-        attachments: [{ type: 'audio', url: 'https://cdn.example.com/audio.mp3', title: '录音' }],
+        attachments: [{ type: 'audio', url: 'https://mediacdn.umiwi.com/audio.mp3', title: '录音' }],
       },
     },
     {
@@ -150,7 +225,7 @@ describe('SyncEngine — existing UID precheck before enrichment', () => {
     {
       label: 'generic attachment',
       noteType: 'plain_text',
-      detail: { attachments: [{ type: 'document', url: 'https://cdn.example.com/file.pdf', title: '附件' }] },
+      detail: { attachments: [{ type: 'document', url: 'https://mediacdn.umiwi.com/file.pdf', title: '附件' }] },
     },
   ])('does not create orphan date-path assets for an existing $label note', async ({ noteType, detail }) => {
     const note = makeNote({
@@ -212,7 +287,7 @@ describe('SyncEngine — existing UID precheck before enrichment', () => {
       note_type: 'img_text',
       parent_id: parent.note_id,
       is_child_note: true,
-      attachments: [{ type: 'image', url: 'https://cdn.example.com/child.png', title: '图片' }],
+      attachments: [{ type: 'image', url: 'https://mediacdn.umiwi.com/child.png', title: '图片' }],
     });
     const app = makeMockApp();
     app.vault._addFile('得到大脑/纯文本/父.md', '父', { uid: parent.note_id });
@@ -267,7 +342,7 @@ describe('SyncEngine — existing UID precheck before enrichment', () => {
             note: {
               ...parent,
               children_ids: [child.note_id],
-              attachments: [{ type: 'audio', url: 'https://cdn.example.com/parent.mp3', title: '父录音' }],
+              attachments: [{ type: 'audio', url: 'https://mediacdn.umiwi.com/parent.mp3', title: '父录音' }],
               audio: '父转写',
             },
           },
@@ -794,7 +869,7 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
       note_id: noteId,
       title: '历史知识库图片',
       note_type: 'img_text',
-      attachments: [{ type: 'image', url: 'https://cdn.example.com/existing.png', title: 'existing.png' }],
+      attachments: [{ type: 'image', url: 'https://mediacdn.umiwi.com/existing.png', title: 'existing.png' }],
     });
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const requestUrl = String(url);
@@ -812,7 +887,7 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
       if (requestUrl.includes('/resource/note/detail')) {
         return mockFetchResponse({ data: { note } }) as Response;
       }
-      if (requestUrl.startsWith('https://cdn.example.com/')) {
+      if (requestUrl.startsWith('https://mediacdn.umiwi.com/')) {
         return { status: 200, arrayBuffer: async () => new ArrayBuffer(32) } as Response;
       }
       throw new Error(`Unexpected request: ${requestUrl}`);
@@ -837,7 +912,7 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
     expect(result).toEqual(expect.objectContaining({ total: 1, created: 0, skipped: 1, failed: 0 }));
     const requestedUrls = fetchSpy.mock.calls.map(([url]) => String(url));
     expect(requestedUrls.some(url => url.includes('/resource/note/detail'))).toBe(false);
-    expect(requestedUrls.some(url => url.startsWith('https://cdn.example.com/'))).toBe(false);
+    expect(requestedUrls.some(url => url.startsWith('https://mediacdn.umiwi.com/'))).toBe(false);
     expect(app.vault.createFolder).not.toHaveBeenCalled();
     expect(app.vault.createBinary).not.toHaveBeenCalled();
     expect(app.vault.create).not.toHaveBeenCalled();
@@ -850,7 +925,7 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
       noteId: 'created_image_note',
       title: '知识库图片笔记',
       noteType: 'img_text',
-      attachment: { type: 'image', url: 'https://cdn.example.com/knowledge.png', title: 'knowledge.png' },
+      attachment: { type: 'image', url: 'https://mediacdn.umiwi.com/knowledge.png', title: 'knowledge.png' },
       detailExtra: {},
       expectedAssets: ['得到大脑/知识库/我的知识库/asset/知识库图片笔记_image.png'],
       expectedMarkdown: 'asset/知识库图片笔记_image.png',
@@ -859,7 +934,7 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
       noteId: 'created_audio_note',
       title: '知识库音频笔记',
       noteType: 'recorder_audio',
-      attachment: { type: 'audio', url: 'https://cdn.example.com/knowledge.mp3', title: '' },
+      attachment: { type: 'audio', url: 'https://mediacdn.umiwi.com/knowledge.mp3', title: '' },
       detailExtra: { audio: '知识库音频转写' },
       expectedAssets: [
         '得到大脑/知识库/我的知识库/asset/知识库音频笔记_created_audio_note_audio.mp3',
@@ -918,7 +993,7 @@ describe('SyncEngine — subscribed knowledge selected notes', () => {
           },
         }) as Response;
       }
-      if (requestUrl.startsWith('https://cdn.example.com/')) {
+      if (requestUrl.startsWith('https://mediacdn.umiwi.com/')) {
         return {
           status: 200,
           arrayBuffer: async () => new ArrayBuffer(32),
@@ -2074,7 +2149,7 @@ describe('SyncEngine — writeNote', () => {
     // @ts-expect-error private helper is tested directly
     const path = await engine['downloadImageAsset'](
       note,
-      { type: 'image', url: 'https://example.com/image.png', title: '图片' },
+      { type: 'image', url: 'https://mediacdn.umiwi.com/image.png', title: '图片' },
     );
 
     expect(path).toBe('得到大脑/2026/04/纯文本/asset/日期图片_image.png');
@@ -2308,13 +2383,13 @@ describe('SyncEngine — audio note sync', () => {
           data: {
             note: {
               ...audioNote,
-              attachments: [{ type: 'audio', url: 'https://cdn.example.com/test.mp3', title: '', duration: 883920 }],
+              attachments: [{ type: 'audio', url: 'https://mediacdn.umiwi.com/test.mp3', title: '', duration: 883920 }],
               audio: '🟢 说话人1 [00:00:01]\n转写内容',
             },
           },
         }) as Response);
       }
-      if (new URL(urlStr).hostname === 'cdn.example.com') {
+      if (new URL(urlStr).hostname === 'mediacdn.umiwi.com') {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -2348,7 +2423,10 @@ describe('SyncEngine — audio note sync', () => {
       expect(createdFiles.some(f => f.includes('/asset/'))).toBe(true);
       expect(createdFiles).toContain('得到大脑/录音笔记/asset/我的录音笔记_1908723638246504120_audio.mp3');
       expect(createdFiles).toContain('得到大脑/录音笔记/asset/我的录音笔记_1908723638246504120_transcript.md');
-      expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledWith('https://cdn.example.com/test.mp3');
+      expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledWith(
+        'https://mediacdn.umiwi.com/test.mp3',
+        { redirect: 'error' },
+      );
       // 验证 md 文件被创建
       expect(createdFiles.some(f => f.endsWith('.md'))).toBe(true);
       expect(result.items).toEqual([
@@ -2534,9 +2612,59 @@ describe('SyncEngine — audio note sync', () => {
     fetchSpy.mockRestore();
   });
 
+  it('拒绝下载指向 HTTPS 回环地址的音频附件', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const mockApp = makeMockApp();
+    const engine = new SyncEngine(mockApp, makeSettings());
+
+    try {
+      // @ts-expect-error accessing private method for security regression coverage
+      const result = await engine['downloadAudioAsset'](audioNote, {
+        type: 'audio',
+        url: 'https://127.0.0.1/private.mp3',
+        title: '',
+        duration: 1000,
+      });
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('disables redirects when downloading from the trusted attachment CDN', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      status: 200,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    } as Response);
+    const mockApp = makeMockApp();
+    const engine = new SyncEngine(mockApp, makeSettings());
+
+    try {
+      // @ts-expect-error accessing private method for security regression coverage
+      await engine['downloadAudioAsset'](audioNote, {
+        type: 'audio',
+        url: 'https://mediacdn.umiwi.com/voice.mp3',
+        title: '',
+        duration: 1000,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://mediacdn.umiwi.com/voice.mp3',
+        { redirect: 'error' },
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it('音频下载失败日志不泄露附件 URL', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const signedUrl = 'https://cdn.example.com/test.mp3?Expires=1778291785&Signature=secret';
+    const signedUrl = 'https://mediacdn.umiwi.com/test.mp3?Expires=1778291785&Signature=secret';
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,
@@ -2583,13 +2711,13 @@ describe('SyncEngine — audio note sync', () => {
           data: {
             note: {
               ...audioNote,
-              attachments: [{ type: 'audio', url: 'https://cdn.example.com/test.mp3', title: '', duration: 883920 }],
+              attachments: [{ type: 'audio', url: 'https://mediacdn.umiwi.com/test.mp3', title: '', duration: 883920 }],
               audio: { original: '🟢 说话人1 [00:00:01]\n转写内容' },
             },
           },
         }) as Response);
       }
-      if (new URL(urlStr).hostname === 'cdn.example.com') {
+      if (new URL(urlStr).hostname === 'mediacdn.umiwi.com') {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -2934,7 +3062,7 @@ describe('SyncEngine — selective sync cancellation', () => {
         note_type: 'img_text',
         updated_at: '2026-04-28T10:00:00+08:00',
         attachments: [
-          { type: 'image', url: 'https://cdn.example.com/path/photo.jpg', title: 'photo' },
+          { type: 'image', url: 'https://mediacdn.umiwi.com/path/photo.jpg', title: 'photo' },
         ],
       });
       const index = new Map([['image_ready', { path: '得到大脑/图片笔记/test.md' }]]);
@@ -2951,8 +3079,8 @@ describe('SyncEngine — selective sync cancellation', () => {
         title: '测试笔记',
         note_type: 'img_text',
         attachments: [
-          { type: 'image', url: 'https://cdn.example.com/photo-a.jpg', title: 'photo-a' },
-          { type: 'image', url: 'https://cdn.example.com/photo-b.jpg', title: 'photo-b' },
+          { type: 'image', url: 'https://mediacdn.umiwi.com/photo-a.jpg', title: 'photo-a' },
+          { type: 'image', url: 'https://mediacdn.umiwi.com/photo-b.jpg', title: 'photo-b' },
         ],
       });
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({}) as Response);
@@ -2979,8 +3107,8 @@ describe('SyncEngine — selective sync cancellation', () => {
         note_id: 'duplicate_generic_names',
         title: '测试笔记',
         attachments: [
-          { type: 'file', url: 'https://cdn-a.example.com/attachment.pdf', title: 'first' },
-          { type: 'file', url: 'https://cdn-b.example.com/attachment.pdf', title: 'second' },
+          { type: 'file', url: 'https://cdn-a.umiwi.com/attachment.pdf', title: 'first' },
+          { type: 'file', url: 'https://cdn-b.umiwi.com/attachment.pdf', title: 'second' },
         ],
       });
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({}) as Response);
@@ -3007,7 +3135,7 @@ describe('SyncEngine — selective sync cancellation', () => {
         note_id: 'local_fast_path',
         title: '测试笔记',
         attachments: [
-          { type: 'file', url: 'https://cdn.example.com/handout.pdf', title: 'handout' },
+          { type: 'file', url: 'https://mediacdn.umiwi.com/handout.pdf', title: 'handout' },
         ],
       });
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
@@ -3035,7 +3163,7 @@ describe('SyncEngine — selective sync cancellation', () => {
         note_id: 'fragment_generic_name',
         title: '测试笔记',
         attachments: [
-          { type: 'file', url: 'https://cdn.example.com/clip.mp4#t=10', title: 'clip' },
+          { type: 'file', url: 'https://mediacdn.umiwi.com/clip.mp4#t=10', title: 'clip' },
         ],
       });
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({}) as Response);
@@ -3062,7 +3190,7 @@ describe('SyncEngine — selective sync cancellation', () => {
         note_id: 'web_generic_attachment',
         title: '测试笔记',
         attachments: [
-          { type: 'file', url: 'https://cdn.example.com/handout.pdf', title: 'handout' },
+          { type: 'file', url: 'https://mediacdn.umiwi.com/handout.pdf', title: 'handout' },
         ],
       });
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse({}) as Response);
@@ -3094,7 +3222,7 @@ describe('SyncEngine — selective sync cancellation', () => {
           ...note,
           audio: { duration: 10 },
           attachments: [
-            { type: 'audio', url: 'https://cdn.example.com/audio.mp3', title: 'audio' },
+            { type: 'audio', url: 'https://mediacdn.umiwi.com/audio.mp3', title: 'audio' },
           ],
         },
       }) as Response);
@@ -4517,7 +4645,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
         created_at: '2026-04-27T22:26:17+08:00',
         updated_at: '2026-04-28T10:00:00+08:00',
         attachments: [
-          { type: 'audio', url: 'https://cdn.example.com/cross-kb.mp3', title: '', duration: 1000 },
+          { type: 'audio', url: 'https://mediacdn.umiwi.com/cross-kb.mp3', title: '', duration: 1000 },
         ],
         audio: '🟢 说话人1 [00:00:01]\n转写',
       },
@@ -4563,7 +4691,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
                 content: '跨库正文',
                 note_type: 'recorder_audio',
                 attachments: [
-                  { type: 'audio', url: 'https://cdn.example.com/cross-kb.mp3', title: '', duration: 1000 },
+                  { type: 'audio', url: 'https://mediacdn.umiwi.com/cross-kb.mp3', title: '', duration: 1000 },
                 ],
                 audio: '🟢 说话人1 [00:00:01]\n转写',
                 created_at: '2026-04-27T22:26:17+08:00',
@@ -4572,7 +4700,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
             },
           }) as Response;
         }
-        if (new URL(urlStr).hostname === 'cdn.example.com') {
+        if (new URL(urlStr).hostname === 'mediacdn.umiwi.com') {
           return {
             ok: true,
             status: 200,
@@ -4606,7 +4734,7 @@ describe('SyncEngine — 跨库同步 (syncKnowledgeBases)', () => {
       expect(statuses).toEqual(['skipped']);
       // 不应尝试下载音频
       const fetchCalls = vi.mocked(globalThis.fetch).mock.calls.map(call => String(call[0]));
-      expect(fetchCalls.some(url => url === 'https://cdn.example.com/cross-kb.mp3')).toBe(false);
+      expect(fetchCalls.some(url => url === 'https://mediacdn.umiwi.com/cross-kb.mp3')).toBe(false);
     } finally {
       vi.doUnmock('../src/api');
       vi.resetModules();

--- a/tests/workflow-security.spec.ts
+++ b/tests/workflow-security.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+
+const PRIVILEGED_WORKFLOWS = [
+  '.github/workflows/release.yml',
+  '.github/workflows/codex-review.yml',
+];
+
+describe('privileged workflow dependencies', () => {
+  it.each(PRIVILEGED_WORKFLOWS)('%s pins every action to an immutable commit', (path) => {
+    const workflow = readFileSync(path, 'utf8');
+    const actionRefs = [...workflow.matchAll(/^\s*-?\s*uses:\s*([^\s#]+).*$/gm)]
+      .map((match) => match[1]);
+
+    expect(actionRefs.length).toBeGreaterThan(0);
+    for (const ref of actionRefs) {
+      expect(ref).toMatch(/^[^@\s]+@[a-f0-9]{40}$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- prevent remote filename collisions and create races from overwriting unrelated vault notes or Markdown artifacts
- restrict attachment downloads to trusted Umiwi HTTPS hosts and reject redirects
- pin actions in privileged release and Codex review workflows to immutable commit SHAs
- add focused regression coverage for all three findings

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (710 passed, 2 skipped)
- [x] `npm run build`
- [x] `actionlint`
- [x] changed-test ESLint with zero warnings

## Notes

- Remediates Codex Security scan `2d82cafd-fda5-47ae-8f58-4b7f101ca2bc`.
- No version files were changed.
- This PR is intentionally not merged pending required checks and explicit approval.