### PR TITLE
fix(sync): page through all subscribed bloggers

### DIFF
--- a/src/api-clients/openapi-client.ts
+++ b/src/api-clients/openapi-client.ts
@@ -287,7 +287,7 @@ function readArray(value: Record<string, unknown>, keys: string[]): unknown[] {
 }
 
 function readHasMore(value: Record<string, unknown>): boolean {
-  return Boolean(value.has_more ?? value.hasMore);
+  return Boolean(value.has_more ?? value.hasMore ?? value.has_next ?? value.hasNext);
 }
 
 function normalizeData(value: unknown): Record<string, unknown> {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -395,6 +395,7 @@ export const translations: Record<string, Record<string, string>> = {
 
     // === Command / Ribbon ===
     'command.sync': '同步笔记',
+    'command.syncAllSubscribedKnowledge': '同步全部订阅知识',
     'command.reverseSync': '写回得到大脑',
     'command.uploadLocal': '上传本地笔记到得到大脑',
     'command.search': '打开得到大脑搜索',
@@ -798,6 +799,7 @@ export const translations: Record<string, Record<string, string>> = {
 
     // === Command / Ribbon ===
     'command.sync': 'Sync Notes',
+    'command.syncAllSubscribedKnowledge': 'Sync All Subscribed Knowledge',
     'command.reverseSync': 'Write Back to Dedao Brain',
     'command.uploadLocal': 'Upload Local Notes to Dedao Brain',
     'command.search': 'Open Dedao Brain Search',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -254,6 +254,12 @@ export default class GetNoteSyncPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: 'sync-all-subscribed-knowledge',
+      name: t('command.syncAllSubscribedKnowledge'),
+      callback: () => this.syncAllSubscribedKnowledge(),
+    });
+
+    this.addCommand({
       id: 'upload-local-notes',
       name: t('command.uploadLocal'),
       callback: () => this.openLocalUploadModal(),
@@ -891,6 +897,11 @@ export default class GetNoteSyncPlugin extends Plugin {
       : selection;
     void this.runSubscribedKnowledgeSync(syncOptions);
   }
+
+  syncAllSubscribedKnowledge(): void {
+    void this.runSubscribedKnowledgeSync({ syncAll: true });
+  }
+
 
   private async runSubscribedKnowledgeSync(syncOptions?: TopicPickerSelection): Promise<void> {
     if (this.isSyncing || this.isDatePathMigrationRunning) return;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createNote, fetchNoteChildren, fetchNotes, fetchNoteDetail, fetchNoteOriginal, fetchRecallSearch, fetchSubscribedTopics, fetchTopicContentPreviewPage, setWebTokenRefreshHandler } from '../src/api';
+import { createNote, fetchNoteChildren, fetchNotes, fetchNoteDetail, fetchNoteOriginal, fetchRecallSearch, fetchSubscribedKnowledgeNotes, fetchSubscribedTopics, fetchTopicContentPreviewPage, setWebTokenRefreshHandler } from '../src/api';
 
 // Extract the internal safeJsonParse for direct testing
 function safeJsonParse(text: string): unknown {
@@ -762,6 +762,45 @@ describe('web auth mode', () => {
 });
 
 describe('OpenAPI knowledge previews', () => {
+  it('follows has_next while discovering every subscribed blogger before syncing their content', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { topics: [{ topic_id: 'finance', name: '金融' }], has_next: false },
+      }) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { bloggers: [{ follow_id: 'blogger-1', account_name: '博主一' }], has_next: true },
+      }) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { bloggers: [{ follow_id: 'blogger-34', account_name: '博主三十四' }], has_next: false },
+      }) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { contents: [{ post_id_alias: 'post-1', title: '第一页', content: '正文一' }], has_next: false },
+      }) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { post_id_alias: 'post-1', title: '第一页', content: '正文一' },
+      }) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { contents: [{ post_id_alias: 'post-34', title: '第二页', content: '正文三十四' }], has_next: false },
+      }) as Response)
+      .mockResolvedValueOnce(mockFetchResponse({
+        data: { post_id_alias: 'post-34', title: '第二页', content: '正文三十四' },
+      }) as Response);
+
+    try {
+      const notes = await fetchSubscribedKnowledgeNotes({
+        token: 'token',
+        clientId: 'client',
+        authMode: 'openapi',
+        topicIds: ['finance'],
+      });
+
+      expect(notes.map(note => note.note_id)).toEqual(['blogger_post-1', 'blogger_post-34']);
+      expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('bloggers?topic_id=finance&page=2'), expect.anything());
+    } finally {
+      vi.mocked(globalThis.fetch).mockRestore();
+    }
+  });
+
   it('merges created and subscribed knowledge bases', async () => {
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(mockFetchResponse({

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -219,6 +219,17 @@ describe('GetNoteSyncPlugin runSync cleanup', () => {
     });
   });
 
+  it('starts an all-subscription sync without narrowing it to selected topics or notes', async () => {
+    const syncSpy = vi.spyOn(SyncEngine.prototype, 'syncSubscribedKnowledge').mockResolvedValue({
+      created: 0, updated: 0, skipped: 0, failed: 0, total: 0, items: [],
+    });
+    const plugin = makePlugin();
+    const runAll = (plugin as unknown as { syncAllSubscribedKnowledge: () => void }).syncAllSubscribedKnowledge;
+
+    runAll.call(plugin);
+    await vi.waitFor(() => expect(syncSpy).toHaveBeenCalledWith(undefined, { syncAll: true }));
+  });
+
   it('records a completed knowledge-base sync with failed items as partial', async () => {
     vi.spyOn(SyncEngine.prototype, 'syncSubscribedKnowledge').mockResolvedValue({
       created: 1,


### PR DESCRIPTION
## Summary
- recognize the OpenAPI has_next pagination field so subscribed topics, bloggers, and content do not stop after the first page
- add a command-palette entry to sync every subscribed knowledge base without narrowing to selected topics or notes
- retain existing UID-based conservative writes, directories, sync history, and retry behavior

## Verification
- npm run typecheck
- npm run lint
- npx eslint tests --max-warnings=0
- npm test (799 passed, 2 skipped)
- npm run build
- git diff --check