### PR TITLE
Clarify automatic sync settings link

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -176,7 +176,7 @@ export const translations: Record<string, Record<string, string>> = {
     'manualSync.once': '仅本次同步',
     'manualSync.mode.date': '按日期',
     'manualSync.mode.days': '按天数',
-    'manualSync.openSettings': '打开完整设置',
+    'manualSync.openSettings': '打开完整设置，开启自动同步',
 
     // === Sync Button ===
     'sync.syncing': '同步中...',
@@ -579,7 +579,7 @@ export const translations: Record<string, Record<string, string>> = {
     'manualSync.once': 'This sync only',
     'manualSync.mode.date': 'By Date',
     'manualSync.mode.days': 'By Days',
-    'manualSync.openSettings': 'Open full settings',
+    'manualSync.openSettings': 'Open full settings to enable automatic sync',
 
     // === Sync Button ===
     'sync.syncing': 'Syncing...',

--- a/tests/manual-sync-modal.spec.ts
+++ b/tests/manual-sync-modal.spec.ts
@@ -53,7 +53,7 @@ describe('ManualSyncModal filters', () => {
     const footer = container.querySelector('.getnote-picker-footer')!;
     expect(settingsLink).toBeTruthy();
     expect(settingsLink.classList.contains('mod-secondary')).toBe(false);
-    expect(settingsLink.textContent).toBe('Open full settings');
+    expect(settingsLink.textContent).toBe('Open full settings to enable automatic sync');
     expect(settingsLink.parentElement).toBe(footer);
     expect(container.querySelector('.getnote-settings-link-row')).toBeNull();
     expect(container.querySelector('.getnote-picker-count')).toBeNull();
@@ -64,6 +64,24 @@ describe('ManualSyncModal filters', () => {
 
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
     expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('explains in Chinese that full settings can enable automatic sync', () => {
+    initI18n('zh');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(
+      h(ManualSyncModal, {
+        initialOptions: { syncStartDate: '', maxDays: 30 },
+        onConfirm: vi.fn(),
+        onCancel: vi.fn(),
+        onOpenSettings: vi.fn(),
+      }),
+      container
+    );
+
+    expect(container.querySelector('.getnote-settings-link')?.textContent)
+      .toBe('打开完整设置，开启自动同步');
   });
 
   it('defaults to days mode and submits maxDays >= 1', async () => {


### PR DESCRIPTION
## Summary

- change the manual-sync footer link to “打开完整设置，开启自动同步”
- update the English copy to “Open full settings to enable automatic sync”
- cover both localized labels in the modal tests

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx eslint tests --max-warnings=0`
- [x] `npm test` (797 passed, 2 skipped)
- [x] `npm run build`

## Notes

- copy-only change; button behavior is unchanged