### PR TITLE
chore: update settings sync tagline

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,7 +2,7 @@ export const translations: Record<string, Record<string, string>> = {
   zh: {
     // === Settings ===
     'settings.title': '🔄 得到大脑（原Get笔记）Sync',
-    'settings.desc': '得到大脑（原Get笔记） ↔ Obsidian，一键同步无负担，',
+    'settings.desc': '得到大脑（原Get笔记） ↔ Obsidian，双向同步，自动整理，永久免费，',
     'settings.community': '欢迎交流、留下star',
     'settings.communityUrl': 'https://github.com/AndyZhengyan/obsidian-dedao-brain-sync/blob/main/README.md#关于作者',
     'settings.sync.section': '同步',

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -45,7 +45,7 @@ describe('t() - Chinese translations', () => {
   });
 
   it('returns Chinese for settings.desc', () => {
-    expect(i18n.t('settings.desc')).toBe('得到大脑（原Get笔记） ↔ Obsidian，一键同步无负担，');
+    expect(i18n.t('settings.desc')).toBe('得到大脑（原Get笔记） ↔ Obsidian，双向同步，自动整理，永久免费，');
   });
 
   it('returns Chinese for settings.community', () => {


### PR DESCRIPTION
## Summary

- Replace the Chinese settings tagline with “双向同步，自动整理，永久免费”
- Keep the focused i18n assertion aligned with the displayed copy

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] `npx eslint tests --max-warnings=0`
- [x] `git diff --check`

## Notes

- Copy-only change; no English copy or version changes.