### PR TITLE
docs: design anonymous sync telemetry dashboard

### DIFF
--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-plugin-client.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-plugin-client.md
@@ -1,0 +1,366 @@
+# Anonymous Telemetry Plugin Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit-consent, privacy-safe telemetry reporting to the Obsidian plugin after the Cloudflare telemetry service has a verified staging endpoint.
+
+**Architecture:** A focused `src/telemetry/` module owns contracts, client-side sanitization, event construction, queueing, and delivery. The existing sync-history boundary remains the single integration point: local history is saved first, then an already-sanitized task summary is queued and sent without affecting synchronization. Consent UI and settings expose exactly what is collected and clear queued reports when disabled.
+
+**Tech Stack:** TypeScript, Obsidian API, Preact, existing Vitest/happy-dom test stack, Obsidian `requestUrl` for desktop/mobile-compatible delivery.
+
+## Global Constraints
+
+- Do not start until the telemetry service plan has produced a verified staging ingestion URL and schema V1 contract.
+- Telemetry is off until explicit consent; refusal or disabling never changes plugin behavior.
+- Never send note content, titles, tags, note IDs, knowledge-base IDs, attachment data, vault/path data, account identifiers, credentials, request/response bodies, device data, locale, time zone, IP, or persistent installation ID.
+- The queue stores only fully sanitized payloads and contains at most 20 events.
+- Delivery times out after three seconds; failures never change sync status or show a sync failure notice.
+- `success = created + updated`; skipped is separate; partial success is derived from a completed task with failed notes.
+- OpenAPI, Web API, remote-to-local, and local-to-remote paths require focused coverage.
+- Use Obsidian `requestUrl`; do not add axios or a browser-only fetch dependency.
+- Do not change sync semantics, note writing behavior, or local sync-history retention.
+- Do not bump `package.json` or `manifest.json` versions.
+- All changes use a `codex/` branch and a PR targeting `main`; merge requires passing checks, real Obsidian UI acceptance, and explicit user approval.
+
+---
+
+### Task 1: Add Telemetry Settings and Safe Normalization
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/main.tsx`
+- Test: `tests/telemetry-settings.spec.ts`
+
+**Interfaces:**
+- Produces: `TelemetryConsent`, `TelemetrySettings`, `PendingTelemetryEvent`, `DEFAULT_TELEMETRY_SETTINGS`, and `normalizeTelemetrySettings(value: unknown): TelemetrySettings`.
+- Consumes: existing `Settings`, `DEFAULT_SETTINGS`, and `loadData()` normalization.
+
+- [ ] **Step 1: Write failing settings tests**
+
+Cover missing legacy data, explicit `granted`/`declined`, invalid consent reverting to `unknown`, removal of malformed queue entries, and truncation to the newest 20 sanitized events.
+
+```ts
+expect(normalizeTelemetrySettings(undefined)).toEqual({
+  consent: 'unknown',
+  pendingEvents: [],
+});
+```
+
+- [ ] **Step 2: Run the settings test and confirm red**
+
+Run: `npx vitest run tests/telemetry-settings.spec.ts`
+
+Expected: FAIL because telemetry settings are undefined.
+
+- [ ] **Step 3: Add settings types and defaults**
+
+```ts
+export type TelemetryConsent = 'unknown' | 'granted' | 'declined';
+
+export interface TelemetrySettings {
+  consent: TelemetryConsent;
+  pendingEvents: PendingTelemetryEvent[];
+}
+```
+
+Add `telemetry: TelemetrySettings` to `Settings` and normalize it independently when plugin data loads. Never infer consent from the presence of old data.
+
+- [ ] **Step 4: Run focused tests and typecheck**
+
+Run: `npx vitest run tests/telemetry-settings.spec.ts && npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types.ts src/main.tsx tests/telemetry-settings.spec.ts
+git commit -m "feat: persist anonymous telemetry consent"
+```
+
+---
+
+### Task 2: Implement Error Classification and Client Sanitization
+
+**Files:**
+- Create: `src/telemetry/types.ts`
+- Create: `src/telemetry/sanitize.ts`
+- Test: `tests/telemetry-sanitize.spec.ts`
+
+**Interfaces:**
+- Produces: `classifySyncError(message: string, context: ErrorContext): TelemetryErrorGroup`, `sanitizeErrorPreview(message: string): string | undefined`, and fixed `TelemetryErrorCode`/`TelemetryErrorStage` unions matching service schema V1.
+- Consumes: only strings already present in `SyncResultItem.error` or task-level `SyncHistoryEntry.error`; never consumes whole note objects.
+
+- [ ] **Step 1: Write failing sanitizer tests**
+
+Use the same privacy corpus as the service: Bearer tokens, cookies, CSRF values, emails, URLs, POSIX/Windows/vault paths, long IDs, long random strings, quoted content, request bodies, and safe timeout/network templates. Add 100 generated secret-like strings.
+
+```ts
+expect(sanitizeErrorPreview('/Users/alice/Vault/Private note.md')).toBeUndefined();
+expect(classifySyncError('Request timed out', { stage: 'fetch_note_detail' }).code)
+  .toBe('NETWORK_TIMEOUT');
+```
+
+- [ ] **Step 2: Run sanitizer tests and confirm red**
+
+Run: `npx vitest run tests/telemetry-sanitize.spec.ts`
+
+Expected: FAIL because the telemetry sanitizer does not exist.
+
+- [ ] **Step 3: Implement allow-listed classification**
+
+Map known API, auth, quota, parser, vault, and attachment failures to fixed codes/templates. Unknown errors receive a sanitized preview only when the final dangerous-pattern detector passes. Never include original input in thrown/logged sanitizer errors.
+
+- [ ] **Step 4: Run focused tests and typecheck**
+
+Run: `npx vitest run tests/telemetry-sanitize.spec.ts && npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/telemetry tests/telemetry-sanitize.spec.ts
+git commit -m "feat: sanitize telemetry errors on device"
+```
+
+---
+
+### Task 3: Build Task-Level Events Without Note Metadata
+
+**Files:**
+- Create: `src/telemetry/event-builder.ts`
+- Test: `tests/telemetry-event-builder.spec.ts`
+
+**Interfaces:**
+- Consumes: `SyncHistoryEntry`, current `AuthMode`, and plugin version string.
+- Produces: `buildTelemetryEvent(entry, authMode, pluginVersion): PendingTelemetryEvent`.
+
+- [ ] **Step 1: Write failing event-builder tests**
+
+Cover successful, partial, failed, cancelled, skipped-only, empty, knowledge-base, automatic, selected, and upload histories. Include an entry containing titles, note IDs, selected IDs, tags, paths, and raw errors, then recursively assert none occur in serialized output.
+
+```ts
+expect(event.counts.success).toBe(entry.result.created + entry.result.updated);
+expect(JSON.stringify(event)).not.toContain('private-note-id');
+```
+
+- [ ] **Step 2: Run builder tests and confirm red**
+
+Run: `npx vitest run tests/telemetry-event-builder.spec.ts`
+
+Expected: FAIL because the builder is missing.
+
+- [ ] **Step 3: Implement explicit field projection**
+
+Construct a new object field-by-field. Never spread `SyncHistoryEntry`, `SyncResult`, `scope`, or `items`. Group sanitized failures by `code + stage + preview`, cap groups at ten, and sum their counts. Use `crypto.randomUUID()` for `event_id`.
+
+- [ ] **Step 4: Run builder and sanitizer tests**
+
+Run: `npx vitest run tests/telemetry-event-builder.spec.ts tests/telemetry-sanitize.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/telemetry/event-builder.ts tests/telemetry-event-builder.spec.ts
+git commit -m "feat: build privacy-safe sync summaries"
+```
+
+---
+
+### Task 4: Implement the Bounded Queue and Non-Blocking Delivery
+
+**Files:**
+- Create: `src/telemetry/client.ts`
+- Create: `src/telemetry/manager.ts`
+- Test: `tests/telemetry-client.spec.ts`
+- Test: `tests/telemetry-manager.spec.ts`
+
+**Interfaces:**
+- Consumes: service staging URL from the service plan, `TelemetrySettings`, `PendingTelemetryEvent`, Obsidian `requestUrl`, and a `saveSettings(): Promise<void>` callback.
+- Produces: `sendTelemetryEvent(event, timeoutMs): Promise<'accepted' | 'discard' | 'retry'>` and `TelemetryManager.capture(entry, authMode): Promise<void>`, `flush(): Promise<void>`, `disable(): Promise<void>`.
+
+- [ ] **Step 1: Write failing HTTP classification tests**
+
+Test `202 => accepted`, `400/413/415 => discard`, `429/500/503/network/timeout => retry`, a three-second abort, JSON content type, and no credentials or referrer headers.
+
+- [ ] **Step 2: Write failing queue tests**
+
+Test consent gating, local persistence before sending, FIFO retry, stable event IDs, removal after acceptance/discard, retention after retry, maximum 20 entries, concurrent flush coalescing, and immediate queue clearing on disable.
+
+- [ ] **Step 3: Run client/manager tests and confirm red**
+
+Run: `npx vitest run tests/telemetry-client.spec.ts tests/telemetry-manager.spec.ts`
+
+Expected: FAIL because client and manager are missing.
+
+- [ ] **Step 4: Implement delivery with Obsidian `requestUrl`**
+
+Use `Promise.race` around Obsidian `requestUrl` with a three-second timer, because `requestUrl` has no abort signal. Attach a rejection handler to the late request promise so it cannot become an unhandled rejection. A timeout returns `retry`; if the late request reached the server, the stable event ID makes the next attempt harmless. Serialize only `PendingTelemetryEvent.payload`, return a classification instead of throwing to sync callers, and never call Obsidian Notice APIs.
+
+- [ ] **Step 5: Implement bounded queue persistence**
+
+Persist the sanitized event before the first network attempt. Keep one in-flight `flushPromise` to avoid concurrent sends. On `disable()`, set consent to `declined`, clear the queue, and save once.
+
+- [ ] **Step 6: Run focused tests and typecheck**
+
+Run: `npx vitest run tests/telemetry-client.spec.ts tests/telemetry-manager.spec.ts && npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/telemetry tests/telemetry-client.spec.ts tests/telemetry-manager.spec.ts
+git commit -m "feat: queue anonymous telemetry safely"
+```
+
+---
+
+### Task 5: Add Explicit Consent and Settings Controls
+
+**Files:**
+- Create: `src/ui/telemetry-consent-modal.tsx`
+- Modify: `src/settings/index.tsx`
+- Modify: `src/main.tsx`
+- Modify: `src/i18n.ts`
+- Modify: `styles.css`
+- Test: `tests/telemetry-consent.spec.tsx`
+- Test: `tests/settings.spec.tsx`
+
+**Interfaces:**
+- Consumes: `TelemetrySettings` and `TelemetryManager.disable()` from prior tasks.
+- Produces: first-run `openTelemetryConsentModal()` and a settings toggle/summary.
+
+- [ ] **Step 1: Write failing consent UI tests**
+
+Test that `unknown` opens once after layout readiness, granted/declined do not reopen, `Enable anonymous statistics` stores `granted`, `Not now` stores `declined`, closing without a choice stores no consent, and no telemetry request occurs during the modal interaction.
+
+- [ ] **Step 2: Write failing settings tests**
+
+Test the exact disclosure, enable/disable behavior, privacy-documentation link, and queue clearing on disable.
+
+- [ ] **Step 3: Run UI tests and confirm red**
+
+Run: `npx vitest run tests/telemetry-consent.spec.tsx tests/settings.spec.tsx`
+
+Expected: FAIL because consent controls are missing.
+
+- [ ] **Step 4: Implement exact disclosure copy in Chinese and English**
+
+State collected counts/version/modes/sanitized errors/coarse service-side geography and the full prohibited-data list. Include explicit buttons for enable and not now. Do not use a pre-checked toggle or implied consent.
+
+- [ ] **Step 5: Connect first-run lifecycle and settings control**
+
+Open only after `app.workspace.onLayoutReady`. Disabling invokes `TelemetryManager.disable()` and updates mounted settings state immediately.
+
+- [ ] **Step 6: Run UI tests, typecheck, and lint**
+
+Run: `npx vitest run tests/telemetry-consent.spec.tsx tests/settings.spec.tsx && npm run typecheck && npm run lint`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/telemetry-consent-modal.tsx src/settings/index.tsx src/main.tsx src/i18n.ts styles.css tests
+git commit -m "feat: request anonymous telemetry consent"
+```
+
+---
+
+### Task 6: Integrate Telemetry at the Saved Sync-History Boundary
+
+**Files:**
+- Modify: `src/main.tsx`
+- Test: `tests/telemetry-integration.spec.ts`
+- Modify: `tests/sync.spec.ts`
+
+**Interfaces:**
+- Consumes: `TelemetryManager.capture()` and every existing call to `recordSyncHistory`.
+- Produces: one event per completed manual, automatic, selected, knowledge-base, upload, failed, or cancelled task after local history persistence.
+
+- [ ] **Step 1: Write failing integration tests**
+
+Assert local `saveData` completes before capture, every mode maps correctly, partial status is derived when `result.failed > 0`, upload uses `local_to_remote`, failures retain only sanitized classification, disabled consent causes no request, and telemetry exceptions do not alter notices or sync state.
+
+- [ ] **Step 2: Run integration tests and confirm red**
+
+Run: `npx vitest run tests/telemetry-integration.spec.ts tests/sync.spec.ts`
+
+Expected: FAIL because history is not connected to telemetry.
+
+- [ ] **Step 3: Return the saved entry from `recordSyncHistory`**
+
+Change the method to `Promise<SyncHistoryEntry>`, keep `await this.saveSettings()` before returning, and do not change history contents or retention.
+
+- [ ] **Step 4: Capture after persistence on every task path**
+
+Pass only the returned entry, active auth mode, and manifest version to the manager. Start queue flush after plugin load only when consent is `granted`. All capture calls must be awaited inside a telemetry-owned safe boundary or explicitly `void`ed when lifecycle must remain non-blocking.
+
+- [ ] **Step 5: Run integration and existing sync tests**
+
+Run: `npx vitest run tests/telemetry-integration.spec.ts tests/sync.spec.ts`
+
+Expected: PASS with unchanged existing sync assertions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.tsx tests/telemetry-integration.spec.ts tests/sync.spec.ts
+git commit -m "feat: report completed sync health anonymously"
+```
+
+---
+
+### Task 7: Publish Privacy Documentation and Verify the Complete Plugin
+
+**Files:**
+- Create: `docs/anonymous-telemetry.md`
+- Create: `docs/anonymous-telemetry_zh.md`
+- Modify: `README.md`
+- Test: `tests/telemetry-privacy.spec.ts`
+
+**Interfaces:**
+- Consumes: the implemented payload contract and service retention policy.
+- Produces: user-facing disclosure and full implementation evidence.
+
+- [ ] **Step 1: Write a payload privacy regression test**
+
+Build events from adversarial sync histories containing every prohibited field and recursively scan serialized payload/queue data. Fail on known secrets, IDs, titles, tags, paths, URLs, account fields, or keys outside schema V1.
+
+- [ ] **Step 2: Write separate English and Chinese privacy documents**
+
+Document opt-in behavior, exact fields, prohibited fields, coarse geographic aggregation, 30-day detail retention, long-lived aggregates, disabling/queue deletion, and maintainer contact. Keep English and Chinese in separate files.
+
+- [ ] **Step 3: Run the full repository gate**
+
+Run:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm run build
+npx eslint tests --max-warnings=0
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 4: Deploy to the enabled local Obsidian vault**
+
+Use the `obsidian-plugin-deploy` skill to resolve the enabled vault plugin directory by manifest ID, deploy `main.js`, `manifest.json`, and `styles.css`, and verify hashes. Do not treat matching hashes as UI acceptance.
+
+- [ ] **Step 5: Obtain real Obsidian acceptance**
+
+Ask the user to reload Obsidian and verify: first-run disclosure, enable/not-now behavior, settings toggle, queue clearing, successful sync, partial failure display, and no visible sync regression. Do not merge before confirmation.
+
+- [ ] **Step 6: Push the feature branch and open a PR**
+
+Use a new `codex/anonymous-telemetry-client` branch based on current `main`. Include the service endpoint/schema, privacy evidence, test results, and UI acceptance status in the PR. Do not include credentials or raw payloads containing user data.
+
+- [ ] **Step 7: Wait for required checks and explicit merge approval**
+
+Resolve review comments with focused tests. Merge only after all required checks pass and the user explicitly approves the merge.

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -54,7 +54,7 @@ Create the directory with `mkdir`, initialize Git with default branch `main`, an
     "@testing-library/preact": "3.2.4",
     "eslint": "10.8.1",
     "happy-dom": "20.11.2",
-    "typescript": "7.0.2",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.66.0",
     "vite": "8.2.1",
     "vitest": "4.1.10",

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -92,6 +92,32 @@ export type TelemetryMode = 'time' | 'selected' | 'knowledge_base' | 'auto' | 'l
 export type TelemetryAuthMode = 'openapi' | 'web';
 export type TelemetryRunStatus = 'success' | 'partial' | 'failed' | 'cancelled';
 
+export interface TelemetryErrorGroup {
+  code: TelemetryErrorCode;
+  stage: TelemetryErrorStage;
+  count: number;
+  message_preview?: string;
+}
+
+export interface TelemetryEventV1 {
+  schema_version: 1;
+  event_id: string;
+  plugin_version: PublishedPluginVersion;
+  direction: TelemetryDirection;
+  mode: TelemetryMode;
+  auth_mode: TelemetryAuthMode;
+  run_status: TelemetryRunStatus;
+  counts: {
+    success: number;
+    created: number;
+    updated: number;
+    skipped: number;
+    failed: number;
+  };
+  duration_bucket: TelemetryDurationBucket;
+  errors: TelemetryErrorGroup[];
+}
+
 export function parseTelemetryEvent(input: unknown): TelemetryEventV1 {
   const event = telemetryEventSchema.parse(input);
   if (event.counts.success !== event.counts.created + event.counts.updated) {
@@ -107,6 +133,8 @@ Use `.strict()` at every object level. Define these fixed schema V1 allow-lists 
 - Stages: `list_notes`, `fetch_note_detail`, `fetch_relationships`, `download_attachment`, `parse_note`, `read_vault`, `write_vault`, `create_remote_note`, `task_setup`, `unknown`.
 - Duration buckets: `under_1s`, `1s_3s`, `3s_10s`, `10s_30s`, `30s_2m`, `2m_10m`, `over_10m`.
 - Published plugin versions initially accepted: `1.4.4`. Update this allow-list as part of the release process before a telemetry-enabled plugin version is published; do not accept arbitrary semantic versions.
+
+Every listed event field is required, including `errors` (use an empty array when there are none). `message_preview` is the only optional field and must be omitted, not set to `null`, when no safe preview exists. `event_id` must be a UUID. Every note counter is an integer from 0 through 100,000. Each error-group `count` is an integer from 1 through 100,000; `errors` contains at most ten groups; `message_preview`, when present, contains 1 through 200 characters. In addition to `success = created + updated`, enforce `run_status = success` only when `counts.failed = 0`, and `run_status = partial` only when `counts.failed > 0`. A `failed` task is a task-level termination and may have zero note failures; a `cancelled` task has no extra count relationship. Do not infer or add any other fields or cross-field rules in schema V1.
 
 - [ ] **Step 5: Run contract tests and typecheck**
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -1,0 +1,437 @@
+# Anonymous Telemetry Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and deploy a free, private Cloudflare telemetry service that accepts privacy-safe sync summaries, aggregates daily health and coarse-region metrics, and exposes a maintainer-only dashboard.
+
+**Architecture:** Create a separate private repository at `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry`. A public Worker accepts events and runs reconciliation/retention against D1; a Pages application serves the private Preact dashboard and D1-backed read APIs behind Cloudflare Access. The Worker and Pages Functions share only a small contracts package and use generated binding types.
+
+**Tech Stack:** TypeScript, Cloudflare Workers, Pages Functions, D1, Wrangler 4.x, Preact, Vite, Zod, Vitest, `@cloudflare/vitest-pool-workers`.
+
+## Global Constraints
+
+- Use Cloudflare Free-plan resources only.
+- Use `wrangler.jsonc` with `compatibility_date: "2026-08-10"`, `nodejs_compat`, generated binding types, and structured observability.
+- Use a new private GitHub repository named `dedao-brain-sync-telemetry`; never add service code to the Obsidian plugin bundle.
+- The ingestion endpoint is public; dashboard pages and read APIs are private through Cloudflare Access.
+- Never store or log request bodies, IP addresses, note data, vault data, account identifiers, credentials, precise location, or persistent installation identifiers.
+- Raw task/error rows live for 30 days; aggregate rows live long term.
+- Geographic metrics describe sync activity, not users; China is grouped by province and other activity by country.
+- All D1 access uses prepared statements through bindings, not Cloudflare REST calls from runtime code.
+- Every Promise is awaited, returned, or passed to `ctx.waitUntil()`; no mutable request state at module scope.
+- No production deploy, D1 creation, Access policy, or GitHub repository creation occurs until the user approves the execution plan.
+
+---
+
+### Task 1: Scaffold the Independent Service and Shared Contract
+
+**Files:**
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/package.json`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/tsconfig.base.json`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/eslint.config.mjs`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/.gitignore`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/package.json`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/tsconfig.json`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/vitest.config.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/packages/contracts/package.json`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/packages/contracts/src/index.ts`
+- Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/packages/contracts/src/index.test.ts`
+
+**Interfaces:**
+- Produces: `TelemetryEventV1`, `TelemetryErrorGroup`, `telemetryEventSchema`, enum constants, and `parseTelemetryEvent(input: unknown): TelemetryEventV1`.
+- Consumes: No prior implementation task.
+
+- [ ] **Step 1: Create the private repository locally and initialize the workspace**
+
+Create the directory with `mkdir`, initialize Git with default branch `main`, and add npm workspaces for `packages/*` and `apps/*`. Define root scripts `test`, `typecheck`, `lint`, and `build`. Pin and lock these versions resolved on 2026-08-10:
+
+```json
+{
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "0.20.3",
+    "@cloudflare/workers-types": "5.20260810.1",
+    "@preact/preset-vite": "2.10.6",
+    "@testing-library/preact": "3.2.4",
+    "eslint": "10.8.1",
+    "happy-dom": "20.11.2",
+    "typescript": "7.0.2",
+    "typescript-eslint": "8.66.0",
+    "vite": "8.2.1",
+    "vitest": "4.1.10",
+    "wrangler": "4.120.0"
+  },
+  "dependencies": {
+    "preact": "10.29.8",
+    "zod": "4.4.3"
+  }
+}
+```
+
+- [ ] **Step 2: Write failing contract tests**
+
+Cover one valid event and rejection of an inconsistent success count, an unknown enum, more than ten error groups, a message over 200 characters, a counter above 100,000, and an unrecognized field.
+
+```ts
+expect(() => parseTelemetryEvent({
+  ...validEvent,
+  counts: { ...validEvent.counts, success: 99 },
+})).toThrow();
+```
+
+- [ ] **Step 3: Run the contract test and confirm red**
+
+Run: `npm test -- packages/contracts/src/index.test.ts`
+
+Expected: FAIL because `parseTelemetryEvent` is not defined.
+
+- [ ] **Step 4: Implement the strict V1 contract**
+
+```ts
+export type TelemetryDirection = 'remote_to_local' | 'local_to_remote';
+export type TelemetryMode = 'time' | 'selected' | 'knowledge_base' | 'auto' | 'local_upload';
+export type TelemetryAuthMode = 'openapi' | 'web';
+export type TelemetryRunStatus = 'success' | 'partial' | 'failed' | 'cancelled';
+
+export function parseTelemetryEvent(input: unknown): TelemetryEventV1 {
+  const event = telemetryEventSchema.parse(input);
+  if (event.counts.success !== event.counts.created + event.counts.updated) {
+    throw new Error('INCONSISTENT_COUNTS');
+  }
+  return event;
+}
+```
+
+Use `.strict()` at every object level. Define fixed allow-lists for error codes, stages, duration buckets, and published plugin versions.
+
+- [ ] **Step 5: Run contract tests and typecheck**
+
+Run: `npm test -- packages/contracts/src/index.test.ts && npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .
+git commit -m "chore: scaffold telemetry service contracts"
+```
+
+---
+
+### Task 2: Implement Double Sanitization and Safe Logging
+
+**Files:**
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/sanitize.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/logging.ts`
+- Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/sanitize.test.ts`
+
+**Interfaces:**
+- Consumes: `TelemetryEventV1` from `@telemetry/contracts`.
+- Produces: `sanitizeEvent(event: TelemetryEventV1): SanitizedTelemetryEvent`, `sanitizeMessage(value: string): string | null`, and `logOperationalEvent(entry: OperationalLog): void`.
+
+- [ ] **Step 1: Write failing table-driven sanitizer tests**
+
+Test Bearer tokens, cookies, email addresses, query strings, HTTP URLs, POSIX paths, Windows paths, 16+ digit identifiers, 20+ character random strings, quoted note-like content, and a fully safe timeout template. Add a generated-property loop that creates 100 secret-like strings and asserts none survive.
+
+```ts
+expect(sanitizeMessage('Authorization: Bearer abcdefghijklmnopqrstuvwxyz')).toBeNull();
+expect(sanitizeMessage('Request timed out after 3000ms')).toBe('Request timed out after <duration>');
+```
+
+- [ ] **Step 2: Run sanitizer tests and confirm red**
+
+Run: `npm test -- apps/ingest/src/sanitize.test.ts`
+
+Expected: FAIL because the sanitizer does not exist.
+
+- [ ] **Step 3: Implement allow-list-first sanitization**
+
+Known error codes return fixed templates. Unknown previews pass through ordered replacement rules, a final dangerous-pattern detector, and a 200-character cap. Return `null` when safety cannot be proven. Never throw an error that embeds the source string.
+
+- [ ] **Step 4: Implement metadata-only structured logging**
+
+```ts
+type OperationalLog = {
+  requestId: string;
+  route: string;
+  status: number;
+  durationMs: number;
+  outcome: 'accepted' | 'duplicate' | 'rejected' | 'failed';
+};
+```
+
+The logger accepts no request, payload, headers, IP, exception message, or stack.
+
+- [ ] **Step 5: Run sanitizer tests and typecheck**
+
+Run: `npm test -- apps/ingest/src/sanitize.test.ts && npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/ingest packages/contracts
+git commit -m "feat: sanitize telemetry at the service boundary"
+```
+
+---
+
+### Task 3: Create the D1 Schema and Idempotent Repository
+
+**Files:**
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/migrations/0001_initial.sql`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/repository.ts`
+- Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/repository.test.ts`
+
+**Interfaces:**
+- Consumes: `SanitizedTelemetryEvent` from Task 2 and generated `Env.DB: D1Database`.
+- Produces: `storeEvent(db, event, receivedAt, reportingDate, region): Promise<'inserted' | 'duplicate'>` and `deleteExpiredDetails(db, cutoffIso, limit): Promise<number>`.
+
+- [ ] **Step 1: Write the migration with five tables**
+
+Create `event_records`, `event_errors`, `daily_stats`, `daily_errors`, and `daily_regions`. Do not add region or installation columns to the first two tables. Add indexes for reporting date, received time, plugin version, error code/stage, and aggregate keys. Add `is_flagged` and `flag_reason` columns to aggregate tables so anomalous traffic can be excluded from trusted totals without creating another detail table.
+
+- [ ] **Step 2: Write failing repository tests**
+
+Test that a first event inserts task/error rows and one region aggregate, a retry returns `duplicate` without changing counts, a failed statement rolls back the batch, and expired deletion removes detail without touching aggregate tables.
+
+- [ ] **Step 3: Run repository tests and confirm red**
+
+Run: `npm test -- apps/ingest/src/repository.test.ts`
+
+Expected: FAIL because the migration/repository is missing.
+
+- [ ] **Step 4: Implement prepared and transactional D1 writes**
+
+Use `INSERT ... ON CONFLICT DO NOTHING RETURNING event_id` for the idempotency gate. For a newly inserted ID, use `env.DB.batch([...])` with bound prepared statements for error detail and `daily_regions` upserts. Never interpolate client values into SQL.
+
+- [ ] **Step 5: Run migration locally and rerun tests**
+
+Run: `npx wrangler d1 migrations apply telemetry-local --local --config apps/ingest/wrangler.jsonc`
+
+Run: `npm test -- apps/ingest/src/repository.test.ts`
+
+Expected: migration and tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/ingest/migrations apps/ingest/src/repository.ts apps/ingest/src/repository.test.ts
+git commit -m "feat: persist idempotent telemetry events"
+```
+
+---
+
+### Task 4: Build the Public Ingestion Worker and Cron Maintenance
+
+**Files:**
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/wrangler.jsonc`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/index.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/geo.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/maintenance.ts`
+- Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/index.test.ts`
+- Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/maintenance.test.ts`
+
+**Interfaces:**
+- Consumes: contracts, sanitizer, and repository from Tasks 1-3.
+- Produces: Worker `fetch(request, env, ctx)` for `POST /v1/events` and `GET /v1/health`, plus `scheduled(controller, env, ctx)`.
+
+- [ ] **Step 1: Write failing request tests**
+
+Cover valid `202`, duplicate `202`, invalid JSON `400`, unsupported schema `400`, body over 8 KiB `413`, wrong method `405`, wrong content type `415`, repository failure `503`, and health `200`. Assert response bodies never echo input.
+
+- [ ] **Step 2: Write failing geographic tests**
+
+```ts
+expect(resolveAggregateRegion({ country: 'CN', regionCode: 'GD' })).toBe('CN-GD');
+expect(resolveAggregateRegion({ country: 'US', regionCode: 'CA' })).toBe('US');
+expect(resolveAggregateRegion({ country: 'XX' })).toBe('UNKNOWN');
+```
+
+- [ ] **Step 3: Write failing maintenance tests**
+
+Test Beijing date calculation across UTC midnight, previous-day reconciliation into `daily_stats` and `daily_errors`, bounded 500-row cleanup, retry idempotency, preservation of detail when reconciliation fails, and deterministic flags for a daily total above both 100 events and five times the prior seven-day average.
+
+- [ ] **Step 4: Run Worker tests and confirm red**
+
+Run: `npm test -- apps/ingest/src/index.test.ts apps/ingest/src/maintenance.test.ts`
+
+Expected: FAIL because handlers are missing.
+
+- [ ] **Step 5: Implement fetch and scheduled handlers**
+
+Use `crypto.randomUUID()` for request IDs. Read at most 8 KiB before JSON parsing. Access coarse location from `request.cf`, pass only the aggregate code into the repository, and never put it in operational logs. Schedule daily reconciliation at `20 16 * * *` UTC, which is 00:20 Asia/Shanghai. Reconciliation upserts `daily_stats` and `daily_errors`, then flags a dimension only when its total is above both 100 and five times its prior seven-day average; dashboard trusted totals exclude flagged rows and show them in a separate anomaly indicator.
+
+- [ ] **Step 6: Configure Worker best practices**
+
+Set `compatibility_date`, `nodejs_compat`, D1 binding, Cron Trigger, and:
+
+```jsonc
+"observability": {
+  "enabled": true,
+  "head_sampling_rate": 1
+}
+```
+
+Generate types with `npx wrangler types --config apps/ingest/wrangler.jsonc` and commit the generated declarations. Configure edge rate limiting for `/v1/events` during deployment; do not implement an application IP table.
+
+- [ ] **Step 7: Run Worker tests, typecheck, lint, and dry run**
+
+Run: `npm test -- apps/ingest && npm run typecheck && npm run lint && npx wrangler deploy --dry-run --config apps/ingest/wrangler.jsonc`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/ingest
+git commit -m "feat: accept and maintain anonymous telemetry"
+```
+
+---
+
+### Task 5: Build Private Dashboard Read APIs
+
+**Files:**
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/wrangler.jsonc`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/dashboard.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/errors.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/regions.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/_shared/query.ts`
+- Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/api.test.ts`
+
+**Interfaces:**
+- Consumes: D1 aggregate tables from Task 3.
+- Produces: `GET /api/dashboard`, `GET /api/errors`, and `GET /api/regions` JSON responses.
+
+- [ ] **Step 1: Write failing API tests**
+
+Test default 7-day range, 30-day range, ISO date validation, plugin/auth/direction/mode filters, no-data responses, and database failure. Assert region responses group total event counts below five into `OTHER`.
+
+- [ ] **Step 2: Run API tests and confirm red**
+
+Run: `npm test -- apps/dashboard/functions/api/api.test.ts`
+
+Expected: FAIL because functions are missing.
+
+- [ ] **Step 3: Implement prepared aggregate queries**
+
+Build filter clauses only from fixed server-owned fragments; bind all values. Return `503` with `{ "error": "DASHBOARD_UNAVAILABLE" }` on storage failure, never a zeroed dataset.
+
+- [ ] **Step 4: Configure Pages D1 bindings and generated types**
+
+Define matching preview and production D1 bindings in `wrangler.jsonc`, run `npx wrangler types --config apps/dashboard/wrangler.jsonc`, and keep local D1 isolated by default.
+
+- [ ] **Step 5: Run API tests and typecheck**
+
+Run: `npm test -- apps/dashboard/functions/api/api.test.ts && npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/dashboard/functions apps/dashboard/wrangler.jsonc
+git commit -m "feat: expose private telemetry aggregates"
+```
+
+---
+
+### Task 6: Build the Maintainer Dashboard
+
+**Files:**
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/package.json`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/tsconfig.json`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/vitest.config.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/vite.config.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/main.tsx`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/api.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/pages/dashboard.tsx`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/pages/errors.tsx`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/pages/regions.tsx`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/styles.css`
+- Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/dashboard.test.tsx`
+
+**Interfaces:**
+- Consumes: the three read APIs from Task 5.
+- Produces: private `/dashboard`, `/errors`, and `/regions` views.
+
+- [ ] **Step 1: Write failing dashboard tests**
+
+Test metric cards, 7/30-day filter changes, successful/failed/skipped trend labels, task-health states, unavailable-panel behavior, error/version details, and the exact label `Synchronization activity, not unique users` on regions.
+
+- [ ] **Step 2: Run UI tests and confirm red**
+
+Run: `npm test -- apps/dashboard/src/dashboard.test.tsx`
+
+Expected: FAIL because views do not exist.
+
+- [ ] **Step 3: Implement the smallest dashboard UI**
+
+Use Preact and accessible HTML/SVG. Do not add a map, realtime transport, public page, member management, or alerting. Preserve the last successful panel data when a refresh fails and show an unavailable state rather than zeros.
+
+- [ ] **Step 4: Run UI tests and production build**
+
+Run: `npm test -- apps/dashboard/src/dashboard.test.tsx && npm run build --workspace apps/dashboard`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/dashboard
+git commit -m "feat: add private telemetry dashboard"
+```
+
+---
+
+### Task 7: Deploy Staging, Protect Access, and Verify End to End
+
+**Files:**
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/README.md`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/docs/privacy-and-operations.md`
+- Modify: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/wrangler.jsonc`
+- Modify: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/wrangler.jsonc`
+
+**Interfaces:**
+- Consumes: all prior service tasks and the authenticated Cloudflare account.
+- Produces: a staging ingestion URL, private dashboard URL, D1 database ID, and verified production-ready configuration for the plugin-client plan.
+
+- [ ] **Step 1: Run the complete local gate**
+
+Run: `npm ci && npm test && npm run typecheck && npm run lint && npm run build && npx wrangler deploy --dry-run --config apps/ingest/wrangler.jsonc`
+
+Expected: all commands PASS.
+
+- [ ] **Step 2: Create the private GitHub repository and push a feature branch**
+
+Create `AndyZhengyan/dedao-brain-sync-telemetry` as private, push `codex/initial-telemetry-service`, and open a PR against `main`. Do not push directly to `main`.
+
+- [ ] **Step 3: Create one D1 database in `apac` and apply migrations**
+
+Use the Cloudflare binding MCP or Wrangler after resolving the exact database name `dedao-brain-sync-telemetry`. Record only the non-secret database ID in both Wrangler configs. Apply migrations remotely and verify all five tables.
+
+- [ ] **Step 4: Deploy staging Worker and Pages projects**
+
+Deploy the ingest Worker first, then the dashboard. Configure an edge rate-limiting rule for `POST /v1/events`. Do not deploy a production plugin endpoint yet.
+
+- [ ] **Step 5: Configure Cloudflare Access**
+
+Protect the production `*.pages.dev` dashboard and its `/api/*` functions with an allow policy for the maintainer email. Verify an unauthenticated browser receives Access authentication and the maintainer can log in.
+
+- [ ] **Step 6: Run privacy and idempotency probes**
+
+Send a safe synthetic event twice and verify counts change once. Send token/path/ID test payloads and verify unsafe previews are empty. Query D1 to confirm no region exists in detail tables and no request body/IP appears in structured Worker logs.
+
+- [ ] **Step 7: Verify retention and scheduled handler in staging**
+
+Insert dated synthetic rows, invoke the scheduled handler in test mode, and confirm only summarized detail older than 30 days is removed.
+
+- [ ] **Step 8: Document endpoints and hand off to the plugin plan**
+
+Record the staging ingestion origin, schema version, published-version allow-list process, rollback command, and dashboard URL. Never record OAuth tokens or account secrets.
+
+- [ ] **Step 9: Request review and merge approval**
+
+Share the service PR and staging dashboard. Merge only after checks pass and the user explicitly approves.

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -300,6 +300,8 @@ git commit -m "feat: persist idempotent telemetry events"
 
 **Files:**
 - Modify: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/wrangler.jsonc`
+- Modify: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/index.ts`
+- Modify: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/index.test.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/index.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/geo.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/maintenance.ts`
@@ -541,7 +543,7 @@ Use the Cloudflare binding MCP or Wrangler after resolving the exact database na
 
 - [ ] **Step 4: Deploy staging Worker and Pages projects**
 
-Deploy the ingest Worker first, then the dashboard. Configure an edge rate-limiting rule for `POST /v1/events`. Do not deploy a production plugin endpoint yet.
+Deploy the ingest Worker first, then the dashboard. This account has no Cloudflare Zone, so a zone WAF rate-limiting rule cannot apply to `workers.dev`. Replace that unavailable control with the official Worker Rate Limiting binding: configure `INGEST_RATE_LIMITER` with `namespace_id: "20260818"`, `limit: 500`, and `period: 60`; call it only for `POST /v1/events` with the fixed key `v1-events`; on exhaustion return `429 { "error": "RATE_LIMITED" }` without reading the body or using an IP, location, or persistent identifier as a key. Add a focused regression test for this path and regenerate Worker binding types. This counter is per Cloudflare location, so it is an abuse brake rather than an authenticity guarantee. Do not deploy a production plugin endpoint yet.
 
 - [ ] **Step 5: Configure Cloudflare Access**
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -455,6 +455,7 @@ git commit -m "feat: expose private telemetry aggregates"
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/tsconfig.json`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/vitest.config.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/vite.config.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/index.html`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/main.tsx`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/api.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/src/pages/dashboard.tsx`
@@ -467,9 +468,25 @@ git commit -m "feat: expose private telemetry aggregates"
 - Consumes: the three read APIs from Task 5.
 - Produces: private `/dashboard`, `/errors`, and `/regions` views.
 
+Use no router or chart dependency. `main.tsx` selects the view from `window.location.pathname`, treats `/` as `/dashboard`, and renders a shared header with ordinary links to all three paths. Unknown paths render a small not-found view. Keep API response types and a replaceable `TelemetryDashboardApi` interface in `api.ts`; its production implementation calls the same-origin endpoints with `range=7|30` and any supported allow-listed filters, requires `response.ok`, and throws a generic `DashboardApiError` without embedding response bodies.
+
+Each page accepts an optional injected API for tests and owns its loading state. On initial failure, render a panel with `role="alert"` and `Data temporarily unavailable`; never render invented zero metrics. After any successful load, keep that last successful data visible when a range/filter refresh fails and show the same unavailable alert alongside stale data. Ignore stale out-of-order responses using a request generation counter or equivalent; do not use mutable state outside components.
+
+The shared header displays `Telemetry health` and navigation labels `Overview`, `Errors`, and `Regions`. Every page has `7 days` and `30 days` buttons using `aria-pressed`; changing range refetches only that page. The Overview additionally exposes `All` plus fixed V1 select options for plugin version (`1.4.4`), direction, mode, and authentication mode. Errors exposes only plugin version and authentication mode. Regions exposes no dimension selector, matching the API privacy boundary.
+
+Render these minimum views:
+
+- Overview: cards for `Successful notes`, `Failed notes`, `Skipped notes`, `Total tasks`, and `Task success rate`; an accessible SVG labelled `Successful, failed, and skipped note trend`; a visible legend for those three series; task-health counts for success/partial/failed/cancelled; and an anomaly notice when `flagged_rows > 0`.
+- Errors: an accessible table with code, stage, occurrences, affected tasks, first/last date, safe preview, plugin-version distribution, and authentication distribution; plus an accessible per-row seven-day trend SVG or text equivalent. Show anomaly counts without exposing flagged dimensions.
+- Regions: the exact heading/label `Synchronization activity, not unique users`, an accessible table for region code, tasks, successful notes, and failed notes, and an anomaly notice. Do not add a map.
+
+Use semantic HTML, visible focus states, sufficient color contrast, and SVG `aria-label`/titles. The production build must contain no external runtime CDN assets and no analytics.
+
 - [ ] **Step 1: Write failing dashboard tests**
 
 Test metric cards, 7/30-day filter changes, successful/failed/skipped trend labels, task-health states, unavailable-panel behavior, error/version details, and the exact label `Synchronization activity, not unique users` on regions.
+
+Also test initial failure without fabricated zero cards, stale-data preservation after a failed refresh, out-of-order response protection, route selection, endpoint-specific filter controls, error table/auth details, anomaly notices, and accessible chart/table names.
 
 - [ ] **Step 2: Run UI tests and confirm red**
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -535,7 +535,7 @@ Expected: all commands PASS.
 
 - [ ] **Step 2: Create the private GitHub repository and push a feature branch**
 
-Create `AndyZhengyan/dedao-brain-sync-telemetry` as private, push `codex/initial-telemetry-service`, and open a PR against `main`. Do not push directly to `main`.
+Create `AndyZhengyan/dedao-brain-sync-telemetry` as private with GitHub's initial README so remote `main` exists without a direct local push. Add the remote, fetch it, merge `origin/main` into `codex/initial-telemetry-service` with `--allow-unrelated-histories`, resolve only the bootstrap README if necessary, then push that feature branch and open a PR against `main`. Do not force-push or push directly to `main`.
 
 - [ ] **Step 3: Create one D1 database in `apac` and apply migrations**
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -162,6 +162,22 @@ git commit -m "chore: scaffold telemetry service contracts"
 - Consumes: `TelemetryEventV1` from `@telemetry/contracts`.
 - Produces: `sanitizeEvent(event: TelemetryEventV1): SanitizedTelemetryEvent`, `sanitizeMessage(value: string): string | null`, and `logOperationalEvent(entry: OperationalLog): void`.
 
+`SanitizedTelemetryEvent` has the same shape as `TelemetryEventV1`; construct a fresh object field-by-field and never mutate or spread the input event or error groups. For each error group, preserve only `code`, `stage`, and `count`. Set `message_preview` to the fixed template below for every known non-`UNKNOWN` code, regardless of client input. For `UNKNOWN`, include `message_preview` only when `sanitizeMessage` returns a non-null value.
+
+Fixed templates:
+
+- `NETWORK_TIMEOUT`: `Network request timed out`
+- `NETWORK_UNREACHABLE`: `Network unreachable`
+- `HTTP_ERROR`: `HTTP request failed`
+- `AUTH_EXPIRED`: `Authentication expired`
+- `AUTH_INVALID`: `Authentication invalid`
+- `QUOTA_EXCEEDED`: `Quota exceeded`
+- `API_RESPONSE_INVALID`: `API response invalid`
+- `NOTE_PARSE_FAILED`: `Note parsing failed`
+- `VAULT_READ_FAILED`: `Vault read failed`
+- `VAULT_WRITE_FAILED`: `Vault write failed`
+- `ATTACHMENT_DOWNLOAD_FAILED`: `Attachment download failed`
+
 - [ ] **Step 1: Write failing table-driven sanitizer tests**
 
 Test Bearer tokens, cookies, email addresses, query strings, HTTP URLs, POSIX paths, Windows paths, 16+ digit identifiers, 20+ character random strings, quoted note-like content, and a fully safe timeout template. Add a generated-property loop that creates 100 secret-like strings and asserts none survive.
@@ -181,6 +197,8 @@ Expected: FAIL because the sanitizer does not exist.
 
 Known error codes return fixed templates. Unknown previews pass through ordered replacement rules, a final dangerous-pattern detector, and a 200-character cap. Return `null` when safety cannot be proven. Never throw an error that embeds the source string.
 
+For unknown previews, normalize milliseconds/seconds/minutes duration expressions to `<duration>` before the final check. Reject instead of retaining or partially redacting any value that contains a Bearer/Authorization/Cookie/CSRF/token/key/password marker, email address, URL or query string, POSIX/Windows/vault path, 16-or-more-digit identifier, 20-or-more-character random-looking alphanumeric string, JSON/request-body fragment, control character, or quoted content. After normalization, accept only non-empty strings of at most 200 characters composed of letters, numbers, spaces, and the punctuation `.,:;_()[]<>/-`; otherwise return `null`. Tests must verify that `sanitizeEvent` does not mutate its input and that no original preview survives for known codes.
+
 - [ ] **Step 4: Implement metadata-only structured logging**
 
 ```ts
@@ -194,6 +212,8 @@ type OperationalLog = {
 ```
 
 The logger accepts no request, payload, headers, IP, exception message, or stack.
+
+`logOperationalEvent` must build a new log record field-by-field in exactly the order shown above and call `console.log(JSON.stringify(record))`. It must not spread or serialize the supplied object. Add a focused test that passes an object with an extra runtime property and proves the property and its value are absent from emitted output.
 
 - [ ] **Step 5: Run sanitizer tests and typecheck**
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -101,7 +101,12 @@ export function parseTelemetryEvent(input: unknown): TelemetryEventV1 {
 }
 ```
 
-Use `.strict()` at every object level. Define fixed allow-lists for error codes, stages, duration buckets, and published plugin versions.
+Use `.strict()` at every object level. Define these fixed schema V1 allow-lists verbatim:
+
+- Error codes: `NETWORK_TIMEOUT`, `NETWORK_UNREACHABLE`, `HTTP_ERROR`, `AUTH_EXPIRED`, `AUTH_INVALID`, `QUOTA_EXCEEDED`, `API_RESPONSE_INVALID`, `NOTE_PARSE_FAILED`, `VAULT_READ_FAILED`, `VAULT_WRITE_FAILED`, `ATTACHMENT_DOWNLOAD_FAILED`, `UNKNOWN`.
+- Stages: `list_notes`, `fetch_note_detail`, `fetch_relationships`, `download_attachment`, `parse_note`, `read_vault`, `write_vault`, `create_remote_note`, `task_setup`, `unknown`.
+- Duration buckets: `under_1s`, `1s_3s`, `3s_10s`, `10s_30s`, `30s_2m`, `2m_10m`, `over_10m`.
+- Published plugin versions initially accepted: `1.4.4`. Update this allow-list as part of the release process before a telemetry-enabled plugin version is published; do not accept arbitrary semantic versions.
 
 - [ ] **Step 5: Run contract tests and typecheck**
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -299,7 +299,7 @@ git commit -m "feat: persist idempotent telemetry events"
 ### Task 4: Build the Public Ingestion Worker and Cron Maintenance
 
 **Files:**
-- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/wrangler.jsonc`
+- Modify: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/wrangler.jsonc`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/index.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/geo.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/maintenance.ts`
@@ -310,9 +310,13 @@ git commit -m "feat: persist idempotent telemetry events"
 - Consumes: contracts, sanitizer, and repository from Tasks 1-3.
 - Produces: Worker `fetch(request, env, ctx)` for `POST /v1/events` and `GET /v1/health`, plus `scheduled(controller, env, ctx)`.
 
+Export `resolveAggregateRegion(cf)`, `beijingReportingDate(at)`, `previousBeijingReportingDate(at)`, `reconcileReportingDate(db, reportingDate)`, `flagAnomalies(db, reportingDate)`, and `runMaintenance(db, at)` as focused test seams. Production `fetch` assigns `receivedAt` and its Beijing reporting date from the same `new Date()` value. `scheduled` passes its Promise to `ctx.waitUntil()`.
+
 - [ ] **Step 1: Write failing request tests**
 
 Cover valid `202`, duplicate `202`, invalid JSON `400`, unsupported schema `400`, body over 8 KiB `413`, wrong method `405`, wrong content type `415`, repository failure `503`, and health `200`. Assert response bodies never echo input.
+
+Use JSON responses `{ "outcome": "accepted" }`, `{ "outcome": "duplicate" }`, `{ "status": "ok" }`, and generic errors `{ "error": "INVALID_EVENT" | "PAYLOAD_TOO_LARGE" | "METHOD_NOT_ALLOWED" | "UNSUPPORTED_MEDIA_TYPE" | "NOT_FOUND" | "SERVICE_UNAVAILABLE" }`. Return `404 NOT_FOUND` for unknown paths. Every response sets `content-type: application/json; charset=utf-8`; `405` also sets the route-appropriate `Allow` header. Accept `application/json` with optional parameters and reject every other media type.
 
 - [ ] **Step 2: Write failing geographic tests**
 
@@ -326,6 +330,10 @@ expect(resolveAggregateRegion({ country: 'XX' })).toBe('UNKNOWN');
 
 Test Beijing date calculation across UTC midnight, previous-day reconciliation into `daily_stats` and `daily_errors`, bounded 500-row cleanup, retry idempotency, preservation of detail when reconciliation fails, and deterministic flags for a daily total above both 100 events and five times the prior seven-day average.
 
+Reconciliation is absolute, not additive: for the requested date, aggregate `event_records` into `daily_stats` and `event_errors` joined to `event_records` into `daily_errors`, then upsert every metric using `SET metric = excluded.metric`. This makes retries idempotent and includes late-arriving rows on a later rerun. Do not delete existing aggregate rows for the date. Use prepared statements only.
+
+For anomaly detection, compare each current row with the average metric for the same full primary-key dimensions except `reporting_date` over the preceding seven calendar dates. Compute it as `COALESCE(SUM(metric), 0) / 7.0`, so missing dates count as zero. Use `task_count` for `daily_stats` and `daily_regions`, and `error_count` for `daily_errors`. Set `is_flagged = 1` and `flag_reason = 'volume_gt_100_and_5x_7d_avg'` only when the current metric is strictly greater than 100 and strictly greater than five times that average; otherwise clear both fields. A missing history has average zero. Run this for all three aggregate tables.
+
 - [ ] **Step 4: Run Worker tests and confirm red**
 
 Run: `npm test -- apps/ingest/src/index.test.ts apps/ingest/src/maintenance.test.ts`
@@ -335,6 +343,12 @@ Expected: FAIL because handlers are missing.
 - [ ] **Step 5: Implement fetch and scheduled handlers**
 
 Use `crypto.randomUUID()` for request IDs. Read at most 8 KiB before JSON parsing. Access coarse location from `request.cf`, pass only the aggregate code into the repository, and never put it in operational logs. Schedule daily reconciliation at `20 16 * * *` UTC, which is 00:20 Asia/Shanghai. Reconciliation upserts `daily_stats` and `daily_errors`, then flags a dimension only when its total is above both 100 and five times its prior seven-day average; dashboard trusted totals exclude flagged rows and show them in a separate anomaly indicator.
+
+Implement the body cap with a stream reader: stop and cancel as soon as accumulated bytes exceed 8,192, including when `Content-Length` is absent or false. Do not call `request.text()`, `request.json()`, or unbounded `arrayBuffer()` first. Parse UTF-8 only after the bounded read completes. Feed the parsed value through `parseTelemetryEvent`, then `sanitizeEvent`, before repository storage. On all parse/schema failures return only `INVALID_EVENT`; on repository or unexpected failures return only `SERVICE_UNAVAILABLE` and log metadata through `logOperationalEvent` without the exception message or stack.
+
+`resolveAggregateRegion` returns `CN-<REGION>` only for `country === 'CN'` with an uppercase two-letter `regionCode`; returns the uppercase two-letter country code for non-China countries except `XX` and `T1`; otherwise returns `UNKNOWN`. It never returns city, postal code, coordinates, or the raw `request.cf` object.
+
+`runMaintenance` first reconciles the previous Beijing reporting date and flags all aggregate tables. Only after both succeed does it call `deleteExpiredDetails` once with an ISO cutoff exactly 30 days before `at` and limit `500`. If reconciliation or flagging fails, propagate the error and retain all detail rows.
 
 - [ ] **Step 6: Configure Worker best practices**
 
@@ -347,7 +361,7 @@ Set `compatibility_date`, `nodejs_compat`, D1 binding, Cron Trigger, and:
 }
 ```
 
-Generate types with `npx wrangler types --config apps/ingest/wrangler.jsonc` and commit the generated declarations. Configure edge rate limiting for `/v1/events` during deployment; do not implement an application IP table.
+Add `main: "src/index.ts"`, Cron, and the shown observability fields to the existing local config without replacing its D1 binding. Generate types with `npx wrangler types --config apps/ingest/wrangler.jsonc` and commit `apps/ingest/worker-configuration.d.ts`. Configure edge rate limiting for `/v1/events` during deployment; do not implement an application IP table.
 
 - [ ] **Step 7: Run Worker tests, typecheck, lint, and dry run**
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -234,16 +234,30 @@ git commit -m "feat: sanitize telemetry at the service boundary"
 
 **Files:**
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/migrations/0001_initial.sql`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/wrangler.jsonc`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/repository.ts`
 - Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/src/repository.test.ts`
+- Modify: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/ingest/vitest.config.ts`
 
 **Interfaces:**
 - Consumes: `SanitizedTelemetryEvent` from Task 2 and generated `Env.DB: D1Database`.
-- Produces: `storeEvent(db, event, receivedAt, reportingDate, region): Promise<'inserted' | 'duplicate'>` and `deleteExpiredDetails(db, cutoffIso, limit): Promise<number>`.
+- Produces: `type AggregateRegion = string`, `storeEvent(db, event, receivedAt, reportingDate, region): Promise<'inserted' | 'duplicate'>` and `deleteExpiredDetails(db, cutoffIso, limit): Promise<number>`.
+
+`receivedAt` is an ISO timestamp assigned by the Worker, `reportingDate` is a Beijing `YYYY-MM-DD` date, and `region` is a server-derived aggregate code such as `CN-GD`, `US`, or `UNKNOWN`; none is client input. `storeEvent` computes `message_fingerprint` as lowercase SHA-256 hex of the already server-sanitized preview, or the fixed value `none` when no preview exists.
 
 - [ ] **Step 1: Write the migration with five tables**
 
 Create `event_records`, `event_errors`, `daily_stats`, `daily_errors`, and `daily_regions`. Do not add region or installation columns to the first two tables. Add indexes for reporting date, received time, plugin version, error code/stage, and aggregate keys. Add `is_flagged` and `flag_reason` columns to aggregate tables so anomalous traffic can be excluded from trusted totals without creating another detail table.
+
+Use these columns and keys:
+
+- `event_records`: `event_id TEXT PRIMARY KEY`, `received_at TEXT NOT NULL`, `reporting_date TEXT NOT NULL`, `schema_version INTEGER NOT NULL`, `plugin_version TEXT NOT NULL`, `direction TEXT NOT NULL`, `mode TEXT NOT NULL`, `auth_mode TEXT NOT NULL`, `run_status TEXT NOT NULL`, `created_count INTEGER NOT NULL`, `updated_count INTEGER NOT NULL`, `success_count INTEGER NOT NULL`, `skipped_count INTEGER NOT NULL`, `failed_count INTEGER NOT NULL`, `duration_bucket TEXT NOT NULL`, and the non-location idempotency marker `region_counted INTEGER NOT NULL DEFAULT 0 CHECK (region_counted IN (0, 1))`.
+- `event_errors`: `event_id TEXT NOT NULL`, `error_index INTEGER NOT NULL`, `error_code TEXT NOT NULL`, `error_stage TEXT NOT NULL`, `error_count INTEGER NOT NULL`, `message_preview TEXT`, `message_fingerprint TEXT NOT NULL`, primary key `(event_id, error_index)`, and foreign key to `event_records(event_id)` with cascade delete.
+- `daily_stats`: dimensions `reporting_date`, `plugin_version`, `direction`, `mode`, `auth_mode`, `run_status`; metrics `task_count`, `created_count`, `updated_count`, `success_count`, `skipped_count`, `failed_count`; anomaly fields `is_flagged INTEGER NOT NULL DEFAULT 0 CHECK (is_flagged IN (0, 1))`, `flag_reason TEXT`; primary key across all dimensions.
+- `daily_errors`: dimensions `reporting_date`, `plugin_version`, `auth_mode`, `error_code`, `error_stage`, `message_fingerprint`; optional safe sample `message_preview`; metrics `error_count`, `affected_task_count`; the same anomaly fields; primary key across all dimensions.
+- `daily_regions`: dimensions `reporting_date`, `region_code`; metrics `task_count`, `success_count`, `failed_count`; the same anomaly fields; primary key `(reporting_date, region_code)`.
+
+All aggregate metric columns are `INTEGER NOT NULL DEFAULT 0`. The migration enables foreign keys. Do not add request bodies, IPs, precise geography, install IDs, or any other columns.
 
 - [ ] **Step 2: Write failing repository tests**
 
@@ -259,7 +273,13 @@ Expected: FAIL because the migration/repository is missing.
 
 Use `INSERT ... ON CONFLICT DO NOTHING RETURNING event_id` for the idempotency gate. For a newly inserted ID, use `env.DB.batch([...])` with bound prepared statements for error detail and `daily_regions` upserts. Never interpolate client values into SQL.
 
+The idempotency gate and every dependent write must be in one `db.batch()` so any failed statement rolls back the entire event. Put the gate first. Error inserts use their `(event_id, error_index)` key with `ON CONFLICT DO NOTHING`. Increment `daily_regions` only through an `INSERT ... SELECT ... WHERE` guard that sees `event_records.region_counted = 0`, then set `region_counted = 1` as the last statement. Thus a successful retry changes neither error rows nor region totals, including for events with an empty error array. Determine `inserted` versus `duplicate` from the gate statement's `RETURNING` result. Do not perform a non-atomic gate query before the batch.
+
+`deleteExpiredDetails` validates `limit` as an integer from 1 through 500, then atomically deletes `event_errors` and at most that many matching `event_records`, oldest first, using bound `cutoffIso` and `limit`; return the deleted event-record count. It never modifies aggregate tables.
+
 - [ ] **Step 5: Run migration locally and rerun tests**
+
+Create the initial `wrangler.jsonc` now with `name: "dedao-brain-sync-telemetry-ingest"`, `compatibility_date: "2026-08-10"`, `compatibility_flags: ["nodejs_compat"]`, and `d1_databases: [{ "binding": "DB", "database_name": "telemetry-local", "database_id": "local", "migrations_dir": "migrations" }]`. Here `local` is an explicit local-development sentinel, not a production database ID. Task 4 will extend this same file with the entry point, Cron, generated types, and observability.
 
 Run: `npx wrangler d1 migrations apply telemetry-local --local --config apps/ingest/wrangler.jsonc`
 

--- a/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
+++ b/docs/superpowers/plans/2026-08-10-anonymous-telemetry-service.md
@@ -386,15 +386,36 @@ git commit -m "feat: accept and maintain anonymous telemetry"
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/errors.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/regions.ts`
 - Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/_shared/query.ts`
+- Create: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/worker-configuration.d.ts`
 - Test: `/Users/zhengyan/Projects/ai-project/dedao-brain-sync-telemetry/apps/dashboard/functions/api/api.test.ts`
 
 **Interfaces:**
 - Consumes: D1 aggregate tables from Task 3.
 - Produces: `GET /api/dashboard`, `GET /api/errors`, and `GET /api/regions` JSON responses.
 
+All three handlers accept an injected `now` only through exported pure/query helpers for tests; production uses the request time. Date queries use Beijing calendar dates. With no date parameters, `range=7` is the default and `range=30` is the only alternative; both end on today's Beijing date. Alternatively, callers may supply `from=YYYY-MM-DD&to=YYYY-MM-DD` together for an inclusive range of 1 through 30 days. Reject mixed `range` plus explicit dates, one-sided dates, invalid/non-canonical calendar dates, `from > to`, spans over 30 days, duplicate parameters, and unknown parameters with `400 { "error": "INVALID_QUERY" }`.
+
+Supported filters are intentionally table-specific:
+
+- `/api/dashboard`: `plugin_version`, `direction`, `mode`, `auth_mode`.
+- `/api/errors`: `plugin_version`, `auth_mode`.
+- `/api/regions`: no dimension filters beyond the date range.
+
+Validate filter values against the shared V1 allow-lists. Reject a filter on an endpoint whose privacy-separated table cannot answer it. Never query raw detail tables from dashboard Functions.
+
+Return these stable shapes (all keys are required):
+
+- `/api/dashboard`: `{ range: { from, to, days }, data_state: 'ready' | 'empty', totals: { tasks, success, created, updated, skipped, failed }, task_health: { success, partial, failed, cancelled, success_rate }, daily: Array<{ date, tasks, success, failed, skipped }>, anomalies: { flagged_rows } }`. Zero-fill each calendar date in `daily`. `success_rate` is successful tasks divided by `success + partial + failed` tasks, excluding cancelled tasks, and is `null` when that denominator is zero.
+- `/api/errors`: `{ range, data_state, items, anomalies: { flagged_rows, occurrences } }`. Each trusted item is `{ code, stage, fingerprint, preview, occurrences, affected_tasks, first_seen, last_seen, plugin_versions: Array<{ version, occurrences }>, auth_modes: Array<{ auth_mode, occurrences }>, daily: Array<{ date, occurrences }> }`. Group across allowed version/auth filters by `code + stage + fingerprint + preview`, zero-fill item trends, sort by occurrences descending then stable keys, and return at most 100 items. `preview` is the already sanitized stored sample or `null`.
+- `/api/regions`: `{ range, data_state, label: 'Synchronization activity, not unique users', items: Array<{ region_code, task_count, success_count, failed_count }>, anomalies: { flagged_rows, task_count } }`. Sum trusted rows over the selected period; any individual region with total `task_count < 5` contributes only to one combined `OTHER` row. Sort by `task_count` descending then `region_code`.
+
+Trusted totals/items use only rows with `is_flagged = 0`. The anomaly objects summarize excluded flagged rows without exposing their dimensions. A successful query with no trusted or flagged rows uses `data_state: 'empty'`; otherwise use `ready`.
+
 - [ ] **Step 1: Write failing API tests**
 
 Test default 7-day range, 30-day range, ISO date validation, plugin/auth/direction/mode filters, no-data responses, and database failure. Assert region responses group total event counts below five into `OTHER`.
+
+Also test rejection of unsupported cross-filters, flagged-row exclusion/anomaly counts, zero-filled dates, null success rate for no task denominator, stable error grouping/sorting, the 100-item cap, and that low-volume region codes never appear anywhere in serialized output.
 
 - [ ] **Step 2: Run API tests and confirm red**
 
@@ -406,9 +427,11 @@ Expected: FAIL because functions are missing.
 
 Build filter clauses only from fixed server-owned fragments; bind all values. Return `503` with `{ "error": "DASHBOARD_UNAVAILABLE" }` on storage failure, never a zeroed dataset.
 
+Return all successful and error payloads as JSON with `content-type: application/json; charset=utf-8`. Handlers support GET only and return `405 { "error": "METHOD_NOT_ALLOWED" }` with `Allow: GET` otherwise. Do not log SQL, bound values, or exception messages.
+
 - [ ] **Step 4: Configure Pages D1 bindings and generated types**
 
-Define matching preview and production D1 bindings in `wrangler.jsonc`, run `npx wrangler types --config apps/dashboard/wrangler.jsonc`, and keep local D1 isolated by default.
+Define a local D1 binding and matching `preview` and `production` environment bindings named `DB` in `wrangler.jsonc`. Until Task 7 creates the real databases, use the explicit non-production `database_id: "local"` sentinel for all three and document it in a JSONC comment; never deploy this placeholder configuration. Run `npx wrangler types --config apps/dashboard/wrangler.jsonc`, commit the generated declaration, and keep local D1 isolated by default.
 
 - [ ] **Step 5: Run API tests and typecheck**
 

--- a/docs/superpowers/specs/2026-08-09-anonymous-sync-telemetry-dashboard-design.md
+++ b/docs/superpowers/specs/2026-08-09-anonymous-sync-telemetry-dashboard-design.md
@@ -1,0 +1,437 @@
+# Anonymous Sync Telemetry Dashboard Design
+
+**Status:** Approved for planning
+
+**Date:** 2026-08-09
+
+**Scope:** Design only; this document does not authorize implementation or release
+
+## 1. Purpose
+
+Build a zero-cost private aggregation service that tells the plugin maintainer:
+
+- how many notes were successfully synchronized each day;
+- how many notes failed, were skipped, or were uploaded in the reverse direction;
+- which sanitized error categories caused failures;
+- whether failures correlate with a plugin version, sync mode, authentication mode, or coarse region;
+- how many sync tasks completed successfully, partially succeeded, failed, or were cancelled.
+
+The service must not collect note content, account data, vault information, persistent device identifiers, or precise location.
+
+## 2. Product Decisions
+
+The approved decisions are:
+
+- The dashboard is private and accessible only to the maintainer.
+- Anonymous telemetry is enabled only after explicit user consent.
+- Declining telemetry never limits plugin functionality.
+- Error messages are sanitized on the client and sanitized again on the server.
+- Raw event and error records are retained for 30 days.
+- Daily aggregate records are retained long term.
+- Note counts and task health are separate metrics.
+- Geographic reporting describes sync activity, not unique users.
+- Chinese activity may be aggregated to province level; other activity is aggregated to country level.
+- IP addresses are never written to application storage.
+- Areas with fewer than five events in the selected reporting period are grouped as `Other` in the dashboard.
+
+## 3. Metric Definitions
+
+### 3.1 Note outcomes
+
+For remote-to-local synchronization:
+
+- `created`: a new local note was written.
+- `updated`: an existing local note was changed.
+- `success`: `created + updated`.
+- `skipped`: a note was inspected but did not require a write, or was intentionally excluded by existing sync behavior.
+- `failed`: a note-level operation failed.
+
+Skipped notes are never counted as successful synchronization. This prevents scheduled scans of unchanged notes from inflating the main metric.
+
+For local-to-remote synchronization, `created` is reported under the separate `local_to_remote` direction and is not mixed with remote-to-local success totals.
+
+### 3.2 Task outcomes
+
+- `success`: the task completed normally with zero failed notes.
+- `partial`: the task completed but one or more notes failed.
+- `failed`: the task terminated because of a task-level error.
+- `cancelled`: the user cancelled the task. Cancellation is not a failure.
+
+A successful task may contain zero successful notes when there was nothing new to write.
+
+## 4. Architecture
+
+Use one Cloudflare project for the aggregation service:
+
+```text
+Obsidian plugin
+    |
+    | POST /v1/events
+    v
+Cloudflare Worker
+    |- schema validation
+    |- edge rate limiting
+    |- event-id deduplication
+    |- server-side sanitization
+    |- D1 writes
+    v
+Cloudflare D1
+    |- 30-day task and error detail
+    |- long-lived daily aggregates
+    v
+Cloudflare Pages private dashboard
+    |- /dashboard
+    |- /errors
+    `- /regions
+
+Cloudflare Cron Trigger
+    |- daily reconciliation
+    `- retention cleanup
+```
+
+The static dashboard and read APIs are protected by Cloudflare Access and restricted to the maintainer's email identity. The ingestion endpoint is public because an open-source plugin cannot safely contain a shared secret.
+
+The telemetry service should live in an independent repository or deployment project. The plugin repository contains only the telemetry client, consent UI, tests, privacy documentation, and this design. Separating the projects prevents the Worker and dashboard toolchain from becoming part of the Obsidian plugin bundle.
+
+## 5. Event Contract
+
+Each completed sync task produces at most one telemetry event. Retries reuse the same `event_id`.
+
+```json
+{
+  "schema_version": 1,
+  "event_id": "5f80b650-2c8f-4f8e-bf58-960ee2531bbc",
+  "plugin_version": "2.3.0",
+  "direction": "remote_to_local",
+  "mode": "time",
+  "auth_mode": "openapi",
+  "run_status": "partial",
+  "counts": {
+    "success": 15,
+    "created": 12,
+    "updated": 3,
+    "skipped": 40,
+    "failed": 2
+  },
+  "duration_bucket": "10s_30s",
+  "errors": [
+    {
+      "code": "NETWORK_TIMEOUT",
+      "stage": "fetch_note_detail",
+      "count": 2,
+      "message_preview": "Request timed out after <duration>"
+    }
+  ]
+}
+```
+
+### 5.1 Allowed dimensions
+
+- `direction`: `remote_to_local` or `local_to_remote`.
+- `mode`: `time`, `selected`, `knowledge_base`, `auto`, or `local_upload`.
+- `auth_mode`: `openapi` or `web`.
+- `run_status`: `success`, `partial`, `failed`, or `cancelled`.
+- `duration_bucket`: `under_1s`, `1s_3s`, `3s_10s`, `10s_30s`, `30s_2m`, `2m_10m`, or `over_10m`.
+
+The client does not send an occurrence time or time zone. The Worker assigns `received_at` and the Beijing reporting date. The client does not send a permanent installation identifier.
+
+### 5.2 Size and count limits
+
+- Request body: at most 8 KiB.
+- Error groups per task: at most 10.
+- Sanitized message preview: at most 200 characters.
+- All note counters: integers from 0 through 100,000.
+- `success` must equal `created + updated`.
+- Only known enum values and published plugin versions are accepted.
+
+## 6. Error Taxonomy
+
+Errors are grouped locally before upload. Initial error codes are:
+
+- `NETWORK_TIMEOUT`
+- `NETWORK_UNREACHABLE`
+- `HTTP_ERROR`
+- `AUTH_EXPIRED`
+- `AUTH_INVALID`
+- `QUOTA_EXCEEDED`
+- `API_RESPONSE_INVALID`
+- `NOTE_PARSE_FAILED`
+- `VAULT_READ_FAILED`
+- `VAULT_WRITE_FAILED`
+- `ATTACHMENT_DOWNLOAD_FAILED`
+- `UNKNOWN`
+
+Initial stages are:
+
+- `list_notes`
+- `fetch_note_detail`
+- `fetch_relationships`
+- `download_attachment`
+- `parse_note`
+- `read_vault`
+- `write_vault`
+- `create_remote_note`
+- `task_setup`
+- `unknown`
+
+The taxonomy is versioned with the event schema. New categories may be added without allowing arbitrary client-provided category names.
+
+## 7. Privacy and Sanitization
+
+### 7.1 Data that must never be uploaded
+
+- note title, content, tags, note ID, detail ID, or knowledge-base ID;
+- attachment names or URLs;
+- vault name, folder name, file name, or file-system path;
+- GetNote account identifiers;
+- API tokens, client identifiers, CSRF values, cookies, or authorization headers;
+- request or response bodies;
+- operating-system name, device model, locale, or precise time zone;
+- IP address, latitude, longitude, city, postal code, or metro code;
+- a persistent installation or device identifier.
+
+### 7.2 Client sanitization
+
+The client first maps each error to an allow-listed error code and stage. It then removes or replaces:
+
+- authorization and cookie values;
+- URL query strings and fragments;
+- email addresses;
+- local and vault-like paths;
+- long numeric identifiers;
+- long random-looking alphanumeric strings;
+- quoted note-like values and request payload fragments.
+
+Known errors should use fixed templates rather than transformed raw text. Unknown errors may produce a sanitized `message_preview`, but the preview is optional and must be discarded when safe sanitization cannot be proven.
+
+### 7.3 Server sanitization
+
+The Worker repeats sanitization using stricter rules before any logging or database write. If the result still resembles a credential, identifier, email address, URL, path, or payload, the Worker stores an empty preview and retains only `code`, `stage`, and `count`.
+
+The Worker must not log request bodies. Operational logs may contain route, status, latency, and generated request correlation IDs only.
+
+## 8. Geographic Aggregation
+
+Cloudflare derives coarse location from the network request:
+
+- requests resolved to China use the province/region code;
+- other requests use the two-letter country code;
+- unknown or privacy-network locations use `Unknown`;
+- city, coordinates, postal code, and time zone are ignored.
+
+Location exists only during request processing. After the event has been accepted and deduplicated, the Worker increments `daily_regions` and discards the location. `event_records` and `event_errors` do not contain a location column.
+
+Because the service has no persistent installation identifier, geographic data measures synchronization activity and note outcomes. It must never be labelled as users, installations, or people.
+
+## 9. Storage Model
+
+### 9.1 `event_records`
+
+Task-level records retained for 30 days:
+
+- `event_id` primary key
+- `received_at`
+- `beijing_date`
+- `schema_version`
+- `plugin_version`
+- `direction`
+- `mode`
+- `auth_mode`
+- `run_status`
+- `created_count`
+- `updated_count`
+- `success_count`
+- `skipped_count`
+- `failed_count`
+- `duration_bucket`
+
+There is deliberately no region or installation column.
+
+### 9.2 `event_errors`
+
+Sanitized error groups retained for 30 days:
+
+- `event_id`
+- `error_code`
+- `error_stage`
+- `error_count`
+- `message_preview`
+- `message_fingerprint`
+
+The fingerprint is computed after server sanitization and is used only to group equivalent previews.
+
+### 9.3 Aggregate tables
+
+`daily_stats` stores daily note and task totals by plugin version, direction, mode, and authentication mode.
+
+`daily_errors` stores daily error totals by plugin version, error code, error stage, and sanitized fingerprint.
+
+`daily_regions` stores daily task and note totals by coarse region code. Regions do not join back to individual events.
+
+## 10. Ingestion, Deduplication, and Abuse Controls
+
+The ingestion sequence is:
+
+1. Reject unsupported methods, content types, body sizes, or schemas.
+2. Validate enums, counts, internal count relationships, and plugin version.
+3. Apply server sanitization.
+4. Attempt to insert `event_records` by `event_id`.
+5. If the ID already exists, return success without changing aggregates.
+6. For a new event, write sanitized error groups and increment the region aggregate.
+7. Return `202 Accepted` without exposing stored data.
+
+No embedded plugin secret is used. Authenticity is therefore probabilistic, not cryptographic. The metrics are appropriate for product health and operational diagnosis, not billing or financial reporting.
+
+Controls include:
+
+- Cloudflare edge rate limiting without application-level IP storage;
+- fixed request and field limits;
+- published-version allow-listing;
+- event ID uniqueness;
+- rejection of inconsistent or extreme counters;
+- anomaly flags for sudden volume, version, error, or region changes;
+- separation of flagged traffic from trusted dashboard totals.
+
+CORS, an obscure endpoint URL, or a key compiled into the plugin must not be described as security controls.
+
+## 11. Client Reliability
+
+Telemetry is always secondary to synchronization:
+
+- local sync history is saved before telemetry is attempted;
+- a telemetry request times out after three seconds;
+- telemetry errors do not change sync status or display a sync failure notice;
+- retryable events are stored in a local queue capped at 20 entries;
+- queued events are retried on the next plugin start or completed sync;
+- `400` responses discard the event;
+- `429` and `5xx` responses keep the event for a later retry;
+- retry attempts reuse the same event ID;
+- disabling telemetry immediately clears the queue.
+
+The queue stores only the already-sanitized payload. Raw errors are never queued.
+
+## 12. Consent Experience
+
+Telemetry is off until the user explicitly opts in. The consent prompt states:
+
+> When enabled, the plugin sends created, updated, skipped, and failed note counts; plugin version; sync and authentication modes; and sanitized error categories. The service uses the network request to create country- or province-level aggregates but does not store IP addresses. It does not send note content, titles, tags, note IDs, file paths, vault information, account information, tokens, or cookies.
+
+The prompt provides:
+
+- `Enable anonymous statistics`
+- `Not now`
+- a link to the complete privacy documentation
+
+The settings page shows the same summary, allows telemetry to be disabled at any time, and explains that disabling it clears queued reports. Rejection or later disabling has no effect on plugin functionality.
+
+## 13. Dashboard
+
+### 13.1 `/dashboard`
+
+The overview shows:
+
+- today's successful, failed, and skipped note counts;
+- task success rate and counts of partial, failed, and cancelled tasks;
+- comparisons with yesterday and the previous seven-day average;
+- daily note-outcome trends;
+- task-health distribution;
+- top ten error groups;
+- coarse activity-region distribution.
+
+Filters are date range, plugin version, direction, mode, authentication mode, and coarse region where the underlying aggregate supports it. The UI must not imply that a cross-filter is available when the privacy-separated tables cannot answer it.
+
+### 13.2 `/errors`
+
+The error center shows error code, stage, occurrence count, affected task count, first and last appearance, plugin versions, authentication-mode distribution, seven-day trend, and sanitized preview samples. It marks error codes or fingerprints that first appeared after a plugin release.
+
+### 13.3 `/regions`
+
+The region page shows task count, successful note count, and failed note count for Chinese provinces and other countries. Regions with fewer than five events in the selected period are grouped into `Other`. The page is labelled as synchronization activity distribution, not user distribution.
+
+The first version uses cards, line charts, stacked bars, and tables. It does not include a map, public page, multi-user account system, real-time streaming, or alert delivery.
+
+## 14. Scheduled Maintenance
+
+A daily Cron Trigger runs after the end of the Beijing reporting day. It:
+
+1. reconciles the previous day's aggregate totals against retained event detail;
+2. records discrepancies and anomaly flags;
+3. finalizes daily error summaries;
+4. deletes event and error detail older than 30 days in bounded batches;
+5. leaves daily aggregate tables intact.
+
+Cleanup is idempotent and safe to retry. A failed scheduled run must not delete data that has not been successfully summarized.
+
+## 15. Failure Handling
+
+- Invalid events return `400` with a generic error code and are not stored.
+- Duplicate valid events return a successful response without another write.
+- Rate-limited events return `429` and may be retried later.
+- Temporary storage failures return `503`; no partial aggregate is committed.
+- Dashboard read failures show the affected panel as unavailable without replacing previous data with zero.
+- Missing geographic data is recorded only in the aggregate `Unknown` bucket.
+- Unsupported future schema versions are rejected until the Worker supports them.
+
+## 16. Verification and Acceptance
+
+Implementation is accepted only when all of the following are demonstrated:
+
+- No request to the telemetry origin occurs before consent.
+- Declining or disabling telemetry does not affect plugin behavior.
+- Disabling telemetry clears the local queue.
+- Captured payloads contain none of the prohibited fields.
+- Client sanitization tests cover tokens, cookies, emails, URLs, IDs, paths, quoted content, and generated secret-like strings.
+- Server sanitization independently covers the same cases and drops unsafe previews.
+- The Worker never logs event bodies.
+- Repeated delivery of one event ID changes all metrics exactly once.
+- Network timeout, offline mode, `429`, and `5xx` do not affect synchronization.
+- OpenAPI and Web API syncs produce correctly separated aggregates.
+- Remote-to-local and local-to-remote results never mix.
+- Success, partial, failed, cancelled, skipped-only, and empty tasks use the defined semantics.
+- Beijing date boundaries are correct around midnight and UTC date changes.
+- Event detail has no region column and cannot be joined to region aggregates.
+- Unauthorized users cannot access dashboard pages or read APIs.
+- Records older than 30 days are deleted only after successful aggregation.
+- Low-volume regions are grouped into `Other` in dashboard responses.
+
+Before any plugin pull request is proposed as complete, the repository checks remain:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm run build
+```
+
+## 17. Operator Prerequisites
+
+No Cloudflare-specific MCP server is required. Deployment uses Wrangler and the Cloudflare dashboard.
+
+Before the first deployment, the maintainer must:
+
+1. own or create a Cloudflare account on the Free plan;
+2. run `npx wrangler login` locally and complete the browser OAuth flow;
+3. confirm that Wrangler can display the authenticated account;
+4. later configure Cloudflare Access so only the maintainer's email can reach the production `*.pages.dev` dashboard.
+
+No API token, Global API Key, password, OAuth callback, or credential value should be pasted into an issue, pull request, repository file, or assistant conversation. A custom domain is optional; the production `*.pages.dev` domain can be protected by Cloudflare Access. Resource creation, Access policy configuration, and production deployment remain separate implementation actions and require explicit authorization.
+
+## 18. Delivery Phases
+
+1. Create the independent Worker and D1 project, migrations, validation, sanitization, deduplication, and retention job.
+2. Build the private Pages dashboard and Cloudflare Access policy.
+3. Add plugin consent, client sanitization, event construction, bounded queue, and retry behavior.
+4. Verify end to end in a non-production telemetry environment using both authentication modes and both sync directions.
+5. Publish privacy documentation and release the opted-in telemetry client through the normal plugin pull-request and release workflow.
+6. Observe the service for one to two weeks before considering alerts or a separate public aggregate page.
+
+## 19. Explicit Non-Goals
+
+- Counting unique users or installations
+- Collecting precise geography
+- Collecting note-level telemetry
+- Remote debugging with raw logs
+- Billing-grade or tamper-proof analytics
+- Public rankings or public dashboards
+- Modifying synchronization semantics
+- Replacing the existing local sync history


### PR DESCRIPTION
## Summary

- define privacy-first telemetry metrics and consent boundaries
- design a free Cloudflare Workers, D1, Pages, and Access architecture
- specify double sanitization, regional aggregation, retention, dashboard, and acceptance criteria
- add separate implementation plans for the Cloudflare service and Obsidian plugin client
- document operator prerequisites and Cloudflare MCP setup

## Scope

Design and implementation planning only. This PR does not implement telemetry or change plugin behavior.

## Verification

- npm run typecheck
- npm run lint
- npm test (700 passed, 2 skipped)
- npm run build