### PR TITLE
fix(ui): limit full settings link to ribbon

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -256,7 +256,7 @@ export default class GetNoteSyncPlugin extends Plugin {
   }
 
   private registerRibbonActions(): void {
-    this.syncRibbonEl = this.addRibbonIcon('book-lock', t('ribbon.tooltip'), () => this.openManualSyncModal());
+    this.syncRibbonEl = this.addRibbonIcon('book-lock', t('ribbon.tooltip'), () => this.openManualSyncModal(true));
     this.searchRibbonEl = this.addRibbonIcon('brain-circuit', t('ribbon.searchTooltip'), () => void this.openSearchView());
     this.refreshRibbonActions();
   }
@@ -623,10 +623,10 @@ export default class GetNoteSyncPlugin extends Plugin {
     }
   }
 
-  openManualSyncModal(): void {
+  openManualSyncModal(showOpenSettings = false): void {
     if (this.isDatePathMigrationRunning) return;
     closeFloatingSelects();
-    const wrapper = new ManualSyncModalWrapper(this.app, this);
+    const wrapper = new ManualSyncModalWrapper(this.app, this, showOpenSettings);
     wrapper.open();
   }
 
@@ -927,7 +927,11 @@ class GetNoteSearchModal extends Modal {
 }
 
 class ManualSyncModalWrapper extends Modal {
-  constructor(app: App, private plugin: GetNoteSyncPlugin) {
+  constructor(
+    app: App,
+    private plugin: GetNoteSyncPlugin,
+    private showOpenSettings: boolean,
+  ) {
     super(app);
     this.titleEl.setText(t('manualSync.title'));
   }
@@ -941,10 +945,12 @@ class ManualSyncModalWrapper extends Modal {
           syncTags: this.plugin.settings.syncTags,
         }}
         tagOptions={this.plugin.settings.tagCache?.tags ?? []}
-        onOpenSettings={() => {
-          this.close();
-          this.plugin.openSettingsTab();
-        }}
+        {...(this.showOpenSettings ? {
+          onOpenSettings: () => {
+            this.close();
+            this.plugin.openSettingsTab();
+          },
+        } : {})}
         onConfirm={(options) => {
           this.close();
           this.plugin.startSync(options);

--- a/tests/settings-tab.spec.ts
+++ b/tests/settings-tab.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'preact/test-utils';
-import { App } from 'obsidian';
+import { App, Modal } from 'obsidian';
 import GetNoteSyncPlugin from '../src/main';
 import { GetNoteSettingsTab } from '../src/settings-tab';
 import { initI18n } from '../src/i18n';
@@ -28,9 +28,40 @@ afterEach(() => {
   vi.restoreAllMocks();
   initI18n('zh-CN');
   document.body.innerHTML = '';
+  delete (HTMLElement.prototype as typeof HTMLElement.prototype & { setText?: (text: string) => void }).setText;
 });
 
 describe('GetNoteSettingsTab runtime updates', () => {
+  it('opens the manual sync modal without a full-settings link from settings', async () => {
+    const plugin = makePlugin();
+    plugin.settings.openApiToken = 'token';
+    plugin.settings.openApiClientId = 'client-id';
+    const tab = new GetNoteSettingsTab(plugin.app, plugin);
+    const openedModals: Modal[] = [];
+    Object.defineProperty(HTMLElement.prototype, 'setText', {
+      configurable: true,
+      value(this: HTMLElement, text: string) {
+        this.textContent = text;
+      },
+    });
+    vi.spyOn(Modal.prototype, 'open').mockImplementation(function (this: Modal) {
+      openedModals.push(this);
+      (this as Modal & { onOpen(): void }).onOpen();
+    });
+
+    await act(() => {
+      tab.display();
+    });
+    const syncButton = tab.containerEl.querySelector<HTMLButtonElement>('.getnote-sync-action-button')!;
+
+    await act(() => {
+      click(syncButton);
+    });
+
+    expect(openedModals).toHaveLength(1);
+    expect(openedModals[0].contentEl.querySelector('.getnote-settings-link')).toBeNull();
+  });
+
   it('mounts once per display lifecycle and remounts after hide', async () => {
     const plugin = makePlugin();
     const tab = new GetNoteSettingsTab(plugin.app, plugin);

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -776,7 +776,7 @@ describe('GetNoteSyncPlugin ribbon actions', () => {
     syncRibbon![2]();
     searchRibbon![2]();
 
-    expect(openManualSyncModal).toHaveBeenCalledOnce();
+    expect(openManualSyncModal).toHaveBeenCalledWith(true);
     expect(openSearchView).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## Summary

- show “打开完整设置 / Open full settings” only when the manual sync modal is opened from the left ribbon
- hide the redundant link when the same modal is opened from the settings page or command palette
- keep the existing modal layout and sync behavior unchanged

## Verification

- [x] npm run typecheck
- [x] npm run lint
- [x] npx eslint tests --max-warnings=0
- [x] npm test — 724 passed, 2 skipped
- [x] npm run build

## Acceptance

1. Click the left ribbon action “同步得到大脑”: the footer shows “打开完整设置”.
2. Open Settings → Dedao Brain Sync and click the manual sync action: the footer does not show that link.
3. Version remains 1.4.3. Merge only after local Obsidian acceptance.