### PR TITLE
feat: silently renew Web Token from desktop session

### DIFF
--- a/src/api-clients/webapi-client.ts
+++ b/src/api-clients/webapi-client.ts
@@ -2,6 +2,27 @@ import type { GetNoteNote, Attachment, LinkOriginal, SubscribedTopic } from '../
 import { t } from '../i18n';
 import { isRecord, normalizeBearerToken, parseJsonObjectOrEmpty, parseJsonPreservingIds, waitForRetryDelay } from './api-client-utils';
 
+export class WebApiAuthenticationError extends Error {
+  constructor(
+    readonly reason: 'expired' | 'forbidden',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'WebApiAuthenticationError';
+  }
+}
+
+export function isWebApiAuthenticationError(error: unknown): error is WebApiAuthenticationError {
+  return error instanceof WebApiAuthenticationError;
+}
+
+function createWebApiAuthenticationError(message: string): WebApiAuthenticationError {
+  return new WebApiAuthenticationError(
+    message === 'LoginRequired' ? 'expired' : 'forbidden',
+    message === 'LoginRequired' ? t('error.webApiLoginRequired') : t('error.webApiForbidden'),
+  );
+}
+
 function buildHeaders(token: string): Record<string, string> {
   return {
     Authorization: normalizeBearerToken(token),
@@ -122,8 +143,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
     const text = await res.text().catch(() => '');
     const json = tryParseJsonObject(text);
     const msg = (json.message as string) ?? '';
-    if (msg === 'LoginRequired') throw new Error(t('error.webApiLoginRequired'));
-    throw new Error(t('error.webApiForbidden'));
+    throw createWebApiAuthenticationError(msg);
   }
   if (res.status === 429) return handleRateLimit<T>(url, options, res, retries, signal);
   if (res.status < 200 || res.status >= 300) {
@@ -139,6 +159,7 @@ async function apiRequest<T>(url: string, options: RequestInit, retries = 1, sig
   if (json.success === false) {
     const err = (json.error ?? json) as Record<string, unknown>;
     const errMsg = (err?.message as string) ?? (json.message as string) ?? '';
+    if (errMsg === 'LoginRequired') throw createWebApiAuthenticationError(errMsg);
     throw new Error(errMsg ? t('error.apiGenericWithMsg', { msg: errMsg }) : t('error.apiGeneric'));
   }
   return json as T;
@@ -420,7 +441,7 @@ export async function fetchNoteDetail(
   }, 2, signal);
   // Web API detail: data is in .c, not .data
   if (data.message) {
-    if (data.message === 'LoginRequired') throw new Error(t('error.webApiLoginRequired'));
+    if (data.message === 'LoginRequired') throw createWebApiAuthenticationError(data.message);
     throw new Error(data.message ? t('error.apiGenericWithMsg', { msg: data.message }) : t('error.apiGeneric'));
   }
   const c = data.c;
@@ -442,7 +463,7 @@ export async function fetchNoteOriginal(
     headers: buildHeaders(token),
   }, 2, signal);
   if (data.message) {
-    if (data.message === 'LoginRequired') throw new Error(t('error.webApiLoginRequired'));
+    if (data.message === 'LoginRequired') throw createWebApiAuthenticationError(data.message);
     throw new Error(data.message ? t('error.apiGenericWithMsg', { msg: data.message }) : t('error.apiGeneric'));
   }
   return normalizeLinkOriginal(data);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,11 +1,22 @@
 // Central API entry point - delegates to client implementations based on authMode
 import { createNote as openapiCreateNote, fetchNotes as openapiFetchNotes, fetchNoteDetail as openapiFetchNoteDetail, fetchRecallSearch as openapiFetchRecallSearch, fetchSubscribedKnowledgeNotes as openapiFetchSubscribedKnowledgeNotes, fetchTopicBloggers as openapiFetchTopicBloggers, fetchTopicContentPreviewPage as openapiFetchTopicContentPreviewPage, fetchTopicContentPreviews as openapiFetchTopicContentPreviews, fetchSubscribedTopics as openapiFetchSubscribedTopics } from './api-clients/openapi-client';
-import { createNote as webapiCreateNote, fetchNotes as webapiFetchNotes, fetchNoteChildren as webapiFetchNoteChildren, fetchNoteDetail as webapiFetchNoteDetail, fetchNoteOriginal as webapiFetchNoteOriginal, fetchSubscribedKnowledgeNotes as webapiFetchSubscribedKnowledgeNotes, fetchTopicContentPreviewPage as webapiFetchTopicContentPreviewPage, fetchTopicContentPreviews as webapiFetchTopicContentPreviews, fetchSubscribedTopics as webapiFetchSubscribedTopics } from './api-clients/webapi-client';
+import { createNote as webapiCreateNote, fetchNotes as webapiFetchNotes, fetchNoteChildren as webapiFetchNoteChildren, fetchNoteDetail as webapiFetchNoteDetail, fetchNoteOriginal as webapiFetchNoteOriginal, fetchSubscribedKnowledgeNotes as webapiFetchSubscribedKnowledgeNotes, fetchTopicContentPreviewPage as webapiFetchTopicContentPreviewPage, fetchTopicContentPreviews as webapiFetchTopicContentPreviews, fetchSubscribedTopics as webapiFetchSubscribedTopics, isWebApiAuthenticationError } from './api-clients/webapi-client';
 import type { GetNoteNote, AuthMode, LinkOriginal, RecallSearchResult, SubscribedTopic } from './types';
 import type { Blogger } from './api-clients/openapi-client';
 import { t } from './i18n';
 
 export const GETNOTE_LIST_LIMIT = 20;
+
+export interface WebTokenRefreshHandler {
+  getToken(): string;
+  refresh(): Promise<string>;
+}
+
+let webTokenRefreshHandler: WebTokenRefreshHandler | null = null;
+
+export function setWebTokenRefreshHandler(handler: WebTokenRefreshHandler | null): void {
+  webTokenRefreshHandler = handler;
+}
 
 export interface FetchNotesOptions {
   token: string;
@@ -19,6 +30,34 @@ export interface FetchNotesOptions {
   createdTopicIds?: string[];
   bloggerIds?: string[];
   selectedNoteIds?: string[];
+  skipWebTokenRefresh?: boolean;
+}
+
+type WebTokenRequestOptions = Pick<FetchNotesOptions, 'token' | 'signal' | 'skipWebTokenRefresh'>;
+
+async function requestWithWebTokenRefresh<T>(
+  options: WebTokenRequestOptions,
+  request: (token: string) => Promise<T>,
+): Promise<T> {
+  const handler = webTokenRefreshHandler;
+  const configuredToken = options.skipWebTokenRefresh ? '' : handler?.getToken().trim() ?? '';
+  const token = configuredToken || options.token;
+
+  try {
+    return await request(token);
+  } catch (error) {
+    if (
+      options.skipWebTokenRefresh
+      || options.signal?.aborted
+      || !handler
+      || !isWebApiAuthenticationError(error)
+    ) {
+      throw error;
+    }
+    const renewedToken = (await handler.refresh()).trim();
+    if (!renewedToken) throw error;
+    return request(renewedToken);
+  }
 }
 
 export async function fetchNotes(options: FetchNotesOptions): Promise<{
@@ -27,7 +66,12 @@ export async function fetchNotes(options: FetchNotesOptions): Promise<{
 }> {
   const { token, clientId, authMode } = options;
   if (authMode === 'web') {
-    return webapiFetchNotes({ token, sinceId: options.sinceId, limit: options.limit, signal: options.signal });
+    return requestWithWebTokenRefresh(options, refreshedToken => webapiFetchNotes({
+      token: refreshedToken,
+      sinceId: options.sinceId,
+      limit: options.limit,
+      signal: options.signal,
+    }));
   }
   return openapiFetchNotes({ token, clientId, sinceId: options.sinceId, limit: options.limit, signal: options.signal });
 }
@@ -61,7 +105,7 @@ export async function fetchNoteDetail(
   _csrfToken?: string // kept for API compatibility, unused
 ): Promise<Partial<GetNoteNote>> {
   if (authMode === 'web') {
-    return webapiFetchNoteDetail(id, token, signal);
+    return requestWithWebTokenRefresh({ token, signal }, refreshedToken => webapiFetchNoteDetail(id, refreshedToken, signal));
   }
   return openapiFetchNoteDetail(id, token, clientId, signal);
 }
@@ -73,7 +117,7 @@ export async function fetchNoteOriginal(
   authMode?: AuthMode
 ): Promise<LinkOriginal | null> {
   if (authMode !== 'web') return null;
-  return webapiFetchNoteOriginal(id, token, signal);
+  return requestWithWebTokenRefresh({ token, signal }, refreshedToken => webapiFetchNoteOriginal(id, refreshedToken, signal));
 }
 
 export async function fetchNoteChildren(
@@ -83,26 +127,26 @@ export async function fetchNoteChildren(
   authMode?: AuthMode
 ): Promise<GetNoteNote[]> {
   if (authMode !== 'web') return [];
-  return webapiFetchNoteChildren(parentPrimeId, token, signal);
+  return requestWithWebTokenRefresh({ token, signal }, refreshedToken => webapiFetchNoteChildren(parentPrimeId, refreshedToken, signal));
 }
 
 export async function fetchSubscribedTopics(options: { token: string; clientId: string; authMode?: AuthMode; signal?: AbortSignal }): Promise<SubscribedTopic[]> {
   if (options.authMode === 'web') {
-    return webapiFetchSubscribedTopics(options.token, options.signal);
+    return requestWithWebTokenRefresh(options, refreshedToken => webapiFetchSubscribedTopics(refreshedToken, options.signal));
   }
   return openapiFetchSubscribedTopics(options.token, options.clientId, options.signal);
 }
 
 export async function fetchSubscribedKnowledgeNotes(options: FetchNotesOptions): Promise<GetNoteNote[]> {
   if (options.authMode === 'web') {
-    return webapiFetchSubscribedKnowledgeNotes({
-      token: options.token,
+    return requestWithWebTokenRefresh(options, refreshedToken => webapiFetchSubscribedKnowledgeNotes({
+      token: refreshedToken,
       sinceId: options.sinceId,
       limit: options.limit,
       signal: options.signal,
       topicIds: options.topicIds,
       selectedNoteIds: options.selectedNoteIds,
-    });
+    }));
   }
   return openapiFetchSubscribedKnowledgeNotes({
     token: options.token,
@@ -165,7 +209,7 @@ export async function fetchTopicContentPreviews(
   options?: TopicContentPreviewOptions
 ): Promise<ContentPreview[]> {
   if (authMode === 'web') {
-    return webapiFetchTopicContentPreviews(topicId, token, signal, options);
+    return requestWithWebTokenRefresh({ token, signal }, refreshedToken => webapiFetchTopicContentPreviews(topicId, refreshedToken, signal, options));
   }
   return openapiFetchTopicContentPreviews(topicId, topicName, token, clientId, signal, options);
 }
@@ -181,7 +225,7 @@ export async function fetchTopicContentPreviewPage(
   topicSource?: SubscribedTopic['source']
 ): Promise<TopicContentPreviewPage> {
   if (authMode === 'web') {
-    return webapiFetchTopicContentPreviewPage(topicId, token, signal, cursor);
+    return requestWithWebTokenRefresh({ token, signal }, refreshedToken => webapiFetchTopicContentPreviewPage(topicId, refreshedToken, signal, cursor));
   }
   return openapiFetchTopicContentPreviewPage(topicId, topicName, token, clientId, signal, cursor, topicSource);
 }
@@ -205,14 +249,14 @@ export interface CreateNoteResult {
 
 export async function createNote(options: CreateNoteOptions): Promise<CreateNoteResult> {
   if (options.authMode === 'web') {
-    return webapiCreateNote({
-      token: options.token,
+    return requestWithWebTokenRefresh(options, refreshedToken => webapiCreateNote({
+      token: refreshedToken,
       title: options.title,
       content: options.content,
       noteType: options.noteType,
       tags: options.tags,
       signal: options.signal,
-    });
+    }));
   }
   return openapiCreateNote({
     token: options.token,

--- a/src/desktop-web-auth.ts
+++ b/src/desktop-web-auth.ts
@@ -2,6 +2,7 @@ const WEB_LOGIN_URL = 'https://www.biji.com/note';
 const WEB_API_URL_PREFIX = 'https://get-notes.luojilab.com/';
 const WEB_AUTH_PARTITION = 'persist:dedao-brain-web-auth';
 const DEFAULT_CAPTURE_TIMEOUT_MS = 2 * 60 * 1000;
+const DEFAULT_SILENT_CAPTURE_TIMEOUT_MS = 15 * 1000;
 
 export interface DesktopWebAuthRequestDetails {
   url: string;
@@ -46,9 +47,16 @@ export interface DesktopWebAuthElectron {
 }
 
 export interface DesktopWebAuthManager {
-  captureToken(validate: (token: string) => Promise<void>): Promise<string>;
+  captureToken(
+    validate: (token: string) => Promise<void>,
+    options?: DesktopWebAuthCaptureOptions,
+  ): Promise<string>;
   clearSession(): Promise<void>;
   dispose(): void;
+}
+
+export interface DesktopWebAuthCaptureOptions {
+  interactive?: boolean;
 }
 
 type ElectronRequire = (moduleName: string) => unknown;
@@ -107,22 +115,29 @@ class ElectronDesktopWebAuthManager implements DesktopWebAuthManager {
   private readonly authSession: DesktopWebAuthSession;
   private activeWindow: DesktopWebAuthWindow | null = null;
   private activeCapture: Promise<string> | null = null;
+  private activeCaptureInteractive = false;
   private rejectActiveCapture: ((error: Error) => void) | null = null;
   private captureTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     private readonly electron: DesktopWebAuthElectron,
     private readonly timeoutMs: number,
+    private readonly silentTimeoutMs: number,
   ) {
     this.authSession = electron.session.fromPartition(WEB_AUTH_PARTITION);
   }
 
-  captureToken(validate: (token: string) => Promise<void>): Promise<string> {
+  captureToken(
+    validate: (token: string) => Promise<void>,
+    options: DesktopWebAuthCaptureOptions = {},
+  ): Promise<string> {
+    const interactive = options.interactive ?? true;
     if (this.activeCapture) {
-      this.activeWindow?.focus();
+      if (interactive) this.revealActiveWindow();
       return this.activeCapture;
     }
 
+    this.activeCaptureInteractive = interactive;
     const validatingTokens = new Set<string>();
     let settled = false;
 
@@ -176,7 +191,11 @@ class ElectronDesktopWebAuthManager implements DesktopWebAuthManager {
       });
       this.activeWindow = loginWindow;
       loginWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
-      loginWindow.once('ready-to-show', () => loginWindow.show());
+      loginWindow.once('ready-to-show', () => {
+        if (this.activeCaptureInteractive && !loginWindow.isDestroyed()) {
+          loginWindow.show();
+        }
+      });
       loginWindow.on('closed', () => {
         this.activeWindow = null;
         if (!settled) fail(new Error('Desktop Web authentication window closed'));
@@ -184,7 +203,7 @@ class ElectronDesktopWebAuthManager implements DesktopWebAuthManager {
 
       this.captureTimeout = setTimeout(() => {
         fail(new Error('Desktop Web authentication timed out'));
-      }, this.timeoutMs);
+      }, interactive ? this.timeoutMs : this.silentTimeoutMs);
 
       void loginWindow.loadURL(WEB_LOGIN_URL).catch(error => {
         fail(error instanceof Error ? error : new Error(String(error)));
@@ -230,9 +249,16 @@ class ElectronDesktopWebAuthManager implements DesktopWebAuthManager {
     this.authSession.webRequest.onBeforeSendHeaders(null);
     const loginWindow = this.activeWindow;
     this.activeWindow = null;
+    this.activeCaptureInteractive = false;
     if (closeWindow && loginWindow && !loginWindow.isDestroyed()) {
       loginWindow.close();
     }
+  }
+
+  private revealActiveWindow(): void {
+    this.activeCaptureInteractive = true;
+    this.activeWindow?.show();
+    this.activeWindow?.focus();
   }
 }
 
@@ -240,12 +266,16 @@ export function createDesktopWebAuthManager({
   isDesktopApp,
   loadElectron = defaultElectronLoader,
   timeoutMs = DEFAULT_CAPTURE_TIMEOUT_MS,
+  silentTimeoutMs = DEFAULT_SILENT_CAPTURE_TIMEOUT_MS,
 }: {
   isDesktopApp: boolean;
   loadElectron?: () => DesktopWebAuthElectron | null | undefined;
   timeoutMs?: number;
+  silentTimeoutMs?: number;
 }): DesktopWebAuthManager | null {
   if (!isDesktopApp) return null;
   const electron = loadElectron();
-  return electron ? new ElectronDesktopWebAuthManager(electron, timeoutMs) : null;
+  return electron
+    ? new ElectronDesktopWebAuthManager(electron, timeoutMs, silentTimeoutMs)
+    : null;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -380,6 +380,7 @@ export const translations: Record<string, Record<string, string>> = {
     'error.rateLimited': 'API 调用频率过高，请稍后再试',
     'error.webApiLoginRequired': 'Web Token 已过期，请刷新登录后重新复制 Token',
     'error.webApiForbidden': 'Web Token 无效，请检查设置',
+    'error.webApiSessionExpired': '网页登录状态已失效，请重新登录',
     'error.reverseSyncOpenApiOnly': '反向写回仅支持 OpenAPI，请填写会员 OpenAPI Token 和 Client ID',
     'error.createNoteFailed': '创建得到大脑笔记失败',
 
@@ -777,6 +778,7 @@ export const translations: Record<string, Record<string, string>> = {
     'error.rateLimited': 'API rate limit exceeded, please try again later',
     'error.webApiLoginRequired': 'Web Token expired, please refresh login and copy a new Token',
     'error.webApiForbidden': 'Web Token invalid, please check settings',
+    'error.webApiSessionExpired': 'Web login session expired, please sign in again',
     'error.reverseSyncOpenApiOnly': 'Reverse write-back only supports OpenAPI. Please enter a PRO OpenAPI Token and Client ID.',
     'error.createNoteFailed': 'Failed to create Dedao Brain note',
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,7 +12,7 @@ import { initI18n, t } from './i18n';
 import { ReverseSyncEngine, type ReverseSyncResult } from './reverse-sync';
 import { migrateSyncedNoteTags } from './tag-migration';
 import { getLastQuotaState, resetQuotaState } from './api-clients/openapi-client';
-import { fetchNotes, fetchRecallSearch } from './api';
+import { fetchNotes, fetchRecallSearch, setWebTokenRefreshHandler } from './api';
 import { mergeTagCache } from './utils/tag-aggregator';
 import { SearchPanel, findSyncedNoteFile } from './ui/search-view';
 import {
@@ -22,6 +22,7 @@ import {
 } from './date-path-migration';
 import { validateDatePathFormat } from './date-paths';
 import { createDesktopWebAuthManager, type DesktopWebAuthManager } from './desktop-web-auth';
+import { WebTokenRefreshCoordinator } from './web-token-refresh';
 
 const MAX_SYNC_HISTORY = 20;
 const TAG_MIGRATION_VERSION = 2;
@@ -157,6 +158,7 @@ export default class GetNoteSyncPlugin extends Plugin {
   private lastProgressUpdate = 0;
   private autoSyncFailCount = 0;
   private desktopWebAuthManager: DesktopWebAuthManager | null = null;
+  private webTokenRefreshCoordinator: WebTokenRefreshCoordinator | null = null;
 
   async onload(): Promise<void> {
     initI18n(getLanguage());
@@ -199,6 +201,36 @@ export default class GetNoteSyncPlugin extends Plugin {
     this.desktopWebAuthManager = createDesktopWebAuthManager({
       isDesktopApp: Platform.isDesktopApp,
     });
+    if (this.desktopWebAuthManager) {
+      const coordinator = new WebTokenRefreshCoordinator({
+        captureToken: (validate, options) => this.desktopWebAuthManager!.captureToken(validate, options),
+        validate: async token => {
+          await fetchNotes({
+            token,
+            clientId: '',
+            authMode: 'web',
+            sinceId: '0',
+            limit: 1,
+            skipWebTokenRefresh: true,
+          });
+        },
+        persist: async token => {
+          this.settings.webApiToken = token;
+          if (this.settings.authMode === 'web') this.settings.apiToken = token;
+          await this.saveSettings();
+          this.updateSettingsRuntimeState();
+        },
+        notifyFailure: () => showError(t('error.webApiSessionExpired'), 10000),
+      });
+      this.webTokenRefreshCoordinator = coordinator;
+      setWebTokenRefreshHandler({
+        getToken: () => {
+          const credentials = getAuthCredentials(this.settings);
+          return credentials.authMode === 'web' ? credentials.token : '';
+        },
+        refresh: () => coordinator.refresh(),
+      });
+    }
 
     this.app.workspace.onLayoutReady(() => {
       void this.migrateExistingTags();
@@ -258,6 +290,8 @@ export default class GetNoteSyncPlugin extends Plugin {
 
   onunload(): void {
     this.stopAutoSync();
+    setWebTokenRefreshHandler(null);
+    this.webTokenRefreshCoordinator = null;
     this.desktopWebAuthManager?.dispose();
   }
 
@@ -274,6 +308,7 @@ export default class GetNoteSyncPlugin extends Plugin {
         authMode: 'web',
         sinceId: '0',
         limit: 1,
+        skipWebTokenRefresh: true,
       });
     });
   }

--- a/src/web-token-refresh.ts
+++ b/src/web-token-refresh.ts
@@ -1,0 +1,41 @@
+import type { DesktopWebAuthCaptureOptions } from './desktop-web-auth';
+
+export interface WebTokenRefreshCoordinatorOptions {
+  captureToken(
+    validate: (token: string) => Promise<void>,
+    options?: DesktopWebAuthCaptureOptions,
+  ): Promise<string>;
+  validate(token: string): Promise<void>;
+  persist(token: string): Promise<void>;
+  notifyFailure(): void;
+}
+
+export class WebTokenRefreshCoordinator {
+  private activeRefresh: Promise<string> | null = null;
+  private failureNotified = false;
+
+  constructor(private readonly options: WebTokenRefreshCoordinatorOptions) {}
+
+  refresh(): Promise<string> {
+    if (this.activeRefresh) return this.activeRefresh;
+
+    this.activeRefresh = this.options.captureToken(this.options.validate, { interactive: false })
+      .then(async token => {
+        await this.options.persist(token);
+        this.failureNotified = false;
+        return token;
+      })
+      .catch(error => {
+        if (!this.failureNotified) {
+          this.failureNotified = true;
+          this.options.notifyFailure();
+        }
+        throw error;
+      })
+      .finally(() => {
+        this.activeRefresh = null;
+      });
+
+    return this.activeRefresh;
+  }
+}

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createNote, fetchNoteChildren, fetchNotes, fetchNoteDetail, fetchNoteOriginal, fetchRecallSearch, fetchSubscribedTopics, fetchTopicContentPreviewPage } from '../src/api';
+import { createNote, fetchNoteChildren, fetchNotes, fetchNoteDetail, fetchNoteOriginal, fetchRecallSearch, fetchSubscribedTopics, fetchTopicContentPreviewPage, setWebTokenRefreshHandler } from '../src/api';
 
 // Extract the internal safeJsonParse for direct testing
 function safeJsonParse(text: string): unknown {
@@ -477,6 +477,86 @@ describe('web auth mode', () => {
         })
       );
     } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
+  it('silently renews an expired Web Token once and retries the original request with the replacement token', async () => {
+    const refresh = vi.fn().mockResolvedValue('Bearer renewed-token');
+    setWebTokenRefreshHandler({
+      getToken: () => 'Bearer expired-token',
+      refresh,
+    });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockFetchResponse({ message: 'LoginRequired' }, 401) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({ h: {}, c: { list: [], has_more: false } }) as Response);
+
+    try {
+      await expect(fetchNotes({
+        token: 'Bearer expired-token',
+        clientId: '',
+        authMode: 'web',
+      })).resolves.toEqual({ notes: [], hasMore: false });
+
+      expect(refresh).toHaveBeenCalledOnce();
+      expect(globalThis.fetch).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer renewed-token' }),
+        }),
+      );
+    } finally {
+      setWebTokenRefreshHandler(null);
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
+  it('does not trigger session renewal for a non-auth Web API failure', async () => {
+    const refresh = vi.fn().mockResolvedValue('Bearer should-not-be-used');
+    setWebTokenRefreshHandler({
+      getToken: () => 'Bearer existing-token',
+      refresh,
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ message: 'upstream validation failure' }, 400) as Response,
+    );
+
+    try {
+      await expect(fetchNotes({
+        token: 'Bearer existing-token',
+        clientId: '',
+        authMode: 'web',
+      })).rejects.toThrow('400');
+
+      expect(refresh).not.toHaveBeenCalled();
+    } finally {
+      setWebTokenRefreshHandler(null);
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
+  it('does not renew again when the one allowed retry still receives an authentication failure', async () => {
+    const refresh = vi.fn().mockResolvedValue('Bearer renewed-token');
+    setWebTokenRefreshHandler({
+      getToken: () => 'Bearer expired-token',
+      refresh,
+    });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockFetchResponse({ message: 'LoginRequired' }, 401) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({ message: 'LoginRequired' }, 401) as Response);
+
+    try {
+      await expect(fetchNotes({
+        token: 'Bearer expired-token',
+        clientId: '',
+        authMode: 'web',
+      })).rejects.toThrow('Web Token 已过期');
+
+      expect(refresh).toHaveBeenCalledOnce();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      setWebTokenRefreshHandler(null);
       vi.mocked(globalThis.fetch).mockRestore();
     }
   });

--- a/tests/desktop-web-auth.spec.ts
+++ b/tests/desktop-web-auth.spec.ts
@@ -162,6 +162,35 @@ describe('desktop Web auth', () => {
     expect(fixture.session.webRequest.onBeforeSendHeaders).toHaveBeenLastCalledWith(null);
   });
 
+  it('keeps a session-reuse token capture completely hidden until an interactive caller joins it', async () => {
+    const fixture = makeElectron();
+    const manager = createDesktopWebAuthManager({
+      isDesktopApp: true,
+      loadElectron: () => fixture.electron,
+    })!;
+    const validate = vi.fn().mockResolvedValue(undefined);
+
+    const silentCapture = manager.captureToken(validate, { interactive: false });
+    const windowInstance = fixture.FakeBrowserWindow.instances[0];
+    windowInstance.events.get('ready-to-show')?.();
+    expect(windowInstance.show).not.toHaveBeenCalled();
+
+    const interactiveCapture = manager.captureToken(validate);
+    expect(interactiveCapture).toBe(silentCapture);
+    expect(windowInstance.show).toHaveBeenCalledOnce();
+    expect(windowInstance.focus).toHaveBeenCalledOnce();
+
+    fixture.getRequestListener()!(
+      {
+        url: 'https://get-notes.luojilab.com/voicenotes/web/notes',
+        requestHeaders: { authorization: 'Bearer renewed-token' },
+      },
+      vi.fn(),
+    );
+
+    await expect(silentCapture).resolves.toBe('Bearer renewed-token');
+  });
+
   it('keeps waiting when a stale captured token fails validation', async () => {
     const fixture = makeElectron();
     const manager = createDesktopWebAuthManager({
@@ -267,6 +296,28 @@ describe('desktop Web auth', () => {
       })!;
 
       const capture = manager.captureToken(vi.fn());
+      const rejection = expect(capture).rejects.toThrow('timed out');
+      await vi.advanceTimersByTimeAsync(25);
+
+      await rejection;
+      expect(fixture.FakeBrowserWindow.instances[0].close).toHaveBeenCalledWith();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses a shorter timeout for hidden session-reuse capture than for interactive login', async () => {
+    vi.useFakeTimers();
+    try {
+      const fixture = makeElectron();
+      const manager = createDesktopWebAuthManager({
+        isDesktopApp: true,
+        loadElectron: () => fixture.electron,
+        timeoutMs: 2_000,
+        silentTimeoutMs: 25,
+      })!;
+
+      const capture = manager.captureToken(vi.fn(), { interactive: false });
       const rejection = expect(capture).rejects.toThrow('timed out');
       await vi.advanceTimersByTimeAsync(25);
 

--- a/tests/web-token-refresh.spec.ts
+++ b/tests/web-token-refresh.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WebTokenRefreshCoordinator } from '../src/web-token-refresh';
+
+describe('WebTokenRefreshCoordinator', () => {
+  it('shares one hidden session-reuse capture, then persists the validated replacement token', async () => {
+    const validate = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const captureToken = vi.fn(async (captureValidate: (token: string) => Promise<void>) => {
+      await captureValidate('Bearer renewed-token');
+      return 'Bearer renewed-token';
+    });
+    const coordinator = new WebTokenRefreshCoordinator({
+      captureToken,
+      validate,
+      persist,
+      notifyFailure: vi.fn(),
+    });
+
+    const [first, second] = await Promise.all([coordinator.refresh(), coordinator.refresh()]);
+
+    expect(first).toBe('Bearer renewed-token');
+    expect(second).toBe('Bearer renewed-token');
+    expect(captureToken).toHaveBeenCalledOnce();
+    expect(captureToken).toHaveBeenCalledWith(expect.any(Function), { interactive: false });
+    expect(validate).toHaveBeenCalledWith('Bearer renewed-token');
+    expect(persist).toHaveBeenCalledWith('Bearer renewed-token');
+  });
+
+  it('shows the expired-session notice once when hidden renewal cannot obtain a token', async () => {
+    const notifyFailure = vi.fn();
+    const coordinator = new WebTokenRefreshCoordinator({
+      captureToken: vi.fn().mockRejectedValue(new Error('timed out')),
+      validate: vi.fn(),
+      persist: vi.fn(),
+      notifyFailure,
+    });
+
+    await expect(coordinator.refresh()).rejects.toThrow('timed out');
+    await expect(coordinator.refresh()).rejects.toThrow('timed out');
+
+    expect(notifyFailure).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- silently reuse the desktop web-login session when a Web Token expires
- validate and persist a refreshed token, single-flight concurrent refreshes, retry each failed request once
- show a concise re-login error only when the background session cannot renew

Closes #264

## Validation
- npm test (755 passed, 2 skipped)
- npm run typecheck
- npm run lint
- npx eslint tests --max-warnings=0
- npm run build
- local Obsidian plugin deployment with settings-page acceptance
- security diff scan: 0 findings