### PR TITLE
chore: rename plugin display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ OpenAPI 搜索侧边栏：在 Obsidian 侧边栏直接搜索得到大脑笔记�
 [![Available on Obsidian](https://img.shields.io/badge/Obsidian-Community%20Plugin-7c3aed?style=flat-square&logo=obsidian)](https://community.obsidian.md/plugins/dedao-brain-sync)
 
 1. 打开 `设置 -> 第三方插件 -> 浏览`。
-2. 搜索 `Dedao Brain Sync`、`得到大脑` 或原名 `GetNote` / `Get笔记`。
+2. 搜索 `Dedao Brain Sync1`、`得到大脑` 或原名 `GetNote` / `Get笔记`。
 3. 安装并启用插件。
 
 ### 手动安装
@@ -82,7 +82,7 @@ OpenAPI 搜索侧边栏：在 Obsidian 侧边栏直接搜索得到大脑笔记�
 <your-vault>/.obsidian/plugins/dedao-brain-sync/
 ```
 
-3. 重启 Obsidian 并启用 `Dedao Brain Sync`。
+3. 重启 Obsidian 并启用 `Dedao Brain Sync1`。
 
 > 插件目录名为 `getnote-importer`（与 `manifest.json` 中的 `id` 一致，保持与历史 listing 的兼容性），仓库本身已重命名为 `obsidian-dedao-brain-sync`。旧版 GetNote Importer 的本地 `data.json` 会在首次启动时自动迁移。
 
@@ -126,7 +126,7 @@ OpenAPI 搜索侧边栏：在 Obsidian 侧边栏直接搜索得到大脑笔记�
 在设置页点击 `按时间同步`，或在命令面板运行：
 
 ```text
-Dedao Brain Sync: 同步笔记
+Dedao Brain Sync1: 同步笔记
 ```
 
 下载同步默认采用保守策略：如果本地已经存在同一篇笔记，插件会跳过它，不覆盖你在 Obsidian 里的内容。需要重新拉取某篇远端笔记时，直接删除本地对应文件后重新同步；只要远端笔记仍存在，插件会把它作为本地缺失笔记重新创建。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-# Dedao Brain Sync
+# Dedao Brain Sync1
 
 [中文](./README.md) | [English](./README_EN.md)
 
@@ -70,7 +70,7 @@ OpenAPI search sidebar: search Dedao Brain notes from the Obsidian sidebar and o
 [![Available on Obsidian](https://img.shields.io/badge/Obsidian-Community%20Plugin-7c3aed?style=flat-square&logo=obsidian)](https://community.obsidian.md/plugins/dedao-brain-sync)
 
 1. Open `Settings -> Third-party plugin -> Browse`.
-2. Search for `Dedao Brain Sync`, `得到大脑`, or the legacy name `GetNote` / `Get笔记`.
+2. Search for `Dedao Brain Sync1`, `得到大脑`, or the legacy name `GetNote` / `Get笔记`.
 3. Install and enable the plugin.
 
 ### Manual installation
@@ -82,7 +82,7 @@ OpenAPI search sidebar: search Dedao Brain notes from the Obsidian sidebar and o
 <your-vault>/.obsidian/plugins/dedao-brain-sync/
 ```
 
-3. Restart Obsidian and enable `Dedao Brain Sync`.
+3. Restart Obsidian and enable `Dedao Brain Sync1`.
 
 > The plugin folder name is `getnote-importer` (matching the `id` in `manifest.json` for backward compatibility with the existing listing); the repository itself has been renamed to `obsidian-dedao-brain-sync`. Legacy GetNote Importer `data.json` is migrated automatically on first startup.
 
@@ -97,7 +97,7 @@ Credentials are stored only in your local Obsidian plugin data, and are used to 
 1. Open the Dedao Brain app.
 2. Go to `Settings -> Open Platform`.
 3. Create an application, then copy the `Token` and `Client ID`.
-4. In `Settings -> Dedao Brain Sync`, choose `OpenAPI auth (members)` and paste both values.
+4. In `Settings -> Dedao Brain Sync1`, choose `OpenAPI auth (members)` and paste both values.
 5. You can also use the OAuth button on the settings page to fetch credentials automatically.
 
 ### Web mode (manual token)
@@ -114,7 +114,7 @@ To copy the token:
 4. Reload the web app, or open the note list / any note, to trigger API requests.
 5. In the request list, open one whose name looks like `notes?...` or `list?...`; the `Host` in the right-hand Headers is usually `get-notes.luojilab.com`.
 6. Under `Request Headers`, copy the full `Authorization` value.
-7. Paste it into the Token field under `Settings -> Dedao Brain Sync -> Temporary auth`.
+7. Paste it into the Token field under `Settings -> Dedao Brain Sync1 -> Temporary auth`.
 8. Click `Test connection`, then run `Sync by date` or `Sync by note` once it succeeds.
 
 The value usually starts with `Bearer eyJ...`. The plugin accepts a full `Bearer ...` string, or just the JWT token. Do not paste an OpenAPI `gk_...` token into Temporary auth. A Web token is a browser session credential and can expire; if you see `401`, `403`, or `Web Token expired`, refresh the web app and re-copy the `Authorization` header.
@@ -126,7 +126,7 @@ The value usually starts with `Bearer eyJ...`. The plugin accepts a full `Bearer
 Click `Sync by date` on the settings page, or run the command:
 
 ```text
-Dedao Brain Sync: Sync notes
+Dedao Brain Sync1: Sync notes
 ```
 
 Download sync uses a conservative default: if the same note already exists locally, the plugin skips it and does not overwrite your Obsidian content. To pull a remote note again, delete the corresponding local file and run sync again; as long as the remote note still exists, the plugin recreates it as a locally missing note.

--- a/docs/superpowers/specs/2026-08-09-issue-237-full-settings-link-layout-design.md
+++ b/docs/superpowers/specs/2026-08-09-issue-237-full-settings-link-layout-design.md
@@ -16,7 +16,7 @@ Use the footer's existing left-side utility position:
 
 ## Interaction
 
-Clicking the link closes the manual sync modal and opens the Dedao Brain Sync settings tab. It does not trigger sync and does not preserve the modal's temporary filters.
+Clicking the link closes the manual sync modal and opens the Dedao Brain Sync1 settings tab. It does not trigger sync and does not preserve the modal's temporary filters.
 
 ## Accessibility
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "getnote-importer",
-  "name": "Dedao Brain Sync",
+  "name": "Dedao Brain Sync1",
   "version": "1.5.5",
   "description": "Bidirectional sync for notes, links, recordings, and AI summaries between GetNote / 得到大脑（原Get笔记） and your local vault.",
   "author": "Andy Zheng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-dedao-brain-sync",
   "version": "1.5.5",
-  "description": "Dedao Brain Sync for Obsidian",
+  "description": "Dedao Brain Sync1 for Obsidian",
   "main": "main.js",
   "scripts": {
     "build": "node esbuild.config.mjs",

--- a/tests/manifest.spec.ts
+++ b/tests/manifest.spec.ts
@@ -8,7 +8,7 @@ const OLD_REPO = 'obsidian-getnote-importer';
 
 describe('plugin manifest', () => {
   it('uses sync wording for the bidirectional plugin name', () => {
-    expect(manifest.name).toBe('Dedao Brain Sync');
+    expect(manifest.name).toBe('Dedao Brain Sync1');
     expect(manifest.name).not.toContain('Importer');
     expect(manifest.name).toMatch(/^[\x20-\x7E]+$/);
   });


### PR DESCRIPTION
## Summary
- rename the Obsidian plugin display name to `Dedao Brain Sync1`
- update the manifest contract test

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- git diff --check